### PR TITLE
Fix: Handle nested objects and arrays in query string

### DIFF
--- a/src/templates/core/functions/getQueryString.hbs
+++ b/src/templates/core/functions/getQueryString.hbs
@@ -1,19 +1,22 @@
 function getQueryString(params: Record<string, any>): string {
-    const qs: string[] = [];
-    Object.keys(params).forEach(key => {
-        const value = params[key];
-        if (isDefined(value)) {
-            if (Array.isArray(value)) {
-                value.forEach(value => {
-                    qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
-                });
-            } else {
-                qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+    const serialize = function (obj: {[paramName: string]: any}, prefix: string): string {
+        const str = [];
+        for (let p in obj) {
+            if (obj.hasOwnProperty(p)) {
+                const k = prefix ? prefix + '[' + p + ']' : p;
+                const v = obj[p];
+                str.push(
+                    (v !== null && typeof v === 'object')
+                        ? serialize(v, k)
+                        : encodeURIComponent(k) + '=' + encodeURIComponent(v),
+                );
             }
         }
-    });
-    if (qs.length > 0) {
-        return `?${qs.join('&')}`;
+        return str.join('&');
+    };
+    const qs = serialize(params, '');
+    if (qs !== '') {
+        return `?${qs}`;
     }
     return '';
 }

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -110,21 +110,24 @@ function isBlob(value: any): value is Blob {
 }
 
 function getQueryString(params: Record<string, any>): string {
-    const qs: string[] = [];
-    Object.keys(params).forEach(key => {
-        const value = params[key];
-        if (isDefined(value)) {
-            if (Array.isArray(value)) {
-                value.forEach(value => {
-                    qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
-                });
-            } else {
-                qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
+    const serialize = function (obj: {[paramName: string]: any}, prefix: string): string {
+        const str = [];
+        for (let p in obj) {
+            if (obj.hasOwnProperty(p)) {
+                const k = prefix ? prefix + '[' + p + ']' : p;
+                const v = obj[p];
+                str.push(
+                    (v !== null && typeof v === 'object')
+                        ? serialize(v, k)
+                        : encodeURIComponent(k) + '=' + encodeURIComponent(v),
+                );
             }
         }
-    });
-    if (qs.length > 0) {
-        return \`?\${qs.join('&')}\`;
+        return str.join('&');
+    };
+    const qs = serialize(params, '');
+    if (qs !== '') {
+        return \`?\${qs}\`;
     }
     return '';
 }
@@ -2463,21 +2466,24 @@ function isBlob(value: any): value is Blob {
 }
 
 function getQueryString(params: Record<string, any>): string {
-    const qs: string[] = [];
-    Object.keys(params).forEach(key => {
-        const value = params[key];
-        if (isDefined(value)) {
-            if (Array.isArray(value)) {
-                value.forEach(value => {
-                    qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
-                });
-            } else {
-                qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
+    const serialize = function (obj: {[paramName: string]: any}, prefix: string): string {
+        const str = [];
+        for (let p in obj) {
+            if (obj.hasOwnProperty(p)) {
+                const k = prefix ? prefix + '[' + p + ']' : p;
+                const v = obj[p];
+                str.push(
+                    (v !== null && typeof v === 'object')
+                        ? serialize(v, k)
+                        : encodeURIComponent(k) + '=' + encodeURIComponent(v),
+                );
             }
         }
-    });
-    if (qs.length > 0) {
-        return \`?\${qs.join('&')}\`;
+        return str.join('&');
+    };
+    const qs = serialize(params, '');
+    if (qs !== '') {
+        return \`?\${qs}\`;
     }
     return '';
 }


### PR DESCRIPTION
Implemented correct handling of nested objects and arrays in getQueryString method.
Example:
Parameter in openapi docs
```yaml
in: query
name: pagination
schema:
  type: object
  properties:
    count:
      type: integer
    offset:
      type: integer
```
Object that I pass
```json
{
  "pagination": {
    "count": 10,
    "offset": 0
  }
}
```
Before:
```?pagination=%5Bobject+Object%5D```
After:
```?pagination%5Bcount%5D=10&pagination%5Boffset%5D=0```