### PR TITLE
fix: accept relative schema ref paths

### DIFF
--- a/src/utils/getOpenApiSpec.spec.ts
+++ b/src/utils/getOpenApiSpec.spec.ts
@@ -1,27 +1,52 @@
+import RefParser from 'json-schema-ref-parser';
+
 import { exists, readFile } from './fileSystem';
 import { getOpenApiSpec } from './getOpenApiSpec';
 
 jest.mock('./fileSystem');
+jest.mock('json-schema-ref-parser');
 
 const existsMocked = exists as jest.MockedFunction<typeof exists>;
 const readFileMocked = readFile as jest.MockedFunction<typeof readFile>;
+const bundleMocked = RefParser.bundle as jest.MockedFunction<typeof RefParser.bundle>;
 
 function mockPromise<T>(value: T): Promise<T> {
     return new Promise<T>(resolve => resolve(value));
 }
 
 describe('getOpenApiSpec', () => {
+    const fixture = {
+        message: 'Hello World!',
+    };
+
+    existsMocked.mockReturnValue(mockPromise(true));
+    bundleMocked.mockReturnValue(mockPromise(fixture));
+    readFileMocked.mockReturnValue(mockPromise(JSON.stringify(fixture)));
+
     it('should read the json file', async () => {
-        existsMocked.mockReturnValue(mockPromise(true));
-        readFileMocked.mockReturnValue(mockPromise('{"message": "Hello World!"}'));
         const spec = await getOpenApiSpec('spec.json');
         expect(spec.message).toEqual('Hello World!');
     });
 
     it('should read the yaml file', async () => {
-        existsMocked.mockReturnValue(mockPromise(true));
-        readFileMocked.mockReturnValue(mockPromise('message: "Hello World!"'));
         const spec = await getOpenApiSpec('spec.yaml');
         expect(spec.message).toEqual('Hello World!');
+    });
+
+    it('should throw an error if the json is not valid', async () => {
+        readFileMocked.mockReturnValueOnce(mockPromise('not json'));
+        await expect(getOpenApiSpec('spec.json')).rejects.toThrow('Could not parse OpenApi JSON');
+    });
+
+    it('should throw an error if the json is not valid', async () => {
+        readFileMocked.mockReturnValueOnce(
+            mockPromise(`
+        asfiasdfm:
+          asdfasdf -
+          asdf: asdf; -
+        kasdfjasdf
+      `)
+        );
+        await expect(getOpenApiSpec('spec.yaml')).rejects.toThrow('Could not parse OpenApi YAML');
     });
 });

--- a/src/utils/getOpenApiSpec.ts
+++ b/src/utils/getOpenApiSpec.ts
@@ -13,12 +13,11 @@ import { readSpec } from './readSpec';
 export async function getOpenApiSpec(input: string): Promise<any> {
     const extension = extname(input).toLowerCase();
     const content = await readSpec(input);
-    let rootObject: any;
     switch (extension) {
         case '.yml':
         case '.yaml':
             try {
-                rootObject = load(content);
+                load(content);
             } catch (e) {
                 throw new Error(`Could not parse OpenApi YAML: "${input}"`);
             }
@@ -26,11 +25,12 @@ export async function getOpenApiSpec(input: string): Promise<any> {
 
         default:
             try {
-                rootObject = JSON.parse(content);
+                JSON.parse(content);
             } catch (e) {
+                console.log(e);
                 throw new Error(`Could not parse OpenApi JSON: "${input}"`);
             }
             break;
     }
-    return await RefParser.bundle(rootObject);
+    return await RefParser.bundle(input);
 }

--- a/test/spec/refs/ModelWithBoolean.yaml
+++ b/test/spec/refs/ModelWithBoolean.yaml
@@ -1,0 +1,7 @@
+title: ModelWithBoolean
+description: This is a model with one boolean property
+type: object
+properties:
+  prop:
+    type: boolean
+    description: This is a simple boolean property

--- a/test/spec/refs/ModelWithString.json
+++ b/test/spec/refs/ModelWithString.json
@@ -1,0 +1,10 @@
+{
+    "description": "This is a model with one string property",
+    "type": "object",
+    "properties": {
+        "prop": {
+            "description": "This is a simple string property",
+            "type": "string"
+        }
+    }
+}

--- a/test/spec/v2.json
+++ b/test/spec/v2.json
@@ -969,24 +969,10 @@
             }
         },
         "ModelWithBoolean": {
-            "description": "This is a model with one boolean property",
-            "type": "object",
-            "properties": {
-                "prop": {
-                    "description": "This is a simple boolean property",
-                    "type": "boolean"
-                }
-            }
+            "$ref": "./refs/ModelWithBoolean.yaml"
         },
         "ModelWithString": {
-            "description": "This is a model with one string property",
-            "type": "object",
-            "properties": {
-                "prop": {
-                    "description": "This is a simple string property",
-                    "type": "string"
-                }
-            }
+            "$ref": "./refs/ModelWithString.json"
         },
         "ModelWithNullableString": {
             "description": "This is a model with one string property",

--- a/test/spec/v3.json
+++ b/test/spec/v3.json
@@ -1464,24 +1464,10 @@
                 }
             },
             "ModelWithBoolean": {
-                "description": "This is a model with one boolean property",
-                "type": "object",
-                "properties": {
-                    "prop": {
-                        "description": "This is a simple boolean property",
-                        "type": "boolean"
-                    }
-                }
+                "$ref": "./refs/ModelWithBoolean.yaml"
             },
             "ModelWithString": {
-                "description": "This is a model with one string property",
-                "type": "object",
-                "properties": {
-                    "prop": {
-                        "description": "This is a simple string property",
-                        "type": "string"
-                    }
-                }
+                "$ref": "./refs/ModelWithString.json"
             },
             "ModelWithEnum": {
                 "description": "This is a model with one enum",


### PR DESCRIPTION
Cool library, thanks!

I've been having trouble with $refs on my local filesystem. The tool expects the files to be relative to process.cwd(). This PR leverages json-schema-ref-parser's ability to resolve everything when given a path to a yaml or json file. 

I've chosen to preserve the existing errors, but I'm not sure they're terribly valuable because those errors don't take into account any parsing errors when the refs are resolved. I think it's possible the entire `getOpenApiSpec` function is just `RefParser.bundle` 🤔 

Maybe there's something I'm missing in these tests. Either way, this library is really awesome, I'd like to get it working with relative $refs.