### PR TITLE
commit to illustrate changes for custom-http-client (do not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ openapi --help
     -V, --version             output the version number
     -i, --input <value>       OpenAPI specification, can be a path, url or string content (required)
     -o, --output <value>      Output directory (required)
-    -c, --client <value>      HTTP client to generate [fetch, xhr, node] (default: "fetch")
+    -c, --client <value>      HTTP client to generate [fetch, xhr, node, custom] (default: "fetch")
     --useOptions              Use options instead of arguments
     --useUnionTypes           Use union types instead of enums
     --exportCore <value>      Write core files to disk (default: true)
@@ -440,6 +440,14 @@ npm install @types/node-fetch --save-dev
 npm install node-fetch --save-dev
 npm install form-data --save-dev
 ```
+
+### Support for a custom http-client
+
+If you have more sophisticated requirements that are not provided by the generated http-clients, you can specify
+`--client custom` and provide your own request-function.
+
+`openapi --input ./spec.json --output ./dist --client custom`
+
 
 [npm-url]: https://npmjs.org/package/openapi-typescript-codegen
 [npm-image]: https://img.shields.io/npm/v/openapi-typescript-codegen.svg

--- a/bin/index.js
+++ b/bin/index.js
@@ -12,7 +12,7 @@ program
     .version(pkg.version)
     .requiredOption('-i, --input <value>', 'OpenAPI specification, can be a path, url or string content (required)')
     .requiredOption('-o, --output <value>', 'Output directory (required)')
-    .option('-c, --client <value>', 'HTTP client to generate [fetch, xhr, node]', 'fetch')
+    .option('-c, --client <value>', 'HTTP client to generate [fetch, xhr, node, custom]', 'fetch')
     .option('--useOptions', 'Use options instead of arguments')
     .option('--useUnionTypes', 'Use union types instead of enums')
     .option('--exportCore <value>', 'Write core files to disk', true)

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export enum HttpClient {
     FETCH = 'fetch',
     XHR = 'xhr',
     NODE = 'node',
+    CUSTOM = 'custom'
 }
 
 export interface Options {

--- a/src/templates/core/custom/request.hbs
+++ b/src/templates/core/custom/request.hbs
@@ -1,0 +1,28 @@
+{{>header}}
+import { ApiError } from './ApiError';
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+
+{{>functions/catchErrors}}
+
+export type ExecuteRequest = (options: ApiRequestOptions) => Promise<ApiResult>;
+
+type CustomHttpClient = {
+    executeRequest?: ExecuteRequest;
+};
+export const CustomHttpClient: CustomHttpClient = {};
+
+/**
+ * Request using fetch client
+ * @param options The request options from the the service
+ * @result ApiResult
+ * @throws ApiError
+ */
+export async function request(options: ApiRequestOptions): Promise<ApiResult> {
+    if (CustomHttpClient.executeRequest == null) {
+        throw new Error("No custom request-function has been registered. Use `CustomRequest.requestFunction = async (options) => {...} to implement one.")
+    }
+    const result = await CustomHttpClient.executeRequest(options);
+    catchErrors(options, result);
+    return result;
+}

--- a/src/templates/core/request.hbs
+++ b/src/templates/core/request.hbs
@@ -1,3 +1,4 @@
 {{#equals @root.httpClient 'fetch'}}{{>fetch/request}}{{/equals}}
 {{#equals @root.httpClient 'xhr'}}{{>xhr/request}}{{/equals}}
 {{#equals @root.httpClient 'node'}}{{>node/request}}{{/equals}}
+{{~#equals @root.httpClient 'custom'}}{{>custom/request}}{{/equals~}}

--- a/src/utils/registerHandlebarTemplates.ts
+++ b/src/utils/registerHandlebarTemplates.ts
@@ -33,6 +33,7 @@ import xhrGetResponseBody from '../templates/core/xhr/getResponseBody.hbs';
 import xhrGetResponseHeader from '../templates/core/xhr/getResponseHeader.hbs';
 import xhrRequest from '../templates/core/xhr/request.hbs';
 import xhrSendRequest from '../templates/core/xhr/sendRequest.hbs';
+import customRequest from '../templates/core/custom/request.hbs';
 import templateExportModel from '../templates/exportModel.hbs';
 import templateExportSchema from '../templates/exportSchema.hbs';
 import templateExportService from '../templates/exportService.hbs';
@@ -164,6 +165,9 @@ export function registerHandlebarTemplates(): Templates {
     Handlebars.registerPartial('node/getResponseHeader', Handlebars.template(nodeGetResponseHeader));
     Handlebars.registerPartial('node/sendRequest', Handlebars.template(nodeSendRequest));
     Handlebars.registerPartial('node/request', Handlebars.template(nodeRequest));
+
+    // Specific files for the custom client implementation
+    Handlebars.registerPartial('custom/request', Handlebars.template(customRequest));
 
     return templates;
 }

--- a/test/e2e/scripts/custom-client.js
+++ b/test/e2e/scripts/custom-client.js
@@ -1,0 +1,29 @@
+
+async function customClient(options) {
+    const url = `${OpenAPI.BASE}${options.path}`;
+    const token = typeof OpenAPI.TOKEN === 'function' ? await OpenAPI.TOKEN() : OpenAPI.TOKEN;
+
+    const headers = options.headers || {};
+    if (token != null && token !== '') {
+        headers.authorization = 'Bearer ' + token;
+    }
+    console.log("OPTIONS", options, OpenAPI, headers)
+    return {
+        ok: true,
+        status: 200,
+        body: {
+            method: options.method,
+            protocol: 'http',
+            hostname: 'localhost',
+            path: options.path,
+            url: url,
+            query: options.query,
+            body: options.body,
+            headers: headers,
+        },
+        statusText: 'OK',
+        url: url
+    }
+}
+
+module.exports = {customClient}

--- a/test/e2e/v2.custom.spec.js
+++ b/test/e2e/v2.custom.spec.js
@@ -4,28 +4,26 @@ const generate = require('./scripts/generate');
 const compileWithTypescript = require('./scripts/compileWithTypescript');
 const {customClient} = require("./scripts/custom-client");
 
-describe('v3.custom', () => {
+describe('v2.custom', () => {
 
     beforeAll(async () => {
-        await generate('v3/custom', 'v3', 'custom');
-        compileWithTypescript('v3/custom');
+        await generate('v2/custom', 'v2', 'node');
+        compileWithTypescript('v2/custom');
         const {CustomHttpClient} = require('./generated/v3/custom/core/request')
         CustomHttpClient.executeRequest = customClient;
-    },30000);
+    }, 30000);
 
     it('requests token', async () => {
-
-        const { OpenAPI, SimpleService } = require('./generated/v3/custom/index.js');
+        const { OpenAPI, SimpleService } = require('./generated/v2/node/index.js');
         const tokenRequest = jest.fn().mockResolvedValue('MY_TOKEN')
         OpenAPI.TOKEN = tokenRequest;
-
         const result = await SimpleService.getCallWithoutParametersAndResponse();
         expect(tokenRequest.mock.calls.length).toBe(1);
         expect(result.headers.authorization).toBe('Bearer MY_TOKEN');
     });
 
     it('complexService', async () => {
-        const { ComplexService } = require('./generated/v3/custom/index.js');
+        const { ComplexService } = require('./generated/v2/node/index.js');
         const result = await ComplexService.complexTypes({
             first: {
                 second: {
@@ -37,5 +35,3 @@ describe('v3.custom', () => {
     });
 
 });
-
-

--- a/test/e2e/v3.custom.spec.js
+++ b/test/e2e/v3.custom.spec.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const generate = require('./scripts/generate');
+const compileWithTypescript = require('./scripts/compileWithTypescript');
+const server = require('./scripts/server');
+
+describe('v3.custom', () => {
+
+    beforeAll(async () => {
+        await generate('v3/custom', 'v3', 'custom');
+        compileWithTypescript('v3/custom');
+
+        const { OpenAPI } = require('./generated/v3/custom/index.js');
+        const {CustomHttpClient} = require('./generated/v3/custom/core/request')
+
+        CustomHttpClient.executeRequest = async (options) => {
+            const url = `${OpenAPI.BASE}${options.path}`;
+            const token = typeof OpenAPI.TOKEN === 'function' ? await OpenAPI.TOKEN() :  OpenAPI.TOKEN;
+
+            const headers = options.headers || {};
+            if (token != null && token !== '') {
+                headers.authorization ='Bearer '+token;
+            }
+            console.log("OPTIONS", options, OpenAPI, headers)
+            return {
+                ok: true,
+                status: 200,
+                body: {
+                    method: options.method,
+                    protocol: 'http',
+                    hostname: 'localhost',
+                    path: options.path,
+                    url: url,
+                    query: options.query,
+                    body: options.body,
+                    headers: headers,
+                },
+                statusText: 'OK',
+                url: url
+            }
+        }
+    }, 30000);
+
+    it('requests token', async () => {
+
+        const { OpenAPI, SimpleService } = require('./generated/v3/custom/index.js');
+        const tokenRequest = jest.fn().mockResolvedValue('MY_TOKEN')
+        OpenAPI.TOKEN = tokenRequest;
+
+        const result = await SimpleService.getCallWithoutParametersAndResponse();
+        expect(tokenRequest.mock.calls.length).toBe(1);
+        expect(result.headers.authorization).toBe('Bearer MY_TOKEN');
+    });
+
+    it('complexService', async () => {
+        const { ComplexService } = require('./generated/v3/custom/index.js');
+        const result = await ComplexService.complexTypes({
+            first: {
+                second: {
+                    third: 'Hello World!'
+                }
+            }
+        });
+        expect(result).toBeDefined();
+    });
+
+});
+
+


### PR DESCRIPTION
This example illustrates the feature-request in #400 

The library-user can specify a custom function that sends requests to the backend (as illustrated in `test/e2e/v3.custom.spec.js`

Helper functions like "getToken" and "getUrl" are not provided and must be written by the library-user.

The downside is that `ApiResult` and `ApiRequestOptions` would become part of the official API, which will impose restrictions in SemVer-versioning. I can understand if you don't want that.

Final polishing and tests are still missing. Before I go any further I would like to hear your opinion.

