### PR TITLE
feat: new method naming

### DIFF
--- a/src/openApi/v3/parser/getOperationName.ts
+++ b/src/openApi/v3/parser/getOperationName.ts
@@ -6,6 +6,9 @@ import camelCase from 'camelcase';
  * the most popular Javascript and Typescript writing style.
  */
 export function getOperationName(value: string): string {
+    const parts = value.split('.');
+    if (parts.length === 2) value = parts[1];
+    
     const clean = value
         .replace(/^[^a-zA-Z]+/g, '')
         .replace(/[^\w\-]+/g, '-')


### PR DESCRIPTION
Method names that are now is ugly. I propose to name the method as it called in specs. In short, before:
```
UsersService.usersControllerGetInfo
```
after:
```
UsersService.getInfo
```