### PR TITLE
Allow FormData as body argument

### DIFF
--- a/src/templates/core/fetch/getHeaders.hbs
+++ b/src/templates/core/fetch/getHeaders.hbs
@@ -33,7 +33,7 @@ async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
             headers.append('Content-Type', options.body.type || 'application/octet-stream');
         } else if (isString(options.body)) {
             headers.append('Content-Type', 'text/plain');
-        } else {
+        } else if (!isFormData(options.body)) {
             headers.append('Content-Type', 'application/json');
         }
     }

--- a/src/templates/core/fetch/getRequestBody.hbs
+++ b/src/templates/core/fetch/getRequestBody.hbs
@@ -2,7 +2,7 @@ function getRequestBody(options: ApiRequestOptions): BodyInit | undefined {
     if (options.body) {
         if (options.mediaType?.includes('/json')) {
             return JSON.stringify(options.body)
-        } else if (isString(options.body) || isBlob(options.body)) {
+        } else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
             return options.body;
         } else {
             return JSON.stringify(options.body);

--- a/src/templates/core/fetch/request.hbs
+++ b/src/templates/core/fetch/request.hbs
@@ -19,6 +19,9 @@ import { OpenAPI } from './OpenAPI';
 {{>functions/isBlob}}
 
 
+{{>functions/isFormData}}
+
+
 {{>functions/base64}}
 
 

--- a/src/templates/core/functions/isFormData.hbs
+++ b/src/templates/core/functions/isFormData.hbs
@@ -1,0 +1,3 @@
+function isFormData(value: any): value is FormData {
+    return value instanceof FormData;
+}

--- a/src/templates/core/node/getHeaders.hbs
+++ b/src/templates/core/node/getHeaders.hbs
@@ -33,7 +33,7 @@ async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
             headers.append('Content-Type', 'application/octet-stream');
         } else if (isString(options.body)) {
             headers.append('Content-Type', 'text/plain');
-        } else {
+        } else if (!isFormData(options.body)) {
             headers.append('Content-Type', 'application/json');
         }
     }

--- a/src/templates/core/node/getRequestBody.hbs
+++ b/src/templates/core/node/getRequestBody.hbs
@@ -2,7 +2,7 @@ function getRequestBody(options: ApiRequestOptions): BodyInit | undefined {
     if (options.body) {
         if (options.mediaType?.includes('/json')) {
             return JSON.stringify(options.body)
-        } else if (isString(options.body) || isBlob(options.body)) {
+        } else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
             return options.body as any;
         } else {
             return JSON.stringify(options.body);

--- a/src/templates/core/xhr/getHeaders.hbs
+++ b/src/templates/core/xhr/getHeaders.hbs
@@ -33,7 +33,7 @@ async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
             headers.append('Content-Type', options.body.type || 'application/octet-stream');
         } else if (isString(options.body)) {
             headers.append('Content-Type', 'text/plain');
-        } else {
+        } else if (!isFormData(options.body)) {
             headers.append('Content-Type', 'application/json');
         }
     }

--- a/src/templates/core/xhr/getRequestBody.hbs
+++ b/src/templates/core/xhr/getRequestBody.hbs
@@ -2,7 +2,7 @@ function getRequestBody(options: ApiRequestOptions): any {
     if (options.body) {
         if (options.mediaType?.includes('/json')) {
             return JSON.stringify(options.body)
-        } else if (isString(options.body) || isBlob(options.body)) {
+        } else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
             return options.body;
         } else {
             return JSON.stringify(options.body);

--- a/src/utils/registerHandlebarTemplates.ts
+++ b/src/utils/registerHandlebarTemplates.ts
@@ -24,6 +24,7 @@ import functionGetQueryString from '../templates/core/functions/getQueryString.h
 import functionGetUrl from '../templates/core/functions/getUrl.hbs';
 import functionIsBlob from '../templates/core/functions/isBlob.hbs';
 import functionIsDefined from '../templates/core/functions/isDefined.hbs';
+import functionIsFormData from '../templates/core/functions/isFormData.hbs';
 import functionIsString from '../templates/core/functions/isString.hbs';
 import functionIsStringWithValue from '../templates/core/functions/isStringWithValue.hbs';
 import functionIsSuccess from '../templates/core/functions/isSuccess.hbs';
@@ -157,6 +158,7 @@ export function registerHandlebarTemplates(root: {
     Handlebars.registerPartial('functions/getUrl', Handlebars.template(functionGetUrl));
     Handlebars.registerPartial('functions/isBlob', Handlebars.template(functionIsBlob));
     Handlebars.registerPartial('functions/isDefined', Handlebars.template(functionIsDefined));
+    Handlebars.registerPartial('functions/isFormData', Handlebars.template(functionIsFormData));
     Handlebars.registerPartial('functions/isString', Handlebars.template(functionIsString));
     Handlebars.registerPartial('functions/isStringWithValue', Handlebars.template(functionIsStringWithValue));
     Handlebars.registerPartial('functions/isSuccess', Handlebars.template(functionIsSuccess));

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -233,6 +233,10 @@ function isBlob(value: any): value is Blob {
     return value instanceof Blob;
 }
 
+function isFormData(value: any): value is FormData {
+    return value instanceof FormData;
+}
+
 function base64(str: string): string {
     try {
         return btoa(str);
@@ -347,7 +351,7 @@ async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
             headers.append('Content-Type', options.body.type || 'application/octet-stream');
         } else if (isString(options.body)) {
             headers.append('Content-Type', 'text/plain');
-        } else {
+        } else if (!isFormData(options.body)) {
             headers.append('Content-Type', 'application/json');
         }
     }
@@ -359,7 +363,7 @@ function getRequestBody(options: ApiRequestOptions): BodyInit | undefined {
     if (options.body) {
         if (options.mediaType?.includes('/json')) {
             return JSON.stringify(options.body)
-        } else if (isString(options.body) || isBlob(options.body)) {
+        } else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
             return options.body;
         } else {
             return JSON.stringify(options.body);
@@ -2896,6 +2900,10 @@ function isBlob(value: any): value is Blob {
     return value instanceof Blob;
 }
 
+function isFormData(value: any): value is FormData {
+    return value instanceof FormData;
+}
+
 function base64(str: string): string {
     try {
         return btoa(str);
@@ -3010,7 +3018,7 @@ async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
             headers.append('Content-Type', options.body.type || 'application/octet-stream');
         } else if (isString(options.body)) {
             headers.append('Content-Type', 'text/plain');
-        } else {
+        } else if (!isFormData(options.body)) {
             headers.append('Content-Type', 'application/json');
         }
     }
@@ -3022,7 +3030,7 @@ function getRequestBody(options: ApiRequestOptions): BodyInit | undefined {
     if (options.body) {
         if (options.mediaType?.includes('/json')) {
             return JSON.stringify(options.body)
-        } else if (isString(options.body) || isBlob(options.body)) {
+        } else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
             return options.body;
         } else {
             return JSON.stringify(options.body);


### PR DESCRIPTION
This PR adds support for sending a `FormData` directly as `requestBody`. Often used for file upload.

Note the warning here:  https://developer.mozilla.org/en-US/docs/Web/API/FormData/Using_FormData_Objects that you should  not explicitly set the `Content-Type` header on the request.