### PR TITLE
Filter undefined headers before creating the headers

### DIFF
--- a/src/openApi/v2/parser/getOperationParameterName.ts
+++ b/src/openApi/v2/parser/getOperationParameterName.ts
@@ -1,6 +1,7 @@
 import camelCase from 'camelcase';
 
-const reservedWords = /^(arguments|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|eval|export|extends|false|finally|for|function|if|implements|import|in|instanceof|interface|let|new|null|package|private|protected|public|return|static|super|switch|this|throw|true|try|typeof|var|void|while|with|yield)$/g;
+const reservedWords =
+    /^(arguments|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|eval|export|extends|false|finally|for|function|if|implements|import|in|instanceof|interface|let|new|null|package|private|protected|public|return|static|super|switch|this|throw|true|try|typeof|var|void|while|with|yield)$/g;
 
 /**
  * Replaces any invalid characters from a parameter name.

--- a/src/openApi/v3/parser/getOperationParameterName.ts
+++ b/src/openApi/v3/parser/getOperationParameterName.ts
@@ -1,6 +1,7 @@
 import camelCase from 'camelcase';
 
-const reservedWords = /^(arguments|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|eval|export|extends|false|finally|for|function|if|implements|import|in|instanceof|interface|let|new|null|package|private|protected|public|return|static|super|switch|this|throw|true|try|typeof|var|void|while|with|yield)$/g;
+const reservedWords =
+    /^(arguments|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|eval|export|extends|false|finally|for|function|if|implements|import|in|instanceof|interface|let|new|null|package|private|protected|public|return|static|super|switch|this|throw|true|try|typeof|var|void|while|with|yield)$/g;
 
 /**
  * Replaces any invalid characters from a parameter name.

--- a/src/templates/core/fetch/getHeaders.hbs
+++ b/src/templates/core/fetch/getHeaders.hbs
@@ -4,11 +4,20 @@ async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
     const password = await resolve(options, OpenAPI.PASSWORD);
     const defaultHeaders = await resolve(options, OpenAPI.HEADERS);
 
-    const headers = new Headers({
+    const filteredHeaders = Object.entries({
         Accept: 'application/json',
         ...defaultHeaders,
         ...options.headers,
-    });
+    }).reduce((acc, [headerKey, headerValue]) => {
+        if (typeof headerValue !== 'undefined') {
+            return {
+                ...acc,
+                [headerKey]: headerValue,
+            };
+        }
+        return acc;
+    }, {});
+    const headers = new Headers(filteredHeaders);
 
     if (isStringWithValue(token)) {
         headers.append('Authorization', `Bearer ${token}`);

--- a/src/templates/core/node/getHeaders.hbs
+++ b/src/templates/core/node/getHeaders.hbs
@@ -4,11 +4,20 @@ async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
     const password = await resolve(options, OpenAPI.PASSWORD);
     const defaultHeaders = await resolve(options, OpenAPI.HEADERS);
 
-    const headers = new Headers({
+    const filteredHeaders = Object.entries({
         Accept: 'application/json',
         ...defaultHeaders,
         ...options.headers,
-    });
+    }).reduce((acc, [headerKey, headerValue]) => {
+        if (typeof headerValue !== 'undefined') {
+            return {
+                ...acc,
+                [headerKey]: headerValue,
+            };
+        }
+        return acc;
+    }, {});
+    const headers = new Headers(filteredHeaders);
 
     if (isStringWithValue(token)) {
         headers.append('Authorization', `Bearer ${token}`);

--- a/src/templates/core/xhr/getHeaders.hbs
+++ b/src/templates/core/xhr/getHeaders.hbs
@@ -4,11 +4,20 @@ async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
     const password = await resolve(options, OpenAPI.PASSWORD);
     const defaultHeaders = await resolve(options, OpenAPI.HEADERS);
 
-    const headers = new Headers({
+    const filteredHeaders = Object.entries({
         Accept: 'application/json',
         ...defaultHeaders,
         ...options.headers,
-    });
+    }).reduce((acc, [headerKey, headerValue]) => {
+        if (typeof headerValue !== 'undefined') {
+            return {
+                ...acc,
+                [headerKey]: headerValue,
+            };
+        }
+        return acc;
+    }, {});
+    const headers = new Headers(filteredHeaders);
 
     if (isStringWithValue(token)) {
         headers.append('Authorization', `Bearer ${token}`);

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -165,11 +165,20 @@ async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
     const password = await resolve(options, OpenAPI.PASSWORD);
     const defaultHeaders = await resolve(options, OpenAPI.HEADERS);
 
-    const headers = new Headers({
+    const filteredHeaders = Object.entries({
         Accept: 'application/json',
         ...defaultHeaders,
         ...options.headers,
-    });
+    }).reduce((acc, [headerKey, headerValue]) => {
+        if (typeof headerValue !== 'undefined') {
+            return {
+                ...acc,
+                [headerKey]: headerValue,
+            };
+        }
+        return acc;
+    }, {});
+    const headers = new Headers(filteredHeaders);
 
     if (isStringWithValue(token)) {
         headers.append('Authorization', \`Bearer \${token}\`);
@@ -2518,11 +2527,20 @@ async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
     const password = await resolve(options, OpenAPI.PASSWORD);
     const defaultHeaders = await resolve(options, OpenAPI.HEADERS);
 
-    const headers = new Headers({
+    const filteredHeaders = Object.entries({
         Accept: 'application/json',
         ...defaultHeaders,
         ...options.headers,
-    });
+    }).reduce((acc, [headerKey, headerValue]) => {
+        if (typeof headerValue !== 'undefined') {
+            return {
+                ...acc,
+                [headerKey]: headerValue,
+            };
+        }
+        return acc;
+    }, {});
+    const headers = new Headers(filteredHeaders);
 
     if (isStringWithValue(token)) {
         headers.append('Authorization', \`Bearer \${token}\`);


### PR DESCRIPTION
PR for issue https://github.com/ferdikoomen/openapi-typescript-codegen/issues/760

- Reduce headers by checking value of typeof undefined
- Update snapshot test
- run yarn eslint:fix (getOperationParamaterName changes)

With thanks to @vanhoofmaarten 