### PR TITLE
Fix empty parameter descriptions

### DIFF
--- a/src/templates/partials/parameters.hbs
+++ b/src/templates/partials/parameters.hbs
@@ -6,7 +6,9 @@
 {{/each}}
 }: {
 {{#each parameters}}
+{{#if description}}
 /** {{{description}}} **/
+{{/if}}
 {{{name}}}{{>isRequired}}: {{>type}},
 {{/each}}
 }


### PR DESCRIPTION
This PR omits generation of comments to parameters if `useOptions` is true and the parameter doesn't have description field.

After upgrade from 0.5.4 to 0.7.0 our re-generated types have a lot of empty comments in them, because parameters don't have the description field filled in.

This change has been introduced in https://github.com/ferdikoomen/openapi-typescript-codegen/pull/410