### PR TITLE
Fix: Respect mediatype

### DIFF
--- a/src/client/interfaces/OperationParameter.d.ts
+++ b/src/client/interfaces/OperationParameter.d.ts
@@ -3,4 +3,5 @@ import type { Model } from './Model';
 export interface OperationParameter extends Model {
     in: 'path' | 'query' | 'header' | 'formData' | 'body' | 'cookie';
     prop: string;
+    mediaType: string | null;
 }

--- a/src/openApi/v2/parser/getOperationParameter.ts
+++ b/src/openApi/v2/parser/getOperationParameter.ts
@@ -42,6 +42,7 @@ export function getOperationParameter(openApi: OpenApi, parameter: OpenApiParame
         enum: [],
         enums: [],
         properties: [],
+        mediaType: null,
     };
 
     if (parameter.$ref) {

--- a/src/openApi/v3/parser/getMediaType.ts
+++ b/src/openApi/v3/parser/getMediaType.ts
@@ -1,0 +1,10 @@
+import type { Dictionary } from '../../../utils/types';
+import type { OpenApi } from '../interfaces/OpenApi';
+import type { OpenApiMediaType } from '../interfaces/OpenApiMediaType';
+
+export function getMediaType(openApi: OpenApi, content: Dictionary<OpenApiMediaType>): string | null {
+    return (
+        Object.keys(content).find(key => ['application/json-patch+json', 'application/json', 'text/json', 'text/plain', 'multipart/mixed', 'multipart/related', 'multipart/batch'].includes(key)) ||
+        null
+    );
+}

--- a/src/openApi/v3/parser/getOperationParameter.ts
+++ b/src/openApi/v3/parser/getOperationParameter.ts
@@ -27,6 +27,7 @@ export function getOperationParameter(openApi: OpenApi, parameter: OpenApiParame
         enum: [],
         enums: [],
         properties: [],
+        mediaType: null,
     };
 
     if (parameter.$ref) {

--- a/src/openApi/v3/parser/getOperationRequestBody.ts
+++ b/src/openApi/v3/parser/getOperationRequestBody.ts
@@ -4,6 +4,7 @@ import type { OpenApi } from '../interfaces/OpenApi';
 import type { OpenApiRequestBody } from '../interfaces/OpenApiRequestBody';
 import { getComment } from './getComment';
 import { getContent } from './getContent';
+import { getMediaType } from './getMediaType';
 import { getModel } from './getModel';
 import { getType } from './getType';
 
@@ -27,11 +28,14 @@ export function getOperationRequestBody(openApi: OpenApi, parameter: OpenApiRequ
         enum: [],
         enums: [],
         properties: [],
+        mediaType: null,
     };
 
     if (parameter.content) {
         const schema = getContent(openApi, parameter.content);
+        const mediaType = getMediaType(openApi, parameter.content);
         if (schema) {
+            requestBody.mediaType = mediaType;
             if (schema?.$ref) {
                 const model = getType(schema.$ref);
                 requestBody.export = 'reference';

--- a/src/templates/core/ApiRequestOptions.hbs
+++ b/src/templates/core/ApiRequestOptions.hbs
@@ -8,6 +8,7 @@ export type ApiRequestOptions = {
     readonly query?: Record<string, any>;
     readonly formData?: Record<string, any>;
     readonly body?: any;
+    readonly bodyMediaType?: string;
     readonly responseHeader?: string;
     readonly errors?: Record<number, string>;
 }

--- a/src/templates/core/fetch/getHeaders.hbs
+++ b/src/templates/core/fetch/getHeaders.hbs
@@ -20,12 +20,16 @@ async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
     }
 
     if (options.body) {
-        if (isBlob(options.body)) {
-            headers.append('Content-Type', options.body.type || 'application/octet-stream');
-        } else if (isString(options.body)) {
-            headers.append('Content-Type', 'text/plain');
+        if (options.bodyMediaType) {
+            headers.append('Content-Type', options.bodyMediaType);
         } else {
-            headers.append('Content-Type', 'application/json');
+            if (isBlob(options.body)) {
+                headers.append('Content-Type', options.body.type || 'application/octet-stream');
+            } else if (isString(options.body)) {
+                headers.append('Content-Type', 'text/plain');
+            } else {
+                headers.append('Content-Type', 'application/json');
+            }
         }
     }
     return headers;

--- a/src/templates/core/fetch/getRequestBody.hbs
+++ b/src/templates/core/fetch/getRequestBody.hbs
@@ -3,7 +3,9 @@ function getRequestBody(options: ApiRequestOptions): BodyInit | undefined {
         return getFormData(options.formData);
     }
     if (options.body) {
-        if (isString(options.body) || isBlob(options.body)) {
+        if (options.bodyMediaType.includes('/json')) {
+            return JSON.stringify(options.body)
+        } else if (isString(options.body) || isBlob(options.body)) {
             return options.body;
         } else {
             return JSON.stringify(options.body);

--- a/src/templates/core/fetch/getRequestBody.hbs
+++ b/src/templates/core/fetch/getRequestBody.hbs
@@ -3,7 +3,7 @@ function getRequestBody(options: ApiRequestOptions): BodyInit | undefined {
         return getFormData(options.formData);
     }
     if (options.body) {
-        if (options.bodyMediaType.includes('/json')) {
+        if (options.bodyMediaType?.includes('/json')) {
             return JSON.stringify(options.body)
         } else if (isString(options.body) || isBlob(options.body)) {
             return options.body;

--- a/src/templates/core/node/getHeaders.hbs
+++ b/src/templates/core/node/getHeaders.hbs
@@ -20,12 +20,16 @@ async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
     }
 
     if (options.body) {
-        if (isBinary(options.body)) {
-            headers.append('Content-Type', 'application/octet-stream');
-        } else if (isString(options.body)) {
-            headers.append('Content-Type', 'text/plain');
+        if (options.bodyMediaType) {
+            headers.append('Content-Type', options.bodyMediaType);
         } else {
-            headers.append('Content-Type', 'application/json');
+            if (isBinary(options.body)) {
+                headers.append('Content-Type', 'application/octet-stream');
+            } else if (isString(options.body)) {
+                headers.append('Content-Type', 'text/plain');
+            } else {
+                headers.append('Content-Type', 'application/json');
+            }
         }
     }
     return headers;

--- a/src/templates/core/node/getRequestBody.hbs
+++ b/src/templates/core/node/getRequestBody.hbs
@@ -3,7 +3,9 @@ function getRequestBody(options: ApiRequestOptions): BodyInit | undefined {
         return getFormData(options.formData);
     }
     if (options.body) {
-        if (isString(options.body) || isBinary(options.body)) {
+        if (options.bodyMediaType.includes('/json')) {
+            return JSON.stringify(options.body)
+        } else if (isString(options.body) || isBlob(options.body)) {
             return options.body;
         } else {
             return JSON.stringify(options.body);

--- a/src/templates/core/node/getRequestBody.hbs
+++ b/src/templates/core/node/getRequestBody.hbs
@@ -3,9 +3,9 @@ function getRequestBody(options: ApiRequestOptions): BodyInit | undefined {
         return getFormData(options.formData);
     }
     if (options.body) {
-        if (options.bodyMediaType.includes('/json')) {
+        if (options.bodyMediaType?.includes('/json')) {
             return JSON.stringify(options.body)
-        } else if (isString(options.body) || isBlob(options.body)) {
+        } else if (isString(options.body) || isBinary(options.body)) {
             return options.body;
         } else {
             return JSON.stringify(options.body);

--- a/src/templates/core/xhr/getHeaders.hbs
+++ b/src/templates/core/xhr/getHeaders.hbs
@@ -20,12 +20,16 @@ async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
     }
 
     if (options.body) {
-        if (isBlob(options.body)) {
-            headers.append('Content-Type', options.body.type || 'application/octet-stream');
-        } else if (isString(options.body)) {
-            headers.append('Content-Type', 'text/plain');
+        if (options.bodyMediaType) {
+            headers.append('Content-Type', options.bodyMediaType);
         } else {
-            headers.append('Content-Type', 'application/json');
+            if (isBlob(options.body)) {
+                headers.append('Content-Type', options.body.type || 'application/octet-stream');
+            } else if (isString(options.body)) {
+                headers.append('Content-Type', 'text/plain');
+            } else {
+                headers.append('Content-Type', 'application/json');
+            }
         }
     }
     return headers;

--- a/src/templates/core/xhr/getRequestBody.hbs
+++ b/src/templates/core/xhr/getRequestBody.hbs
@@ -3,7 +3,9 @@ function getRequestBody(options: ApiRequestOptions): any {
         return getFormData(options.formData);
     }
     if (options.body) {
-        if (isString(options.body) || isBlob(options.body)) {
+        if (options.bodyMediaType.includes('/json')) {
+            return JSON.stringify(options.body)
+        } else if (isString(options.body) || isBlob(options.body)) {
             return options.body;
         } else {
             return JSON.stringify(options.body);

--- a/src/templates/core/xhr/getRequestBody.hbs
+++ b/src/templates/core/xhr/getRequestBody.hbs
@@ -3,7 +3,7 @@ function getRequestBody(options: ApiRequestOptions): any {
         return getFormData(options.formData);
     }
     if (options.body) {
-        if (options.bodyMediaType.includes('/json')) {
+        if (options.bodyMediaType?.includes('/json')) {
             return JSON.stringify(options.body)
         } else if (isString(options.body) || isBlob(options.body)) {
             return options.body;

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -69,6 +69,9 @@ export class {{{name}}} {
             {{/if}}
             {{#if parametersBody}}
             body: {{{parametersBody.name}}},
+            {{#if parametersBody.mediaType}}
+            bodyMediaType: '{{{parametersBody.mediaType}}}',
+            {{/if}}
             {{/if}}
             {{#if responseHeader}}
             responseHeader: '{{{responseHeader}}}',

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -35,6 +35,7 @@ export type ApiRequestOptions = {
     readonly query?: Record<string, any>;
     readonly formData?: Record<string, any>;
     readonly body?: any;
+    readonly bodyMediaType?: string;
     readonly responseHeader?: string;
     readonly errors?: Record<number, string>;
 }"
@@ -180,12 +181,16 @@ async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
     }
 
     if (options.body) {
-        if (isBlob(options.body)) {
-            headers.append('Content-Type', options.body.type || 'application/octet-stream');
-        } else if (isString(options.body)) {
-            headers.append('Content-Type', 'text/plain');
+        if (options.bodyMediaType) {
+            headers.append('Content-Type', options.bodyMediaType);
         } else {
-            headers.append('Content-Type', 'application/json');
+            if (isBlob(options.body)) {
+                headers.append('Content-Type', options.body.type || 'application/octet-stream');
+            } else if (isString(options.body)) {
+                headers.append('Content-Type', 'text/plain');
+            } else {
+                headers.append('Content-Type', 'application/json');
+            }
         }
     }
     return headers;
@@ -196,7 +201,9 @@ function getRequestBody(options: ApiRequestOptions): BodyInit | undefined {
         return getFormData(options.formData);
     }
     if (options.body) {
-        if (isString(options.body) || isBlob(options.body)) {
+        if (options.bodyMediaType?.includes('/json')) {
+            return JSON.stringify(options.body)
+        } else if (isString(options.body) || isBlob(options.body)) {
             return options.body;
         } else {
             return JSON.stringify(options.body);
@@ -2383,6 +2390,7 @@ export type ApiRequestOptions = {
     readonly query?: Record<string, any>;
     readonly formData?: Record<string, any>;
     readonly body?: any;
+    readonly bodyMediaType?: string;
     readonly responseHeader?: string;
     readonly errors?: Record<number, string>;
 }"
@@ -2528,12 +2536,16 @@ async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
     }
 
     if (options.body) {
-        if (isBlob(options.body)) {
-            headers.append('Content-Type', options.body.type || 'application/octet-stream');
-        } else if (isString(options.body)) {
-            headers.append('Content-Type', 'text/plain');
+        if (options.bodyMediaType) {
+            headers.append('Content-Type', options.bodyMediaType);
         } else {
-            headers.append('Content-Type', 'application/json');
+            if (isBlob(options.body)) {
+                headers.append('Content-Type', options.body.type || 'application/octet-stream');
+            } else if (isString(options.body)) {
+                headers.append('Content-Type', 'text/plain');
+            } else {
+                headers.append('Content-Type', 'application/json');
+            }
         }
     }
     return headers;
@@ -2544,7 +2556,9 @@ function getRequestBody(options: ApiRequestOptions): BodyInit | undefined {
         return getFormData(options.formData);
     }
     if (options.body) {
-        if (isString(options.body) || isBlob(options.body)) {
+        if (options.bodyMediaType?.includes('/json')) {
+            return JSON.stringify(options.body)
+        } else if (isString(options.body) || isBlob(options.body)) {
             return options.body;
         } else {
             return JSON.stringify(options.body);
@@ -4481,6 +4495,7 @@ export class ComplexService {
             method: 'PUT',
             path: \`/api/v\${OpenAPI.VERSION}/complex/\${id}\`,
             body: requestBody,
+            bodyMediaType: 'application/json-patch+json',
         });
         return result.body;
     }
@@ -4777,6 +4792,7 @@ export class ParametersService {
                 'parameterForm': parameterForm,
             },
             body: requestBody,
+            bodyMediaType: 'application/json',
         });
         return result.body;
     }
@@ -4821,6 +4837,7 @@ export class ParametersService {
                 'parameter_form': parameterForm,
             },
             body: requestBody,
+            bodyMediaType: 'application/json',
         });
         return result.body;
     }
@@ -4841,6 +4858,7 @@ export class ParametersService {
                 'parameter': parameter,
             },
             body: requestBody,
+            bodyMediaType: 'application/json',
         });
         return result.body;
     }
@@ -4861,6 +4879,7 @@ export class ParametersService {
                 'parameter': parameter,
             },
             body: requestBody,
+            bodyMediaType: 'application/json',
         });
         return result.body;
     }
@@ -4889,6 +4908,7 @@ export class RequestBodyService {
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/requestBody/\`,
             body: requestBody,
+            bodyMediaType: 'application/json',
         });
         return result.body;
     }


### PR DESCRIPTION
## Issue
The current version of the `openapi-typescript-codegen` does not always respect the [Media Type](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#mediaTypeObject) of the requestBody in the `Content-Type` Request header.

Example:

If we have an operation with the following `requestBody` property ...
```json
{
  "requestBody": {
    "content": {
      "application/json": {
        "schema": {
          "type": "string"
        }
      }
    }
  }
}
```

... and we use the following method in our generated client ...
```js
await api.operationMethod({ requestBody: "test" });
```

... the client will send a request with the `Content-Type` header `text/plain` because of the following code:
1. https://github.com/ferdikoomen/openapi-typescript-codegen/blob/master/src/templates/core/fetch/getHeaders.hbs#L25-L26
1. https://github.com/ferdikoomen/openapi-typescript-codegen/blob/master/src/templates/core/xhr/getHeaders.hbs#L25-L26
1. https://github.com/ferdikoomen/openapi-typescript-codegen/blob/master/src/templates/core/node/getHeaders.hbs#L25-L26

Also, the value given in the `requestBody` parameter should be passed to the `JSON.stringify` function.

## Solution
1. Parse the Media Type from the OpenAPI document.
2. Check if it is a supported media-type, like in the `getContent` function.
3. Add the media type value to a new property in the request methods `bodyMediaType`
4. Check in the core `request` functionality if `bodyMediaType` property is defined and act accordingly.
5. If not, fallback to original flow.



