### PR TITLE
namespace converted to object since babel does not play well with this

### DIFF
--- a/src/templates/core/OpenAPI.hbs
+++ b/src/templates/core/OpenAPI.hbs
@@ -3,9 +3,9 @@
 /* eslint-disable */
 /* prettier-ignore */
 
-export namespace OpenAPI {
-    export let BASE = '{{{server}}}';
-    export let VERSION = '{{{version}}}';
-    export let CLIENT = '{{{httpClient}}}';
-    export let TOKEN = '';
+export const OpenAPI = {
+    BASE: '{{{server}}}';
+    VERSION: '{{{version}}}';
+    CLIENT: '{{{httpClient}}}';
+    TOKEN: '';
 }

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -67,11 +67,11 @@ exports[`generation v2 file(./test/result/v2/core/OpenAPI.ts): ./test/result/v2/
 /* eslint-disable */
 /* prettier-ignore */
 
-export namespace OpenAPI {
-    export let BASE = 'http://localhost:8080/api';
-    export let VERSION = '9.0';
-    export let CLIENT = 'fetch';
-    export let TOKEN = '';
+export const OpenAPI = {
+    BASE: 'http://localhost:8080/api';
+    VERSION: '9.0';
+    CLIENT: 'fetch';
+    TOKEN: '';
 }"
 `;
 
@@ -2337,11 +2337,11 @@ exports[`generation v3 file(./test/result/v3/core/OpenAPI.ts): ./test/result/v3/
 /* eslint-disable */
 /* prettier-ignore */
 
-export namespace OpenAPI {
-    export let BASE = '/api';
-    export let VERSION = '1';
-    export let CLIENT = 'fetch';
-    export let TOKEN = '';
+export const OpenAPI = {
+    BASE: '/api';
+    VERSION: '1';
+    CLIENT: 'fetch';
+    TOKEN: '';
 }"
 `;
 


### PR DESCRIPTION
Hey Ferdi,

I was playing with this in a next app. Babel complained about this namespaced non-const exports so I updated it to an object and can be used with the same syntax. And again good job! Very useful library  :)

Kutlu