### PR TITLE
Backquote/backtick symbol (`) is not escaped correctly (Fix)

### DIFF
--- a/src/openApi/v2/parser/escapeDescription.spec.ts
+++ b/src/openApi/v2/parser/escapeDescription.spec.ts
@@ -3,6 +3,7 @@ import { escapeDescription } from './escapeDescription';
 describe('escapeDescription', () => {
     it('should escape', () => {
         expect(escapeDescription('foo `test` bar')).toEqual('foo \\`test\\` bar');
+        expect(escapeDescription('`foo `test` bar')).toEqual('\\`foo \\`test\\` bar');
     });
 
     it('should not escape', () => {

--- a/src/openApi/v2/parser/escapeDescription.ts
+++ b/src/openApi/v2/parser/escapeDescription.ts
@@ -1,3 +1,3 @@
 export function escapeDescription(value: string): string {
-    return value.replace(/([^\\])`/g, '$1\\`').replace(/(\*\/)/g, '*_/');
+    return value.replace(/(?<!\\)`/g, '\\`').replace(/(\*\/)/g, '*_/');
 }

--- a/src/openApi/v3/parser/escapeDescription.spec.ts
+++ b/src/openApi/v3/parser/escapeDescription.spec.ts
@@ -3,6 +3,7 @@ import { escapeDescription } from './escapeDescription';
 describe('escapeDescription', () => {
     it('should escape', () => {
         expect(escapeDescription('foo `test` bar')).toEqual('foo \\`test\\` bar');
+        expect(escapeDescription('`foo `test` bar')).toEqual('\\`foo \\`test\\` bar');
     });
 
     it('should not escape', () => {

--- a/src/openApi/v3/parser/escapeDescription.ts
+++ b/src/openApi/v3/parser/escapeDescription.ts
@@ -1,3 +1,3 @@
 export function escapeDescription(value: string): string {
-    return value.replace(/([^\\])`/g, '$1\\`').replace(/(\*\/)/g, '*_/');
+    return value.replace(/(?<!\\)`/g, '\\`').replace(/(\*\/)/g, '*_/');
 }


### PR DESCRIPTION
The previous pull request #452 doesn't work when the backtick is the first character of the description.
See original issue #451.
