### PR TITLE
Wrap negative numbers in quotes, fix Enums in TypeScript

### DIFF
--- a/src/openApi/v2/parser/getEnum.ts
+++ b/src/openApi/v2/parser/getEnum.ts
@@ -11,7 +11,7 @@ export function getEnum(values?: (string | number)[]): Enum[] {
             .map(value => {
                 if (typeof value === 'number') {
                     return {
-                        name: `"_${value}"`,
+                        name: `'_${value}'`,
                         value: String(value),
                         type: 'number',
                         description: null,

--- a/src/openApi/v2/parser/getEnum.ts
+++ b/src/openApi/v2/parser/getEnum.ts
@@ -11,7 +11,7 @@ export function getEnum(values?: (string | number)[]): Enum[] {
             .map(value => {
                 if (typeof value === 'number') {
                     return {
-                        name: `_${value}`,
+                        name: `"_${value}"`,
                         value: String(value),
                         type: 'number',
                         description: null,

--- a/src/openApi/v3/parser/getEnum.ts
+++ b/src/openApi/v3/parser/getEnum.ts
@@ -11,7 +11,7 @@ export function getEnum(values?: (string | number)[]): Enum[] {
             .map(value => {
                 if (typeof value === 'number') {
                     return {
-                        name: `"_${value}"`,
+                        name: `'_${value}'`,
                         value: String(value),
                         type: 'number',
                         description: null,

--- a/src/openApi/v3/parser/getEnum.ts
+++ b/src/openApi/v3/parser/getEnum.ts
@@ -11,7 +11,7 @@ export function getEnum(values?: (string | number)[]): Enum[] {
             .map(value => {
                 if (typeof value === 'number') {
                     return {
-                        name: `_${value}`,
+                        name: `"_${value}"`,
                         value: String(value),
                         type: 'number',
                         description: null,

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -587,10 +587,10 @@ exports[`v2 should generate: ./test/generated/v2/models/EnumWithNumbers.ts 1`] =
  * This is a simple enum with numbers
  */
 export enum EnumWithNumbers {
-    \\"_-1\\" = -1,
-    \\"_1\\" = 1,
-    \\"_2\\" = 2,
-    \\"_3\\" = 3,
+    '_-1' = -1,
+    '_1' = 1,
+    '_2' = 2,
+    '_3' = 3,
 }"
 `;
 
@@ -3017,10 +3017,10 @@ exports[`v3 should generate: ./test/generated/v3/models/EnumWithNumbers.ts 1`] =
  * This is a simple enum with numbers
  */
 export enum EnumWithNumbers {
-    \\"_-1\\" = -1,
-    \\"_1\\" = 1,
-    \\"_2\\" = 2,
-    \\"_3\\" = 3,
+    '_-1' = -1,
+    '_1' = 1,
+    '_2' = 2,
+    '_3' = 3,
 }"
 `;
 

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -587,9 +587,10 @@ exports[`v2 should generate: ./test/generated/v2/models/EnumWithNumbers.ts 1`] =
  * This is a simple enum with numbers
  */
 export enum EnumWithNumbers {
-    _1 = 1,
-    _2 = 2,
-    _3 = 3,
+    \\"_-1\\" = -1,
+    \\"_1\\" = 1,
+    \\"_2\\" = 2,
+    \\"_3\\" = 3,
 }"
 `;
 
@@ -3016,9 +3017,10 @@ exports[`v3 should generate: ./test/generated/v3/models/EnumWithNumbers.ts 1`] =
  * This is a simple enum with numbers
  */
 export enum EnumWithNumbers {
-    _1 = 1,
-    _2 = 2,
-    _3 = 3,
+    \\"_-1\\" = -1,
+    \\"_1\\" = 1,
+    \\"_2\\" = 2,
+    \\"_3\\" = 3,
 }"
 `;
 

--- a/test/spec/v2.json
+++ b/test/spec/v2.json
@@ -793,6 +793,7 @@
         "EnumWithNumbers": {
             "description": "This is a simple enum with numbers",
             "enum": [
+                -1,
                 1,
                 2,
                 3

--- a/test/spec/v3.json
+++ b/test/spec/v3.json
@@ -1289,6 +1289,7 @@
             "EnumWithNumbers": {
                 "description": "This is a simple enum with numbers",
                 "enum": [
+                    -1,
                     1,
                     2,
                     3


### PR DESCRIPTION
Negative numbers in generated enums are broken.
Here's the playground how it's not working and how PR fixes it.
https://www.typescriptlang.org/play?#code/KYOwrgtgBAouEHUCWAXAFgOUgI2AJygG8BYAKCigH0BGKAXimoBoyLKAmeqdl0gXzJlQkWPGTosEXHgBCeAPYBrUEVZUAtLQabebLY11VODHmQGkh8UZHGYc+AGJIAHsAAmq8lABElTd64dNV9qAIZmYI4w7l5zMjgbVDspfAA6GnixJMlpdPZBUgTEbPs8J1c3dOpMxIlS8vc8muK6lLKXdwBtX38AXSA

