### PR TITLE
Implementation for: Optional flag which changes string to Date in case of format data-time

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -19,6 +19,7 @@ program
     .option('--exportServices <value>', 'Write services to disk', true)
     .option('--exportModels <value>', 'Write models to disk', true)
     .option('--exportSchemas <value>', 'Write schemas to disk', false)
+    .option('--useDateType', 'Output Date instead of string for the format "date-time" in the models')
     .parse(process.argv);
 
 const OpenAPI = require(path.resolve(__dirname, '../dist/index.js'));
@@ -34,6 +35,7 @@ if (OpenAPI) {
         exportServices: JSON.parse(program.exportServices) === true,
         exportModels: JSON.parse(program.exportModels) === true,
         exportSchemas: JSON.parse(program.exportSchemas) === true,
+        useDateType: program.useDateType,
     })
         .then(() => {
             process.exit(0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export interface Options {
     exportModels?: boolean;
     exportSchemas?: boolean;
     write?: boolean;
+    useDateType?: boolean;
 }
 
 /**
@@ -52,6 +53,7 @@ export async function generate({
     exportModels = true,
     exportSchemas = false,
     write = true,
+    useDateType = false,
 }: Options): Promise<void> {
     const openApi = isString(input) ? await getOpenApiSpec(input) : input;
     const openApiVersion = getOpenApiVersion(openApi);
@@ -62,7 +64,7 @@ export async function generate({
             const client = parseV2(openApi);
             const clientFinal = postProcessClient(client);
             if (!write) break;
-            await writeClient(clientFinal, templates, output, httpClient, useOptions, useUnionTypes, exportCore, exportServices, exportModels, exportSchemas);
+            await writeClient(clientFinal, templates, output, httpClient, useOptions, useUnionTypes, exportCore, exportServices, exportModels, exportSchemas, useDateType);
             break;
         }
 
@@ -70,7 +72,7 @@ export async function generate({
             const client = parseV3(openApi);
             const clientFinal = postProcessClient(client);
             if (!write) break;
-            await writeClient(clientFinal, templates, output, httpClient, useOptions, useUnionTypes, exportCore, exportServices, exportModels, exportSchemas);
+            await writeClient(clientFinal, templates, output, httpClient, useOptions, useUnionTypes, exportCore, exportServices, exportModels, exportSchemas, useDateType);
             break;
         }
     }

--- a/src/utils/dateTypeOverride.spec.ts
+++ b/src/utils/dateTypeOverride.spec.ts
@@ -1,0 +1,142 @@
+import { dateTypeOverride, RequiredFields } from './dateTypeOverride';
+
+describe('dateTypeOverride', () => {
+    it('should replace the base type for the model combination {base: "string", format: "data-time"}', async () => {
+        const expected = JSON.parse(JSON.stringify(models)) as RequiredFields<ModelOnlyName>[];
+        expected[1].properties[1].base = 'Date';
+        if (expected[3].link?.properties[0].base) {
+            expected[3].link.properties[0].base = 'Date';
+        }
+
+        const result = dateTypeOverride(models);
+        expect(result).toEqual(expected);
+    });
+});
+
+type ModelOnlyName = { name: string };
+
+const baseModel: Omit<RequiredFields<ModelOnlyName>, 'export' | 'base' | 'name'> = {
+    link: null,
+    properties: [],
+};
+
+const models: RequiredFields<ModelOnlyName>[] = [
+    {
+        ...baseModel,
+        name: 'ParentType',
+        export: 'interface',
+        base: 'any',
+        properties: [
+            {
+                ...baseModel,
+                name: 'name',
+                export: 'interface',
+                base: 'any',
+            },
+        ],
+    },
+    {
+        ...baseModel,
+        name: 'ExampleType',
+        export: 'interface',
+        base: 'any',
+        properties: [
+            {
+                ...baseModel,
+                name: 'id',
+                export: 'generic',
+                base: 'number',
+            },
+            {
+                ...baseModel,
+                name: 'dateTime',
+                export: 'generic',
+                base: 'string',
+                format: 'date-time',
+            },
+            {
+                ...baseModel,
+                name: 'date',
+                export: 'generic',
+                base: 'string',
+                format: 'date',
+            },
+            {
+                ...baseModel,
+                name: 'dateTimeNullable',
+                export: 'generic',
+                base: 'string',
+                format: 'date',
+            },
+            {
+                ...baseModel,
+                name: 'dateNullable',
+                export: 'generic',
+                base: 'string',
+                format: 'date',
+            },
+        ],
+    },
+    {
+        ...baseModel,
+        name: 'InheritType',
+        export: 'all-of',
+        base: 'any',
+        properties: [
+            {
+                ...baseModel,
+                name: '',
+                export: 'reference',
+                base: 'ParentType',
+            },
+            {
+                ...baseModel,
+                name: '',
+                export: 'reference',
+                base: 'ExampleType',
+            },
+        ],
+    },
+    {
+        ...baseModel,
+        name: 'WrappedInArray',
+        export: 'array',
+        base: 'any',
+        link: {
+            ...baseModel,
+            name: '',
+            export: 'interface',
+            base: 'any',
+            properties: [
+                {
+                    ...baseModel,
+                    name: 'dateTime',
+                    export: 'generic',
+                    base: 'string',
+                    format: 'date-time',
+                },
+                {
+                    ...baseModel,
+                    name: 'date',
+                    export: 'generic',
+                    base: 'string',
+                    format: 'date',
+                },
+                {
+                    ...baseModel,
+                    name: 'dateTimeNullable',
+                    export: 'generic',
+                    base: 'string',
+                    format: 'date',
+                },
+                {
+                    ...baseModel,
+                    name: 'dateNullable',
+                    export: 'generic',
+                    base: 'string',
+                    format: 'date',
+                },
+            ],
+        },
+    },
+];

--- a/src/utils/dateTypeOverride.ts
+++ b/src/utils/dateTypeOverride.ts
@@ -1,0 +1,39 @@
+import { Model } from '../client/interfaces/Model.d';
+
+const formatDate = ['date-time'];
+export type RequiredFields<T> = Pick<Model, 'export' | 'format' | 'base'> & { properties: RequiredFields<T>[]; link: RequiredFields<T> | null } & T;
+/**
+ * Change Model.base if it is a string and has the format 'date-time'
+ * @param models Array of Models
+ */
+export function dateTypeOverride<T>(models: RequiredFields<T>[]): RequiredFields<T>[] {
+    return models.map(model => {
+        if (model.export === 'interface') {
+            return { ...model, properties: dateTypeOverride(model.properties) };
+        }
+
+        if (model.export === 'array') {
+            if (model.link !== null) {
+                const link = cloneObject(model.link);
+                link.properties = dateTypeOverride(link.properties);
+                return { ...model, link };
+            }
+            return { ...model };
+        }
+
+        if (model.base !== 'string' || model.format === undefined) {
+            return { ...model };
+        }
+
+        let base = model.base;
+        if (formatDate.includes(model.format)) {
+            base = 'Date';
+        }
+
+        return { ...model, base };
+    });
+}
+
+function cloneObject<T>(object: T): T {
+    return { ...object };
+}

--- a/src/utils/writeClient.ts
+++ b/src/utils/writeClient.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 
 import type { Client } from '../client/interfaces/Client';
 import { HttpClient } from '../index';
+import { dateTypeOverride } from './dateTypeOverride';
 import { mkdir, rmdir } from './fileSystem';
 import { isSubDirectory } from './isSubdirectory';
 import { Templates } from './registerHandlebarTemplates';
@@ -67,6 +68,9 @@ export async function writeClient(
 
     if (exportModels) {
         await mkdir(outputPathModels);
+        if (useDateType) {
+            client.models = dateTypeOverride(client.models);
+        }
         await writeClientModels(client.models, templates, outputPathModels, httpClient, useUnionTypes);
     }
 

--- a/src/utils/writeClient.ts
+++ b/src/utils/writeClient.ts
@@ -34,7 +34,8 @@ export async function writeClient(
     exportCore: boolean,
     exportServices: boolean,
     exportModels: boolean,
-    exportSchemas: boolean
+    exportSchemas: boolean,
+    useDateType: boolean
 ): Promise<void> {
     const outputPath = path.resolve(process.cwd(), output);
     const outputPathCore = path.resolve(outputPath, 'core');

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -2211,6 +2211,427 @@ export class TypesService {
 }"
 `;
 
+exports[`v3 datetype should generate files and apply the Date type to interfaces with the string format "date-time": ./test/generated/v3_datetype/core/ApiError.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiResult } from './ApiResult';
+
+export class ApiError extends Error {
+    public readonly url: string;
+    public readonly status: number;
+    public readonly statusText: string;
+    public readonly body: any;
+
+    constructor(response: ApiResult, message: string) {
+        super(message);
+
+        this.url = response.url;
+        this.status = response.status;
+        this.statusText = response.statusText;
+        this.body = response.body;
+    }
+}"
+`;
+
+exports[`v3 datetype should generate files and apply the Date type to interfaces with the string format "date-time": ./test/generated/v3_datetype/core/ApiRequestOptions.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export interface ApiRequestOptions {
+    readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
+    readonly path: string;
+    readonly cookies?: Record<string, any>;
+    readonly headers?: Record<string, any>;
+    readonly query?: Record<string, any>;
+    readonly formData?: Record<string, any>;
+    readonly body?: any;
+    readonly responseHeader?: string;
+    readonly errors?: Record<number, string>;
+}"
+`;
+
+exports[`v3 datetype should generate files and apply the Date type to interfaces with the string format "date-time": ./test/generated/v3_datetype/core/ApiResult.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export interface ApiResult {
+    readonly url: string;
+    readonly ok: boolean;
+    readonly status: number;
+    readonly statusText: string;
+    readonly body: any;
+}"
+`;
+
+exports[`v3 datetype should generate files and apply the Date type to interfaces with the string format "date-time": ./test/generated/v3_datetype/core/OpenAPI.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+interface Config {
+    BASE: string;
+    VERSION: string;
+    WITH_CREDENTIALS: boolean;
+    TOKEN: string | (() => Promise<string>);
+}
+
+export const OpenAPI: Config = {
+    BASE: '/api/v1',
+    VERSION: '1.0',
+    WITH_CREDENTIALS: false,
+    TOKEN: '',
+};"
+`;
+
+exports[`v3 datetype should generate files and apply the Date type to interfaces with the string format "date-time": ./test/generated/v3_datetype/core/request.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import { ApiError } from './ApiError';
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+import { OpenAPI } from './OpenAPI';
+
+function isDefined<T>(value: T | null | undefined): value is Exclude<T, null | undefined> {
+    return value !== undefined && value !== null;
+}
+
+function isString(value: any): value is string {
+    return typeof value === 'string';
+}
+
+function isBlob(value: any): value is Blob {
+    return value instanceof Blob;
+}
+
+function getQueryString(params: Record<string, any>): string {
+    const qs: string[] = [];
+    Object.keys(params).forEach(key => {
+        const value = params[key];
+        if (isDefined(value)) {
+            if (Array.isArray(value)) {
+                value.forEach(value => {
+                    qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
+                });
+            } else {
+                qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
+            }
+        }
+    });
+    if (qs.length > 0) {
+        return \`?\${qs.join('&')}\`;
+    }
+    return '';
+}
+
+function getUrl(options: ApiRequestOptions): string {
+    const path = options.path.replace(/[:]/g, '_');
+    const url = \`\${OpenAPI.BASE}\${path}\`;
+
+    if (options.query) {
+        return \`\${url}\${getQueryString(options.query)}\`;
+    }
+    return url;
+}
+
+function getFormData(params: Record<string, any>): FormData {
+    const formData = new FormData();
+    Object.keys(params).forEach(key => {
+        const value = params[key];
+        if (isDefined(value)) {
+            formData.append(key, value);
+        }
+    });
+    return formData;
+}
+
+async function getToken(): Promise<string> {
+    if (typeof OpenAPI.TOKEN === 'function') {
+        return OpenAPI.TOKEN();
+    }
+    return OpenAPI.TOKEN;
+}
+
+async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
+    const headers = new Headers({
+        Accept: 'application/json',
+        ...options.headers,
+    });
+
+    const token = await getToken();
+    if (isDefined(token) && token !== '') {
+        headers.append('Authorization', \`Bearer \${token}\`);
+    }
+
+    if (options.body) {
+        if (isBlob(options.body)) {
+            headers.append('Content-Type', options.body.type || 'application/octet-stream');
+        } else if (isString(options.body)) {
+            headers.append('Content-Type', 'text/plain');
+        } else {
+            headers.append('Content-Type', 'application/json');
+        }
+    }
+    return headers;
+}
+
+function getRequestBody(options: ApiRequestOptions): BodyInit | undefined {
+    if (options.formData) {
+        return getFormData(options.formData);
+    }
+    if (options.body) {
+        if (isString(options.body) || isBlob(options.body)) {
+            return options.body;
+        } else {
+            return JSON.stringify(options.body);
+        }
+    }
+    return undefined;
+}
+
+async function sendRequest(options: ApiRequestOptions, url: string): Promise<Response> {
+    const request: RequestInit = {
+        method: options.method,
+        headers: await getHeaders(options),
+        body: getRequestBody(options),
+    };
+    return await fetch(url, request);
+}
+
+function getResponseHeader(response: Response, responseHeader?: string): string | null {
+    if (responseHeader) {
+        const content = response.headers.get(responseHeader);
+        if (isString(content)) {
+            return content;
+        }
+    }
+    return null;
+}
+
+async function getResponseBody(response: Response): Promise<any> {
+    try {
+        const contentType = response.headers.get('Content-Type');
+        if (contentType) {
+            const isJSON = contentType.toLowerCase().startsWith('application/json');
+            if (isJSON) {
+                return await response.json();
+            } else {
+                return await response.text();
+            }
+        }
+    } catch (error) {
+        console.error(error);
+    }
+    return null;
+}
+
+function catchErrors(options: ApiRequestOptions, result: ApiResult): void {
+    const errors: Record<number, string> = {
+        400: 'Bad Request',
+        401: 'Unauthorized',
+        403: 'Forbidden',
+        404: 'Not Found',
+        500: 'Internal Server Error',
+        502: 'Bad Gateway',
+        503: 'Service Unavailable',
+        ...options.errors,
+    }
+
+    const error = errors[result.status];
+    if (error) {
+        throw new ApiError(result, error);
+    }
+
+    if (!result.ok) {
+        throw new ApiError(result, 'Generic Error');
+    }
+}
+
+/**
+ * Request using fetch client
+ * @param options The request options from the the service
+ * @result ApiResult
+ * @throws ApiError
+ */
+export async function request(options: ApiRequestOptions): Promise<ApiResult> {
+    const url = getUrl(options);
+    const response = await sendRequest(options, url);
+    const responseBody = await getResponseBody(response);
+    const responseHeader = getResponseHeader(response, options.responseHeader);
+
+    const result: ApiResult = {
+        url,
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
+        body: responseHeader || responseBody,
+    };
+
+    catchErrors(options, result);
+    return result;
+}
+
+"
+`;
+
+exports[`v3 datetype should generate files and apply the Date type to interfaces with the string format "date-time": ./test/generated/v3_datetype/index.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export { ApiError } from './core/ApiError';
+export { OpenAPI } from './core/OpenAPI';
+
+export type { ExampleType } from './models/ExampleType';
+export type { InheritType } from './models/InheritType';
+export type { ParentType } from './models/ParentType';
+export type { WrappedInArray } from './models/WrappedInArray';
+
+export { $ExampleType } from './schemas/$ExampleType';
+export { $InheritType } from './schemas/$InheritType';
+export { $ParentType } from './schemas/$ParentType';
+export { $WrappedInArray } from './schemas/$WrappedInArray';
+"
+`;
+
+exports[`v3 datetype should generate files and apply the Date type to interfaces with the string format "date-time": ./test/generated/v3_datetype/models/ExampleType.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export interface ExampleType {
+    id?: number;
+    dateTime?: Date;
+    date?: string;
+    dateTimeNullable?: string | null;
+    dateNullable?: string | null;
+}
+"
+`;
+
+exports[`v3 datetype should generate files and apply the Date type to interfaces with the string format "date-time": ./test/generated/v3_datetype/models/InheritType.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ExampleType } from './ExampleType';
+import type { ParentType } from './ParentType';
+
+export interface InheritType extends ParentType, ExampleType {
+}
+"
+`;
+
+exports[`v3 datetype should generate files and apply the Date type to interfaces with the string format "date-time": ./test/generated/v3_datetype/models/ParentType.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export interface ParentType {
+    name?: any;
+}
+"
+`;
+
+exports[`v3 datetype should generate files and apply the Date type to interfaces with the string format "date-time": ./test/generated/v3_datetype/models/WrappedInArray.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type WrappedInArray = Array<{
+    dateTime?: Date,
+    date?: string,
+    dateTimeNullable?: string | null,
+    dateNullable?: string | null,
+}>;"
+`;
+
+exports[`v3 datetype should generate files and apply the Date type to interfaces with the string format "date-time": ./test/generated/v3_datetype/schemas/$ExampleType.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ExampleType = {
+    properties: {
+        id: {
+            type: 'number',
+        },
+        dateTime: {
+            type: 'string',
+            format: 'date-time',
+        },
+        date: {
+            type: 'string',
+            format: 'date',
+        },
+        dateTimeNullable: {
+            type: 'string',
+            isNullable: true,
+            format: 'date',
+        },
+        dateNullable: {
+            type: 'string',
+            isNullable: true,
+            format: 'date',
+        },
+    },
+};"
+`;
+
+exports[`v3 datetype should generate files and apply the Date type to interfaces with the string format "date-time": ./test/generated/v3_datetype/schemas/$InheritType.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import { $ParentType } from './$ParentType';
+import { $ExampleType } from './$ExampleType';
+
+export const $InheritType = {
+    properties: {
+        ...$ParentType.properties,
+        ...$ExampleType.properties,
+    },
+};"
+`;
+
+exports[`v3 datetype should generate files and apply the Date type to interfaces with the string format "date-time": ./test/generated/v3_datetype/schemas/$ParentType.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ParentType = {
+    properties: {
+        name: {
+            properties: {
+            },
+        },
+    },
+};"
+`;
+
+exports[`v3 datetype should generate files and apply the Date type to interfaces with the string format "date-time": ./test/generated/v3_datetype/schemas/$WrappedInArray.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $WrappedInArray = {
+    type: 'array',
+    contains: {
+        properties: {
+            dateTime: {
+                type: 'string',
+                format: 'date-time',
+            },
+            date: {
+                type: 'string',
+                format: 'date',
+            },
+            dateTimeNullable: {
+                type: 'string',
+                isNullable: true,
+                format: 'date',
+            },
+            dateNullable: {
+                type: 'string',
+                isNullable: true,
+                format: 'date',
+            },
+        },
+    },
+};"
+`;
+
 exports[`v3 should generate: ./test/generated/v3/core/ApiError.ts 1`] = `
 "/* istanbul ignore file */
 /* tslint:disable */

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -45,3 +45,41 @@ describe('v3', () => {
         });
     });
 });
+
+describe('v3 datetype', () => {
+    it('should generate files and apply the Date type to interfaces with the string format "date-time"', async () => {
+        await OpenAPI.generate({
+            input: './test/spec/v3_datetype.yaml',
+            output: './test/generated/v3_datetype/',
+            httpClient: OpenAPI.HttpClient.FETCH,
+            useOptions: true,
+            useUnionTypes: true,
+            exportCore: true,
+            exportSchemas: true,
+            exportModels: true,
+            exportServices: true,
+            useDateType: true,
+        });
+
+        glob.sync('./test/generated/v3_datetype/**/*.ts').forEach(file => {
+            const content = fs.readFileSync(file, 'utf8').toString();
+            expect(content).toMatchSnapshot(file);
+        });
+
+        glob.sync('./test/generated/v3_datetype/models/*.ts').forEach(file => {
+            const content = fs.readFileSync(file, 'utf8').toString();
+            const getNameAndContentPattern = /export (?:interface|type) (\w+)([\s\S]+)*?\}/;
+            const regexGroup = getNameAndContentPattern.exec(content);
+            const interfaceName = regexGroup[1] || '';
+            const interfaceContent = regexGroup[2] || '';
+            const attribute = interfaceContent
+                .split('\n')
+                .map(att => att.trim())
+                .find(att => att.startsWith('dateTime'));
+            if (attribute) {
+                console.log(`The interface ${interfaceName} with an attribute named 'dateTime' should have the data type of 'Date'`)
+                expect(attribute).toMatch(/Date/);
+            }
+        });
+    });
+});

--- a/test/spec/v3_datetype.yaml
+++ b/test/spec/v3_datetype.yaml
@@ -1,0 +1,70 @@
+openapi: 3.0.1
+info:
+  title: Data Type Test Spec
+  version: "1.0"
+  description: OpenAPI v3 (Swagger) file representing the CoBaLo API
+servers:
+  - url: /api/v1
+paths:
+components:
+  schemas:
+    ParentType:
+      title: Parent
+      type: object
+      properties: 
+        name: string
+    ExampleType:
+      title: ExampleType
+      type: object
+      properties:
+        id:
+          type: integer
+        dateTime:
+          type: string
+          format: date-time
+          example: "2012-10-27T17:18:30.966Z"
+        date:
+          type: string
+          format: date
+          example: "2012-10-27"
+        dateTimeNullable:
+          type: string
+          format: date
+          nullable: true
+          example: "2012-10-27"
+        dateNullable:
+          type: string
+          format: date
+          nullable: true
+          example: "2012-10-27"
+    InheritType:
+      title: InheritType
+      allOf:
+        - $ref: "#/components/schemas/ParentType"
+        - $ref: "#/components/schemas/ExampleType"
+    WrappedInArray:
+      title: WrappedInArray
+      type: array
+      items:
+        type: object
+        properties:
+          dateTime:
+            type: string
+            format: date-time
+            example: "2012-10-27T17:18:30.966Z"
+          date:
+            type: string
+            format: date
+            example: "2012-10-27"
+          dateTimeNullable:
+            type: string
+            format: date
+            nullable: true
+            example: "2012-10-27"
+          dateNullable:
+            type: string
+            format: date
+            nullable: true
+            example: "2012-10-27"
+
+  


### PR DESCRIPTION
This is the implementation for the issue #396. 

**Functionality**

A new flag called `useDateType` is added and it is false per default. If it is used, then any generated model property which is of type `string` and format `date-time`, will be changed to `Date`.

**Usage**

This is useful if you use a response interceptor to automatically find and replace date-ISO strings with an actual Date object.

**TODO**

- [ ] Update Readme with documentation for new option and how to use