### PR TITLE
Replace 'export' with 'export type' for models

### DIFF
--- a/src/templates/index.hbs
+++ b/src/templates/index.hbs
@@ -12,7 +12,7 @@ export { OpenAPI } from './core/OpenAPI';
 {{#if models}}
 
 {{#each models}}
-export { {{{this}}} } from './models/{{{this}}}';
+export type { {{{this}}} } from './models/{{{this}}}';
 {{/each}}
 {{/if}}
 {{/if}}


### PR DESCRIPTION
...which is TypeScript interfaces and should be exported differently