### PR TITLE
Backquote/backtick symbol (`) is not escaped correctly

### DIFF
--- a/src/openApi/v2/parser/escapeDescription.spec.ts
+++ b/src/openApi/v2/parser/escapeDescription.spec.ts
@@ -1,0 +1,9 @@
+import { escapeDescription } from './escapeDescription';
+
+describe('escapeDescription', () => {
+    it('should escape', () => {
+        expect(escapeDescription('')).toEqual('');
+        expect(escapeDescription('fooBar')).toEqual('fooBar');
+        expect(escapeDescription('foo `test` bar')).toEqual('foo \\`test\\` bar');
+    });
+});

--- a/src/openApi/v2/parser/escapeDescription.spec.ts
+++ b/src/openApi/v2/parser/escapeDescription.spec.ts
@@ -2,8 +2,12 @@ import { escapeDescription } from './escapeDescription';
 
 describe('escapeDescription', () => {
     it('should escape', () => {
+        expect(escapeDescription('foo `test` bar')).toEqual('foo \\`test\\` bar');
+    });
+
+    it('should not escape', () => {
         expect(escapeDescription('')).toEqual('');
         expect(escapeDescription('fooBar')).toEqual('fooBar');
-        expect(escapeDescription('foo `test` bar')).toEqual('foo \\`test\\` bar');
+        expect(escapeDescription('foo \\`test\\` bar')).toEqual('foo \\`test\\` bar');
     });
 });

--- a/src/openApi/v2/parser/escapeDescription.ts
+++ b/src/openApi/v2/parser/escapeDescription.ts
@@ -1,3 +1,3 @@
 export function escapeDescription(value: string): string {
-    return value.replace(/`/g, '\\`');
+    return value.replace(/([^\\])`/g, '$1\\`');
 }

--- a/src/openApi/v2/parser/escapeDescription.ts
+++ b/src/openApi/v2/parser/escapeDescription.ts
@@ -1,0 +1,3 @@
+export function escapeDescription(value: string): string {
+    return value.replace(/`/g, '\\`');
+}

--- a/src/openApi/v2/parser/getOperationErrors.ts
+++ b/src/openApi/v2/parser/getOperationErrors.ts
@@ -1,5 +1,6 @@
 import type { OperationError } from '../../../client/interfaces/OperationError';
 import type { OperationResponse } from '../../../client/interfaces/OperationResponse';
+import { escapeDescription } from './escapeDescription';
 
 export function getOperationErrors(operationResponses: OperationResponse[]): OperationError[] {
     return operationResponses
@@ -8,6 +9,6 @@ export function getOperationErrors(operationResponses: OperationResponse[]): Ope
         })
         .map(response => ({
             code: response.code,
-            description: response.description!,
+            description: escapeDescription(response.description!),
         }));
 }

--- a/src/openApi/v3/parser/escapeDescription.spec.ts
+++ b/src/openApi/v3/parser/escapeDescription.spec.ts
@@ -1,0 +1,9 @@
+import { escapeDescription } from './escapeDescription';
+
+describe('escapeDescription', () => {
+    it('should escape', () => {
+        expect(escapeDescription('')).toEqual('');
+        expect(escapeDescription('fooBar')).toEqual('fooBar');
+        expect(escapeDescription('foo `test` bar')).toEqual('foo \\`test\\` bar');
+    });
+});

--- a/src/openApi/v3/parser/escapeDescription.spec.ts
+++ b/src/openApi/v3/parser/escapeDescription.spec.ts
@@ -2,8 +2,12 @@ import { escapeDescription } from './escapeDescription';
 
 describe('escapeDescription', () => {
     it('should escape', () => {
+        expect(escapeDescription('foo `test` bar')).toEqual('foo \\`test\\` bar');
+    });
+
+    it('should not escape', () => {
         expect(escapeDescription('')).toEqual('');
         expect(escapeDescription('fooBar')).toEqual('fooBar');
-        expect(escapeDescription('foo `test` bar')).toEqual('foo \\`test\\` bar');
+        expect(escapeDescription('foo \\`test\\` bar')).toEqual('foo \\`test\\` bar');
     });
 });

--- a/src/openApi/v3/parser/escapeDescription.ts
+++ b/src/openApi/v3/parser/escapeDescription.ts
@@ -1,3 +1,3 @@
 export function escapeDescription(value: string): string {
-    return value.replace(/`/g, '\\`');
+    return value.replace(/([^\\])`/g, '$1\\`');
 }

--- a/src/openApi/v3/parser/escapeDescription.ts
+++ b/src/openApi/v3/parser/escapeDescription.ts
@@ -1,0 +1,3 @@
+export function escapeDescription(value: string): string {
+    return value.replace(/`/g, '\\`');
+}

--- a/src/openApi/v3/parser/getOperationErrors.ts
+++ b/src/openApi/v3/parser/getOperationErrors.ts
@@ -1,5 +1,6 @@
 import type { OperationError } from '../../../client/interfaces/OperationError';
 import type { OperationResponse } from '../../../client/interfaces/OperationResponse';
+import { escapeDescription } from './escapeDescription';
 
 export function getOperationErrors(operationResponses: OperationResponse[]): OperationError[] {
     return operationResponses
@@ -8,6 +9,6 @@ export function getOperationErrors(operationResponses: OperationResponse[]): Ope
         })
         .map(response => ({
             code: response.code,
-            description: response.description!,
+            description: escapeDescription(response.description!),
         }));
 }


### PR DESCRIPTION
closes #451 

Backtick symbol in service description is not being escaped correctly. As result -> invalid TS is generated.

```
    public static async getUser(
        userId: number,
    ): Promise<User> {
        const result = await __request({
            method: 'GET',
            path: `/users/${userId}`,
            errors: {
                404: `|Error code         |Description                                                  |
                 * |-------------------|-------------------------------------------------------------|
                 * |RESOURCE_NOT_FOUND |The user specified in the `userId` path parameter: <br>- either does not exist;<br>- or ....`,
            },
        });
        return result.body;
    }

```

**\`userId\`**   should be   **\\\`userId\\\`**
