### PR TITLE
fix #636: condition of isRequired

### DIFF
--- a/src/openApi/v2/parser/getModel.ts
+++ b/src/openApi/v2/parser/getModel.ts
@@ -22,7 +22,7 @@ export function getModel(openApi: OpenApi, definition: OpenApiSchema, isDefiniti
         isDefinition,
         isReadOnly: definition.readOnly === true,
         isNullable: definition['x-nullable'] === true,
-        isRequired: definition.default !== undefined,
+        isRequired: definition.default === undefined,
         format: definition.format,
         maximum: definition.maximum,
         exclusiveMaximum: definition.exclusiveMaximum,

--- a/src/openApi/v2/parser/getModelProperties.ts
+++ b/src/openApi/v2/parser/getModelProperties.ts
@@ -15,7 +15,7 @@ export function getModelProperties(openApi: OpenApi, definition: OpenApiSchema, 
     for (const propertyName in definition.properties) {
         if (definition.properties.hasOwnProperty(propertyName)) {
             const property = definition.properties[propertyName];
-            const propertyRequired = definition.required?.includes(propertyName) || property.default !== undefined;
+            const propertyRequired = definition.required?.includes(propertyName) || property.default === undefined;
             if (property.$ref) {
                 const model = getType(property.$ref);
                 models.push({

--- a/src/openApi/v3/parser/getModel.ts
+++ b/src/openApi/v3/parser/getModel.ts
@@ -23,7 +23,7 @@ export function getModel(openApi: OpenApi, definition: OpenApiSchema, isDefiniti
         isDefinition,
         isReadOnly: definition.readOnly === true,
         isNullable: definition.nullable === true,
-        isRequired: definition.default !== undefined,
+        isRequired: definition.default === undefined,
         format: definition.format,
         maximum: definition.maximum,
         exclusiveMaximum: definition.exclusiveMaximum,

--- a/src/openApi/v3/parser/getModelProperties.ts
+++ b/src/openApi/v3/parser/getModelProperties.ts
@@ -15,7 +15,7 @@ export function getModelProperties(openApi: OpenApi, definition: OpenApiSchema, 
     for (const propertyName in definition.properties) {
         if (definition.properties.hasOwnProperty(propertyName)) {
             const property = definition.properties[propertyName];
-            const propertyRequired = definition.required?.includes(propertyName) || property.default !== undefined;
+            const propertyRequired = definition.required?.includes(propertyName) || property.default === undefined;
             if (property.$ref) {
                 const model = getType(property.$ref);
                 models.push({


### PR DESCRIPTION
In #636 there is an issue about the isRequired flag.

In common sense, if a parameter has a default value, it means that this parameter is optional (not required). But in the current code, 
"isRequired: definition.default !== undefined" means that if default is not defines, it's required, making it quite strange. I think the condition should  be "definition.default === undefined" in these places.