### PR TITLE
feat: Support x-nullable vendor extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,8 +328,11 @@ enum EnumWithStrings {
 }
 ```
 
-### Nullable in OpenApi v2
-You can use the unofficial `x-nullable` backport in your specification to generate nullable properties in OpenApi v2.
+
+### Nullable in OpenAPI v2
+In the OpenAPI v3 spec you can create properties that can be NULL, by providing a `nullable: true` in your schema.
+However, the v2 spec does not allow you to do this. You can use the unofficial `x-nullable` in your specification
+to generate nullable properties in OpenApi v2.
 
 ```json
 {
@@ -346,7 +349,7 @@ You can use the unofficial `x-nullable` backport in your specification to genera
             "requiredProp": {
                 "description": "This is a simple string property",
                 "type": "string",
-                "x-nullable": true,
+                "x-nullable": true
             }
         }
     }
@@ -355,9 +358,9 @@ You can use the unofficial `x-nullable` backport in your specification to genera
 
 Generated code:
 ```typescript
-enum ModelWithNullableString {
+interface ModelWithNullableString {
     prop?: string | null,
-    requiredProp: string | null
+    requiredProp: string | null,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,39 @@ enum EnumWithStrings {
 }
 ```
 
+### Nullable in OpenApi v2
+You can use the unofficial `x-nullable` backport in your specification to generate nullable properties in OpenApi v2.
+
+```json
+{
+    "ModelWithNullableString": {
+        "required": ["requiredProp"],
+        "description": "This is a model with one string property",
+        "type": "object",
+        "properties": {
+            "prop": {
+                "description": "This is a simple string property",
+                "type": "string",
+                "x-nullable": true
+            },
+            "requiredProp": {
+                "description": "This is a simple string property",
+                "type": "string",
+                "x-nullable": true,
+            }
+        }
+    }
+}
+```
+
+Generated code:
+```typescript
+enum ModelWithNullableString {
+    prop?: string | null,
+    requiredProp: string | null
+}
+```
+
 
 ### Authorization
 The OpenAPI generator supports Bearer Token authorization. In order to enable the sending

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -3,8 +3,8 @@ import * as OpenAPI from './index';
 describe('index', () => {
     it('parses v2 without issues', async () => {
         await OpenAPI.generate({
-            input: './test/spec/v3.json',
-            output: './generated/v3/',
+            input: './test/spec/v2.json',
+            output: './generated/v2/',
             write: false,
         });
     });

--- a/src/openApi/v2/interfaces/Extensions/WithEnumExtension.d.ts
+++ b/src/openApi/v2/interfaces/Extensions/WithEnumExtension.d.ts
@@ -1,6 +1,3 @@
-/**
- * Supported extension for enums
- */
 export interface WithEnumExtension {
     'x-enum-varnames'?: string[];
     'x-enum-descriptions'?: string[];

--- a/src/openApi/v2/interfaces/Extensions/WithNullableExtension.d.ts
+++ b/src/openApi/v2/interfaces/Extensions/WithNullableExtension.d.ts
@@ -1,6 +1,3 @@
-/**
- * Supported extension for enums
- */
 export interface WithNullableExtension {
     'x-nullable'?: boolean;
 }

--- a/src/openApi/v2/interfaces/Extensions/WithNullableExtension.d.ts
+++ b/src/openApi/v2/interfaces/Extensions/WithNullableExtension.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Supported extension for enums
+ */
+export interface WithNullableExtension {
+    'x-nullable'?: boolean;
+}

--- a/src/openApi/v2/interfaces/OpenApiSchema.d.ts
+++ b/src/openApi/v2/interfaces/OpenApiSchema.d.ts
@@ -1,5 +1,6 @@
 import type { Dictionary } from '../../../utils/types';
 import type { WithEnumExtension } from './Extensions/WithEnumExtension';
+import type { WithNullableExtension } from './Extensions/WithNullableExtension';
 import type { OpenApiExternalDocs } from './OpenApiExternalDocs';
 import type { OpenApiReference } from './OpenApiReference';
 import type { OpenApiXml } from './OpenApiXml';
@@ -7,7 +8,7 @@ import type { OpenApiXml } from './OpenApiXml';
 /**
  * https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schemaObject
  */
-export interface OpenApiSchema extends OpenApiReference, WithEnumExtension {
+export interface OpenApiSchema extends OpenApiReference, WithEnumExtension, WithNullableExtension {
     title?: string;
     description?: string;
     default?: any;

--- a/src/openApi/v2/parser/getModelProperties.ts
+++ b/src/openApi/v2/parser/getModelProperties.ts
@@ -26,7 +26,7 @@ export function getModelProperties(openApi: OpenApi, definition: OpenApiSchema, 
                     isDefinition: false,
                     isReadOnly: property.readOnly === true,
                     isRequired: propertyRequired === true,
-                    isNullable: false,
+                    isNullable: property['x-nullable'] === true,
                     format: property.format,
                     maximum: property.maximum,
                     exclusiveMaximum: property.exclusiveMaximum,
@@ -60,7 +60,7 @@ export function getModelProperties(openApi: OpenApi, definition: OpenApiSchema, 
                     isDefinition: false,
                     isReadOnly: property.readOnly === true,
                     isRequired: propertyRequired === true,
-                    isNullable: false,
+                    isNullable: property['x-nullable'] === true,
                     format: property.format,
                     maximum: property.maximum,
                     exclusiveMaximum: property.exclusiveMaximum,
@@ -84,6 +84,5 @@ export function getModelProperties(openApi: OpenApi, definition: OpenApiSchema, 
             }
         }
     }
-
     return models;
 }

--- a/src/openApi/v3/interfaces/Extensions/WithEnumExtension.d.ts
+++ b/src/openApi/v3/interfaces/Extensions/WithEnumExtension.d.ts
@@ -1,6 +1,3 @@
-/**
- * Supported extension for enums
- */
 export interface WithEnumExtension {
     'x-enum-varnames'?: string[];
     'x-enum-descriptions'?: string[];

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -293,6 +293,7 @@ export type { ModelWithInteger } from './models/ModelWithInteger';
 export type { ModelWithLink } from './models/ModelWithLink';
 export type { ModelWithNestedEnums } from './models/ModelWithNestedEnums';
 export type { ModelWithNestedProperties } from './models/ModelWithNestedProperties';
+export type { ModelWithNullableString } from './models/ModelWithNullableString';
 export type { ModelWithOrderedProperties } from './models/ModelWithOrderedProperties';
 export type { ModelWithPattern } from './models/ModelWithPattern';
 export type { ModelWithProperties } from './models/ModelWithProperties';
@@ -335,6 +336,7 @@ export { $ModelWithInteger } from './schemas/$ModelWithInteger';
 export { $ModelWithLink } from './schemas/$ModelWithLink';
 export { $ModelWithNestedEnums } from './schemas/$ModelWithNestedEnums';
 export { $ModelWithNestedProperties } from './schemas/$ModelWithNestedProperties';
+export { $ModelWithNullableString } from './schemas/$ModelWithNullableString';
 export { $ModelWithOrderedProperties } from './schemas/$ModelWithOrderedProperties';
 export { $ModelWithPattern } from './schemas/$ModelWithPattern';
 export { $ModelWithProperties } from './schemas/$ModelWithProperties';
@@ -821,6 +823,26 @@ export interface ModelWithNestedProperties {
             readonly third: string,
         },
     };
+}
+"
+`;
+
+exports[`v2 should generate: ./test/generated/v2/models/ModelWithNullableString.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model with one string property
+ */
+export interface ModelWithNullableString {
+    /**
+     * This is a simple string property
+     */
+    nullableProp?: string | null;
+    /**
+     * This is a simple string property
+     */
+    nullableRequiredProp: string | null;
 }
 "
 `;
@@ -1349,6 +1371,25 @@ export const $ModelWithNestedProperties = {
             },
             isReadOnly: true,
             isRequired: true,
+        },
+    },
+};"
+`;
+
+exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithNullableString.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithNullableString = {
+    properties: {
+        nullableProp: {
+            type: 'string',
+            isNullable: true,
+        },
+        nullableRequiredProp: {
+            type: 'string',
+            isRequired: true,
+            isNullable: true,
         },
     },
 };"

--- a/test/spec/v2.json
+++ b/test/spec/v2.json
@@ -861,7 +861,9 @@
         "ModelWithNullableString": {
             "description": "This is a model with one string property",
             "type": "object",
-            "required": ["nullableRequiredProp"],
+            "required": [
+                "nullableRequiredProp"
+            ],
             "properties": {
                 "nullableProp": {
                     "description": "This is a simple string property",

--- a/test/spec/v2.json
+++ b/test/spec/v2.json
@@ -858,6 +858,23 @@
                 }
             }
         },
+        "ModelWithNullableString": {
+            "description": "This is a model with one string property",
+            "type": "object",
+            "required": ["nullableRequiredProp"],
+            "properties": {
+                "nullableProp": {
+                    "description": "This is a simple string property",
+                    "type": "string",
+                    "x-nullable": true
+                },
+                "nullableRequiredProp": {
+                    "description": "This is a simple string property",
+                    "type": "string",
+                    "x-nullable": true
+                }
+            }
+        },
         "ModelWithEnum": {
             "description": "This is a model with one enum",
             "type": "object",


### PR DESCRIPTION
This PR adds support for the `x-nullable` backport used in e.g. `drf-yasg` and [Apiary](https://help.apiary.io/api_101/swagger-extensions/#x-nullable).

#380
