### PR TITLE
fix(node): import missing Blob from node-fetch in node <= 15

### DIFF
--- a/src/templates/core/node/request.hbs
+++ b/src/templates/core/node/request.hbs
@@ -2,7 +2,7 @@
 
 import { AbortController } from 'abort-controller';
 import FormData from 'form-data';
-import fetch, { BodyInit, Headers, RequestInit, Response } from 'node-fetch';
+import fetch, { BodyInit, Headers, RequestInit, Response, Blob } from 'node-fetch';
 import { types } from 'util';
 
 import { ApiError } from './ApiError';

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -2508,6 +2508,3140 @@ export class TypesService {
 }"
 `;
 
+exports[`v3 should generate for node client: ./test/generated/v3-node/core/ApiError.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiResult } from './ApiResult';
+
+export class ApiError extends Error {
+    public readonly url: string;
+    public readonly status: number;
+    public readonly statusText: string;
+    public readonly body: any;
+
+    constructor(response: ApiResult, message: string) {
+        super(message);
+
+        this.name = 'ApiError';
+        this.url = response.url;
+        this.status = response.status;
+        this.statusText = response.statusText;
+        this.body = response.body;
+    }
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/core/ApiRequestOptions.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiRequestOptions = {
+    readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
+    readonly path: string;
+    readonly cookies?: Record<string, any>;
+    readonly headers?: Record<string, any>;
+    readonly query?: Record<string, any>;
+    readonly formData?: Record<string, any>;
+    readonly body?: any;
+    readonly mediaType?: string;
+    readonly responseHeader?: string;
+    readonly errors?: Record<number, string>;
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/core/ApiResult.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiResult = {
+    readonly url: string;
+    readonly ok: boolean;
+    readonly status: number;
+    readonly statusText: string;
+    readonly body: any;
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/core/CancelablePromise.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export class CancelError extends Error {
+
+    constructor(reason: string = 'Promise was canceled') {
+        super(reason);
+        this.name = 'CancelError';
+    }
+
+    public get isCancelled(): boolean {
+        return true;
+    }
+}
+
+export interface OnCancel {
+    readonly isPending: boolean;
+    readonly isCancelled: boolean;
+
+    (cancelHandler: () => void): void;
+}
+
+export class CancelablePromise<T> implements Promise<T> {
+    readonly [Symbol.toStringTag]: string;
+
+    #isPending: boolean;
+    #isCancelled: boolean;
+    readonly #cancelHandlers: (() => void)[];
+    readonly #promise: Promise<T>;
+    #resolve?: (value: T | PromiseLike<T>) => void;
+    #reject?: (reason?: any) => void;
+
+    constructor(
+        executor: (
+            resolve: (value: T | PromiseLike<T>) => void,
+            reject: (reason?: any) => void,
+            onCancel: OnCancel
+        ) => void
+    ) {
+        this.#isPending = true;
+        this.#isCancelled = false;
+        this.#cancelHandlers = [];
+        this.#promise = new Promise<T>((resolve, reject) => {
+            this.#resolve = resolve;
+            this.#reject = reject;
+
+            const onResolve = (value: T | PromiseLike<T>): void => {
+                if (!this.#isCancelled) {
+                    this.#isPending = false;
+                    this.#resolve?.(value);
+                }
+            };
+
+            const onReject = (reason?: any): void => {
+                this.#isPending = false;
+                this.#reject?.(reason);
+            };
+
+            const onCancel = (cancelHandler: () => void): void => {
+                if (this.#isPending) {
+                    this.#cancelHandlers.push(cancelHandler);
+                }
+            };
+
+            Object.defineProperty(onCancel, 'isPending', {
+                get: (): boolean => this.#isPending,
+            });
+
+            Object.defineProperty(onCancel, 'isCancelled', {
+                get: (): boolean => this.#isCancelled,
+            });
+
+            return executor(onResolve, onReject, onCancel as OnCancel);
+        });
+    }
+
+    public then<TResult1 = T, TResult2 = never>(
+        onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+        onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
+    ): Promise<TResult1 | TResult2> {
+        return this.#promise.then(onFulfilled, onRejected);
+    }
+
+    public catch<TResult = never>(
+        onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
+    ): Promise<T | TResult> {
+        return this.#promise.catch(onRejected);
+    }
+
+    public finally(onFinally?: (() => void) | null): Promise<T> {
+        return this.#promise.finally(onFinally);
+    }
+
+    public cancel(): void {
+        if (!this.#isPending || this.#isCancelled) {
+            return;
+        }
+        this.#isCancelled = true;
+        if (this.#cancelHandlers.length) {
+            try {
+                for (const cancelHandler of this.#cancelHandlers) {
+                    cancelHandler();
+                }
+            } catch (error) {
+                this.#reject?.(error);
+                return;
+            }
+        }
+    }
+
+    public get isCancelled(): boolean {
+        return this.#isCancelled;
+    }
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/core/OpenAPI.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+type Headers = Record<string, string>;
+
+type Config = {
+    BASE: string;
+    VERSION: string;
+    WITH_CREDENTIALS: boolean;
+    TOKEN?: string | Resolver<string>;
+    USERNAME?: string | Resolver<string>;
+    PASSWORD?: string | Resolver<string>;
+    HEADERS?: Headers | Resolver<Headers>;
+    ENCODE_PATH?: (path: string) => string;
+}
+
+export const OpenAPI: Config = {
+    BASE: 'http://localhost:3000/base',
+    VERSION: '1.0',
+    WITH_CREDENTIALS: false,
+    TOKEN: undefined,
+    USERNAME: undefined,
+    PASSWORD: undefined,
+    HEADERS: undefined,
+    ENCODE_PATH: undefined,
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/core/request.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import { AbortController } from 'abort-controller';
+import FormData from 'form-data';
+import fetch, { BodyInit, Headers, RequestInit, Response, Blob } from 'node-fetch';
+import { types } from 'util';
+
+import { ApiError } from './ApiError';
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+import { CancelablePromise } from './CancelablePromise';
+import type { OnCancel } from './CancelablePromise';
+import { OpenAPI } from './OpenAPI';
+
+function isDefined<T>(value: T | null | undefined): value is Exclude<T, null | undefined> {
+    return value !== undefined && value !== null;
+}
+
+function isString(value: any): value is string {
+    return typeof value === 'string';
+}
+
+function isStringWithValue(value: any): value is string {
+    return isString(value) && value !== '';
+}
+
+function isBlob(value: any): value is Blob {
+    return value instanceof Blob;
+}
+
+function isBinary(value: any): value is Buffer | ArrayBuffer | ArrayBufferView {
+    const isBuffer = Buffer.isBuffer(value);
+    const isArrayBuffer = types.isArrayBuffer(value);
+    const isArrayBufferView = types.isArrayBufferView(value);
+    return isBuffer || isArrayBuffer || isArrayBufferView;
+}
+
+function base64(str: string): string {
+    try {
+        return btoa(str);
+    } catch (err) {
+        return Buffer.from(str).toString('base64');
+    }
+}
+
+function getQueryString(params: Record<string, any>): string {
+    const qs: string[] = [];
+
+    Object.keys(params).forEach(key => {
+        const value = params[key];
+        if (isDefined(value)) {
+            if (Array.isArray(value)) {
+                value.forEach(value => {
+                    qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
+                });
+            } else {
+                qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
+            }
+        }
+    });
+
+    if (qs.length > 0) {
+        return \`?\${qs.join('&')}\`;
+    }
+
+    return '';
+}
+
+function getUrl(options: ApiRequestOptions): string {
+    const path = OpenAPI.ENCODE_PATH ? OpenAPI.ENCODE_PATH(options.path) : options.path;
+    const url = \`\${OpenAPI.BASE}\${path}\`;
+    if (options.query) {
+        return \`\${url}\${getQueryString(options.query)}\`;
+    }
+
+    return url;
+}
+
+function getFormData(options: ApiRequestOptions): FormData | undefined {
+    if (options.formData) {
+        const formData = new FormData();
+
+        Object.keys(options.formData).forEach(key => {
+            const value = options.formData?.[key];
+            if (isDefined(value)) {
+                formData.append(key, value);
+            }
+        });
+
+        return formData;
+    }
+    return;
+}
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+
+async function resolve<T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> {
+    if (typeof resolver === 'function') {
+        return (resolver as Resolver<T>)(options);
+    }
+    return resolver;
+}
+
+async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
+    const token = await resolve(options, OpenAPI.TOKEN);
+    const username = await resolve(options, OpenAPI.USERNAME);
+    const password = await resolve(options, OpenAPI.PASSWORD);
+    const additionalHeaders = await resolve(options, OpenAPI.HEADERS);
+
+    const defaultHeaders = Object.entries({
+        Accept: 'application/json',
+        ...additionalHeaders,
+        ...options.headers,
+    })
+        .filter(([_, value]) => isDefined(value))
+        .reduce((headers, [key, value]) => ({
+            ...headers,
+            [key]: value,
+        }), {});
+
+    const headers = new Headers(defaultHeaders);
+
+    if (isStringWithValue(token)) {
+        headers.append('Authorization', \`Bearer \${token}\`);
+    }
+
+    if (isStringWithValue(username) && isStringWithValue(password)) {
+        const credentials = base64(\`\${username}:\${password}\`);
+        headers.append('Authorization', \`Basic \${credentials}\`);
+    }
+
+    if (options.body) {
+        if (options.mediaType) {
+            headers.append('Content-Type', options.mediaType);
+        } else if (isBinary(options.body)) {
+            headers.append('Content-Type', 'application/octet-stream');
+        } else if (isString(options.body)) {
+            headers.append('Content-Type', 'text/plain');
+        } else {
+            headers.append('Content-Type', 'application/json');
+        }
+    }
+    return headers;
+}
+
+function getRequestBody(options: ApiRequestOptions): BodyInit | undefined {
+    if (options.body) {
+        if (options.mediaType?.includes('/json')) {
+            return JSON.stringify(options.body)
+        } else if (isString(options.body) || isBlob(options.body) || isBinary(options.body)) {
+            return options.body as any;
+        } else {
+            return JSON.stringify(options.body);
+        }
+    }
+    return;
+}
+
+async function sendRequest(
+    options: ApiRequestOptions,
+    url: string,
+    formData: FormData | undefined,
+    body: BodyInit | undefined,
+    headers: Headers,
+    onCancel: OnCancel
+): Promise<Response> {
+    const controller = new AbortController();
+
+    const request: RequestInit = {
+        headers,
+        method: options.method,
+        body: body || formData,
+        signal: controller.signal,
+    };
+
+    onCancel(() => controller.abort());
+
+    return await fetch(url, request);
+}
+
+function getResponseHeader(response: Response, responseHeader?: string): string | undefined {
+    if (responseHeader) {
+        const content = response.headers.get(responseHeader);
+        if (isString(content)) {
+            return content;
+        }
+    }
+    return;
+}
+
+async function getResponseBody(response: Response): Promise<any> {
+    if (response.status !== 204) {
+        try {
+            const contentType = response.headers.get('Content-Type');
+            if (contentType) {
+                const isJSON = contentType.toLowerCase().startsWith('application/json');
+                if (isJSON) {
+                    return await response.json();
+                } else {
+                    return await response.text();
+                }
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    }
+    return;
+}
+
+function catchErrors(options: ApiRequestOptions, result: ApiResult): void {
+    const errors: Record<number, string> = {
+        400: 'Bad Request',
+        401: 'Unauthorized',
+        403: 'Forbidden',
+        404: 'Not Found',
+        500: 'Internal Server Error',
+        502: 'Bad Gateway',
+        503: 'Service Unavailable',
+        ...options.errors,
+    }
+
+    const error = errors[result.status];
+    if (error) {
+        throw new ApiError(result, error);
+    }
+
+    if (!result.ok) {
+        throw new ApiError(result, 'Generic Error');
+    }
+}
+
+/**
+ * Request using node-fetch client
+ * @param options The request options from the the service
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export function request<T>(options: ApiRequestOptions): CancelablePromise<T> {
+    return new CancelablePromise(async (resolve, reject, onCancel) => {
+        try {
+            const url = getUrl(options);
+            const formData = getFormData(options);
+            const body = getRequestBody(options);
+            const headers = await getHeaders(options);
+
+            if (!onCancel.isCancelled) {
+                const response = await sendRequest(options, url, formData, body, headers, onCancel);
+                const responseBody = await getResponseBody(response);
+                const responseHeader = getResponseHeader(response, options.responseHeader);
+
+                const result: ApiResult = {
+                    url,
+                    ok: response.ok,
+                    status: response.status,
+                    statusText: response.statusText,
+                    body: responseHeader || responseBody,
+                };
+
+                catchErrors(options, result);
+
+                resolve(result.body);
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/index.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export { ApiError } from './core/ApiError';
+export { CancelablePromise } from './core/CancelablePromise';
+export { OpenAPI } from './core/OpenAPI';
+
+export type { ArrayWithArray } from './models/ArrayWithArray';
+export type { ArrayWithBooleans } from './models/ArrayWithBooleans';
+export type { ArrayWithNumbers } from './models/ArrayWithNumbers';
+export type { ArrayWithProperties } from './models/ArrayWithProperties';
+export type { ArrayWithReferences } from './models/ArrayWithReferences';
+export type { ArrayWithStrings } from './models/ArrayWithStrings';
+export type { CompositionBaseModel } from './models/CompositionBaseModel';
+export type { CompositionExtendedModel } from './models/CompositionExtendedModel';
+export type { CompositionWithAllOfAndNullable } from './models/CompositionWithAllOfAndNullable';
+export type { CompositionWithAnyOf } from './models/CompositionWithAnyOf';
+export type { CompositionWithAnyOfAndNullable } from './models/CompositionWithAnyOfAndNullable';
+export type { CompositionWithAnyOfAnonymous } from './models/CompositionWithAnyOfAnonymous';
+export type { CompositionWithOneOf } from './models/CompositionWithOneOf';
+export type { CompositionWithOneOfAndNullable } from './models/CompositionWithOneOfAndNullable';
+export type { CompositionWithOneOfAnonymous } from './models/CompositionWithOneOfAnonymous';
+export type { DictionaryWithArray } from './models/DictionaryWithArray';
+export type { DictionaryWithDictionary } from './models/DictionaryWithDictionary';
+export type { DictionaryWithProperties } from './models/DictionaryWithProperties';
+export type { DictionaryWithReference } from './models/DictionaryWithReference';
+export type { DictionaryWithString } from './models/DictionaryWithString';
+export type { EnumFromDescription } from './models/EnumFromDescription';
+export { EnumWithExtensions } from './models/EnumWithExtensions';
+export { EnumWithNumbers } from './models/EnumWithNumbers';
+export { EnumWithStrings } from './models/EnumWithStrings';
+export type { ModelThatExtends } from './models/ModelThatExtends';
+export type { ModelThatExtendsExtends } from './models/ModelThatExtendsExtends';
+export type { ModelWithArray } from './models/ModelWithArray';
+export type { ModelWithBoolean } from './models/ModelWithBoolean';
+export type { ModelWithCircularReference } from './models/ModelWithCircularReference';
+export type { ModelWithDictionary } from './models/ModelWithDictionary';
+export type { ModelWithDuplicateImports } from './models/ModelWithDuplicateImports';
+export type { ModelWithDuplicateProperties } from './models/ModelWithDuplicateProperties';
+export { ModelWithEnum } from './models/ModelWithEnum';
+export { ModelWithEnumFromDescription } from './models/ModelWithEnumFromDescription';
+export type { ModelWithInteger } from './models/ModelWithInteger';
+export type { ModelWithNestedEnums } from './models/ModelWithNestedEnums';
+export type { ModelWithNestedProperties } from './models/ModelWithNestedProperties';
+export type { ModelWithNullableString } from './models/ModelWithNullableString';
+export type { ModelWithOrderedProperties } from './models/ModelWithOrderedProperties';
+export type { ModelWithPattern } from './models/ModelWithPattern';
+export type { ModelWithProperties } from './models/ModelWithProperties';
+export type { ModelWithReference } from './models/ModelWithReference';
+export type { ModelWithString } from './models/ModelWithString';
+export type { MultilineComment } from './models/MultilineComment';
+export type { SimpleBoolean } from './models/SimpleBoolean';
+export type { SimpleFile } from './models/SimpleFile';
+export type { SimpleInteger } from './models/SimpleInteger';
+export type { SimpleReference } from './models/SimpleReference';
+export type { SimpleString } from './models/SimpleString';
+export type { SimpleStringWithPattern } from './models/SimpleStringWithPattern';
+
+export { $ArrayWithArray } from './schemas/$ArrayWithArray';
+export { $ArrayWithBooleans } from './schemas/$ArrayWithBooleans';
+export { $ArrayWithNumbers } from './schemas/$ArrayWithNumbers';
+export { $ArrayWithProperties } from './schemas/$ArrayWithProperties';
+export { $ArrayWithReferences } from './schemas/$ArrayWithReferences';
+export { $ArrayWithStrings } from './schemas/$ArrayWithStrings';
+export { $CompositionBaseModel } from './schemas/$CompositionBaseModel';
+export { $CompositionExtendedModel } from './schemas/$CompositionExtendedModel';
+export { $CompositionWithAllOfAndNullable } from './schemas/$CompositionWithAllOfAndNullable';
+export { $CompositionWithAnyOf } from './schemas/$CompositionWithAnyOf';
+export { $CompositionWithAnyOfAndNullable } from './schemas/$CompositionWithAnyOfAndNullable';
+export { $CompositionWithAnyOfAnonymous } from './schemas/$CompositionWithAnyOfAnonymous';
+export { $CompositionWithOneOf } from './schemas/$CompositionWithOneOf';
+export { $CompositionWithOneOfAndNullable } from './schemas/$CompositionWithOneOfAndNullable';
+export { $CompositionWithOneOfAnonymous } from './schemas/$CompositionWithOneOfAnonymous';
+export { $DictionaryWithArray } from './schemas/$DictionaryWithArray';
+export { $DictionaryWithDictionary } from './schemas/$DictionaryWithDictionary';
+export { $DictionaryWithProperties } from './schemas/$DictionaryWithProperties';
+export { $DictionaryWithReference } from './schemas/$DictionaryWithReference';
+export { $DictionaryWithString } from './schemas/$DictionaryWithString';
+export { $EnumFromDescription } from './schemas/$EnumFromDescription';
+export { $EnumWithExtensions } from './schemas/$EnumWithExtensions';
+export { $EnumWithNumbers } from './schemas/$EnumWithNumbers';
+export { $EnumWithStrings } from './schemas/$EnumWithStrings';
+export { $ModelThatExtends } from './schemas/$ModelThatExtends';
+export { $ModelThatExtendsExtends } from './schemas/$ModelThatExtendsExtends';
+export { $ModelWithArray } from './schemas/$ModelWithArray';
+export { $ModelWithBoolean } from './schemas/$ModelWithBoolean';
+export { $ModelWithCircularReference } from './schemas/$ModelWithCircularReference';
+export { $ModelWithDictionary } from './schemas/$ModelWithDictionary';
+export { $ModelWithDuplicateImports } from './schemas/$ModelWithDuplicateImports';
+export { $ModelWithDuplicateProperties } from './schemas/$ModelWithDuplicateProperties';
+export { $ModelWithEnum } from './schemas/$ModelWithEnum';
+export { $ModelWithEnumFromDescription } from './schemas/$ModelWithEnumFromDescription';
+export { $ModelWithInteger } from './schemas/$ModelWithInteger';
+export { $ModelWithNestedEnums } from './schemas/$ModelWithNestedEnums';
+export { $ModelWithNestedProperties } from './schemas/$ModelWithNestedProperties';
+export { $ModelWithNullableString } from './schemas/$ModelWithNullableString';
+export { $ModelWithOrderedProperties } from './schemas/$ModelWithOrderedProperties';
+export { $ModelWithPattern } from './schemas/$ModelWithPattern';
+export { $ModelWithProperties } from './schemas/$ModelWithProperties';
+export { $ModelWithReference } from './schemas/$ModelWithReference';
+export { $ModelWithString } from './schemas/$ModelWithString';
+export { $MultilineComment } from './schemas/$MultilineComment';
+export { $SimpleBoolean } from './schemas/$SimpleBoolean';
+export { $SimpleFile } from './schemas/$SimpleFile';
+export { $SimpleInteger } from './schemas/$SimpleInteger';
+export { $SimpleReference } from './schemas/$SimpleReference';
+export { $SimpleString } from './schemas/$SimpleString';
+export { $SimpleStringWithPattern } from './schemas/$SimpleStringWithPattern';
+
+export { CollectionFormatService } from './services/CollectionFormatService';
+export { ComplexService } from './services/ComplexService';
+export { DefaultsService } from './services/DefaultsService';
+export { DuplicateService } from './services/DuplicateService';
+export { FormDataService } from './services/FormDataService';
+export { HeaderService } from './services/HeaderService';
+export { MultipartService } from './services/MultipartService';
+export { NoContentService } from './services/NoContentService';
+export { ParametersService } from './services/ParametersService';
+export { RequestBodyService } from './services/RequestBodyService';
+export { ResponseService } from './services/ResponseService';
+export { SimpleService } from './services/SimpleService';
+export { TypesService } from './services/TypesService';
+export { UploadService } from './services/UploadService';
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ArrayWithArray.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithString } from './ModelWithString';
+
+/**
+ * This is a simple array containing an array
+ */
+export type ArrayWithArray = Array<Array<ModelWithString>>;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ArrayWithBooleans.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a simple array with booleans
+ */
+export type ArrayWithBooleans = Array<boolean>;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ArrayWithNumbers.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a simple array with numbers
+ */
+export type ArrayWithNumbers = Array<number>;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ArrayWithProperties.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a simple array with properties
+ */
+export type ArrayWithProperties = Array<{
+    foo?: string;
+    bar?: string;
+}>;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ArrayWithReferences.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithString } from './ModelWithString';
+
+/**
+ * This is a simple array with references
+ */
+export type ArrayWithReferences = Array<ModelWithString>;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ArrayWithStrings.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a simple array with strings
+ */
+export type ArrayWithStrings = Array<string>;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/CompositionBaseModel.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a base model with two simple optional properties
+ */
+export type CompositionBaseModel = {
+    firstName?: string;
+    lastname?: string;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/CompositionExtendedModel.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { CompositionBaseModel } from './CompositionBaseModel';
+
+/**
+ * This is a model that extends the base model
+ */
+export type CompositionExtendedModel = (CompositionBaseModel & {
+    firstName: string;
+    lastname: string;
+    age: number;
+});
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/CompositionWithAllOfAndNullable.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithArray } from './ModelWithArray';
+import type { ModelWithDictionary } from './ModelWithDictionary';
+import type { ModelWithEnum } from './ModelWithEnum';
+
+/**
+ * This is a model with one property with a 'all of' relationship
+ */
+export type CompositionWithAllOfAndNullable = {
+    propA?: ({
+        boolean?: boolean;
+    } & ModelWithEnum & ModelWithArray & ModelWithDictionary) | null;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/CompositionWithAnyOf.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithArray } from './ModelWithArray';
+import type { ModelWithDictionary } from './ModelWithDictionary';
+import type { ModelWithEnum } from './ModelWithEnum';
+import type { ModelWithString } from './ModelWithString';
+
+/**
+ * This is a model with one property with a 'any of' relationship
+ */
+export type CompositionWithAnyOf = {
+    propA?: (ModelWithString | ModelWithEnum | ModelWithArray | ModelWithDictionary);
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/CompositionWithAnyOfAndNullable.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithArray } from './ModelWithArray';
+import type { ModelWithDictionary } from './ModelWithDictionary';
+import type { ModelWithEnum } from './ModelWithEnum';
+
+/**
+ * This is a model with one property with a 'any of' relationship
+ */
+export type CompositionWithAnyOfAndNullable = {
+    propA?: ({
+        boolean?: boolean;
+    } | ModelWithEnum | ModelWithArray | ModelWithDictionary) | null;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/CompositionWithAnyOfAnonymous.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model with one property with a 'any of' relationship where the options are not $ref
+ */
+export type CompositionWithAnyOfAnonymous = {
+    propA?: ({
+        propA?: string;
+    } | string | number);
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/CompositionWithOneOf.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithArray } from './ModelWithArray';
+import type { ModelWithDictionary } from './ModelWithDictionary';
+import type { ModelWithEnum } from './ModelWithEnum';
+import type { ModelWithString } from './ModelWithString';
+
+/**
+ * This is a model with one property with a 'one of' relationship
+ */
+export type CompositionWithOneOf = {
+    propA?: (ModelWithString | ModelWithEnum | ModelWithArray | ModelWithDictionary);
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/CompositionWithOneOfAndNullable.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithArray } from './ModelWithArray';
+import type { ModelWithDictionary } from './ModelWithDictionary';
+import type { ModelWithEnum } from './ModelWithEnum';
+
+/**
+ * This is a model with one property with a 'one of' relationship
+ */
+export type CompositionWithOneOfAndNullable = {
+    propA?: ({
+        boolean?: boolean;
+    } | ModelWithEnum | ModelWithArray | ModelWithDictionary) | null;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/CompositionWithOneOfAnonymous.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model with one property with a 'one of' relationship where the options are not $ref
+ */
+export type CompositionWithOneOfAnonymous = {
+    propA?: ({
+        propA?: string;
+    } | string | number);
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/DictionaryWithArray.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithString } from './ModelWithString';
+
+/**
+ * This is a complex dictionary
+ */
+export type DictionaryWithArray = Record<string, Array<ModelWithString>>;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/DictionaryWithDictionary.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a string dictionary
+ */
+export type DictionaryWithDictionary = Record<string, Record<string, string>>;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/DictionaryWithProperties.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a complex dictionary
+ */
+export type DictionaryWithProperties = Record<string, {
+    foo?: string;
+    bar?: string;
+}>;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/DictionaryWithReference.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithString } from './ModelWithString';
+
+/**
+ * This is a string reference
+ */
+export type DictionaryWithReference = Record<string, ModelWithString>;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/DictionaryWithString.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a string dictionary
+ */
+export type DictionaryWithString = Record<string, string>;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/EnumFromDescription.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Success=1,Warning=2,Error=3
+ */
+export type EnumFromDescription = number;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/EnumWithExtensions.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a simple enum with numbers
+ */
+export enum EnumWithExtensions {
+    /**
+     * Used when the status of something is successful
+     */
+    CUSTOM_SUCCESS = 200,
+    /**
+     * Used when the status of something has a warning
+     */
+    CUSTOM_WARNING = 400,
+    /**
+     * Used when the status of something has an error
+     */
+    CUSTOM_ERROR = 500,
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/EnumWithNumbers.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a simple enum with numbers
+ */
+export enum EnumWithNumbers {
+    '_1' = 1,
+    '_2' = 2,
+    '_3' = 3,
+    '_1.1' = 1.1,
+    '_1.2' = 1.2,
+    '_1.3' = 1.3,
+    '_100' = 100,
+    '_200' = 200,
+    '_300' = 300,
+    '_-100' = -100,
+    '_-200' = -200,
+    '_-300' = -300,
+    '_-1.1' = -1.1,
+    '_-1.2' = -1.2,
+    '_-1.3' = -1.3,
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/EnumWithStrings.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a simple enum with strings
+ */
+export enum EnumWithStrings {
+    SUCCESS = 'Success',
+    WARNING = 'Warning',
+    ERROR = 'Error',
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelThatExtends.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithString } from './ModelWithString';
+
+/**
+ * This is a model that extends another model
+ */
+export type ModelThatExtends = (ModelWithString & {
+    propExtendsA?: string;
+    propExtendsB?: ModelWithString;
+});
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelThatExtendsExtends.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelThatExtends } from './ModelThatExtends';
+import type { ModelWithString } from './ModelWithString';
+
+/**
+ * This is a model that extends another model
+ */
+export type ModelThatExtendsExtends = (ModelWithString & ModelThatExtends & {
+    propExtendsC?: string;
+    propExtendsD?: ModelWithString;
+});
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithArray.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithString } from './ModelWithString';
+
+/**
+ * This is a model with one property containing an array
+ */
+export type ModelWithArray = {
+    prop?: Array<ModelWithString>;
+    propWithFile?: Array<Buffer | ArrayBuffer | ArrayBufferView>;
+    propWithNumber?: Array<number>;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithBoolean.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model with one boolean property
+ */
+export type ModelWithBoolean = {
+    /**
+     * This is a simple boolean property
+     */
+    prop?: boolean;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithCircularReference.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model with one property containing a circular reference
+ */
+export type ModelWithCircularReference = {
+    prop?: ModelWithCircularReference;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithDictionary.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model with one property containing a dictionary
+ */
+export type ModelWithDictionary = {
+    prop?: Record<string, string>;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithDuplicateImports.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithString } from './ModelWithString';
+
+/**
+ * This is a model with duplicated imports
+ */
+export type ModelWithDuplicateImports = {
+    propA?: ModelWithString;
+    propB?: ModelWithString;
+    propC?: ModelWithString;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithDuplicateProperties.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithString } from './ModelWithString';
+
+/**
+ * This is a model with duplicated properties
+ */
+export type ModelWithDuplicateProperties = {
+    prop?: ModelWithString;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithEnum.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model with one enum
+ */
+export type ModelWithEnum = {
+    /**
+     * This is a simple enum with strings
+     */
+    test?: ModelWithEnum.test;
+    /**
+     * These are the HTTP error code enums
+     */
+    statusCode?: ModelWithEnum.statusCode;
+    /**
+     * Simple boolean enum
+     */
+    bool?: boolean;
+}
+
+export namespace ModelWithEnum {
+
+    /**
+     * This is a simple enum with strings
+     */
+    export enum test {
+        SUCCESS = 'Success',
+        WARNING = 'Warning',
+        ERROR = 'Error',
+    }
+
+    /**
+     * These are the HTTP error code enums
+     */
+    export enum statusCode {
+        _100 = '100',
+        _200_FOO = '200 FOO',
+        _300_FOO_BAR = '300 FOO_BAR',
+        _400_FOO_BAR = '400 foo-bar',
+        _500_FOO_BAR = '500 foo.bar',
+        _600_FOO_BAR = '600 foo&bar',
+    }
+
+
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithEnumFromDescription.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model with one enum
+ */
+export type ModelWithEnumFromDescription = {
+    /**
+     * Success=1,Warning=2,Error=3
+     */
+    test?: ModelWithEnumFromDescription.test;
+}
+
+export namespace ModelWithEnumFromDescription {
+
+    /**
+     * Success=1,Warning=2,Error=3
+     */
+    export enum test {
+        SUCCESS = 1,
+        WARNING = 2,
+        ERROR = 3,
+    }
+
+
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithInteger.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model with one number property
+ */
+export type ModelWithInteger = {
+    /**
+     * This is a simple number property
+     */
+    prop?: number;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithNestedEnums.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model with nested enums
+ */
+export type ModelWithNestedEnums = {
+    dictionaryWithEnum?: Record<string, 'Success' | 'Warning' | 'Error'>;
+    dictionaryWithEnumFromDescription?: Record<string, 1 | 2 | 3>;
+    arrayWithEnum?: Array<'Success' | 'Warning' | 'Error'>;
+    arrayWithDescription?: Array<1 | 2 | 3>;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithNestedProperties.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model with one nested property
+ */
+export type ModelWithNestedProperties = {
+    readonly first: {
+        readonly second: {
+            readonly third: string | null;
+        } | null;
+    } | null;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithNullableString.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model with one string property
+ */
+export type ModelWithNullableString = {
+    /**
+     * This is a simple string property
+     */
+    nullableProp1?: string | null;
+    /**
+     * This is a simple string property
+     */
+    nullableRequiredProp1: string | null;
+    /**
+     * This is a simple string property
+     */
+    nullableProp2?: string | null;
+    /**
+     * This is a simple string property
+     */
+    nullableRequiredProp2: string | null;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithOrderedProperties.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model with ordered properties
+ */
+export type ModelWithOrderedProperties = {
+    zebra?: string;
+    apple?: string;
+    hawaii?: string;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithPattern.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model that contains a some patterns
+ */
+export type ModelWithPattern = {
+    key: string;
+    name: string;
+    readonly enabled?: boolean;
+    readonly modified?: string;
+    id?: string;
+    text?: string;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithProperties.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithString } from './ModelWithString';
+
+/**
+ * This is a model with one nested property
+ */
+export type ModelWithProperties = {
+    required: string;
+    readonly requiredAndReadOnly: string;
+    requiredAndNullable: string | null;
+    string?: string;
+    number?: number;
+    boolean?: boolean;
+    reference?: ModelWithString;
+    'property with space'?: string;
+    default?: string;
+    try?: string;
+    readonly '@namespace.string'?: string;
+    readonly '@namespace.integer'?: number;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithReference.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithProperties } from './ModelWithProperties';
+
+/**
+ * This is a model with one property containing a reference
+ */
+export type ModelWithReference = {
+    prop?: ModelWithProperties;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/ModelWithString.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model with one string property
+ */
+export type ModelWithString = {
+    /**
+     * This is a simple string property
+     */
+    prop?: string;
+}
+"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/MultilineComment.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Testing multiline comments.
+ * This must go to the next line.
+ *
+ * This will contain a break.
+ */
+export type MultilineComment = number;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/SimpleBoolean.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a simple boolean
+ */
+export type SimpleBoolean = boolean;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/SimpleFile.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a simple file
+ */
+export type SimpleFile = Buffer | ArrayBuffer | ArrayBufferView;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/SimpleInteger.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a simple number
+ */
+export type SimpleInteger = number;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/SimpleReference.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithString } from './ModelWithString';
+
+/**
+ * This is a simple reference
+ */
+export type SimpleReference = ModelWithString;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/SimpleString.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a simple string
+ */
+export type SimpleString = string;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/models/SimpleStringWithPattern.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a simple string
+ */
+export type SimpleStringWithPattern = string;"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ArrayWithArray.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ArrayWithArray = {
+    type: 'array',
+    contains: {
+        type: 'array',
+        contains: {
+            type: 'ModelWithString',
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ArrayWithBooleans.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ArrayWithBooleans = {
+    type: 'array',
+    contains: {
+        type: 'boolean',
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ArrayWithNumbers.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ArrayWithNumbers = {
+    type: 'array',
+    contains: {
+        type: 'number',
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ArrayWithProperties.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ArrayWithProperties = {
+    type: 'array',
+    contains: {
+        properties: {
+            foo: {
+                type: 'string',
+            },
+            bar: {
+                type: 'string',
+            },
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ArrayWithReferences.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ArrayWithReferences = {
+    type: 'array',
+    contains: {
+        type: 'ModelWithString',
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ArrayWithStrings.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ArrayWithStrings = {
+    type: 'array',
+    contains: {
+        type: 'string',
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$CompositionBaseModel.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionBaseModel = {
+    properties: {
+        firstName: {
+            type: 'string',
+        },
+        lastname: {
+            type: 'string',
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$CompositionExtendedModel.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionExtendedModel = {
+    type: 'all-of',
+    contains: [{
+        type: 'CompositionBaseModel',
+    }, {
+        properties: {
+            firstName: {
+                type: 'string',
+                isRequired: true,
+            },
+            lastname: {
+                type: 'string',
+                isRequired: true,
+            },
+            age: {
+                type: 'number',
+                isRequired: true,
+            },
+        },
+    }],
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$CompositionWithAllOfAndNullable.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithAllOfAndNullable = {
+    properties: {
+        propA: {
+            type: 'all-of',
+            contains: [{
+                properties: {
+                    boolean: {
+                        type: 'boolean',
+                    },
+                },
+            }, {
+                type: 'ModelWithEnum',
+            }, {
+                type: 'ModelWithArray',
+            }, {
+                type: 'ModelWithDictionary',
+            }],
+            isNullable: true,
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$CompositionWithAnyOf.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithAnyOf = {
+    properties: {
+        propA: {
+            type: 'any-of',
+            contains: [{
+                type: 'ModelWithString',
+            }, {
+                type: 'ModelWithEnum',
+            }, {
+                type: 'ModelWithArray',
+            }, {
+                type: 'ModelWithDictionary',
+            }],
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$CompositionWithAnyOfAndNullable.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithAnyOfAndNullable = {
+    properties: {
+        propA: {
+            type: 'any-of',
+            contains: [{
+                properties: {
+                    boolean: {
+                        type: 'boolean',
+                    },
+                },
+            }, {
+                type: 'ModelWithEnum',
+            }, {
+                type: 'ModelWithArray',
+            }, {
+                type: 'ModelWithDictionary',
+            }],
+            isNullable: true,
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$CompositionWithAnyOfAnonymous.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithAnyOfAnonymous = {
+    properties: {
+        propA: {
+            type: 'any-of',
+            contains: [{
+                properties: {
+                    propA: {
+                        type: 'string',
+                    },
+                },
+            }, {
+                type: 'string',
+            }, {
+                type: 'number',
+            }],
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$CompositionWithOneOf.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithOneOf = {
+    properties: {
+        propA: {
+            type: 'one-of',
+            contains: [{
+                type: 'ModelWithString',
+            }, {
+                type: 'ModelWithEnum',
+            }, {
+                type: 'ModelWithArray',
+            }, {
+                type: 'ModelWithDictionary',
+            }],
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$CompositionWithOneOfAndNullable.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithOneOfAndNullable = {
+    properties: {
+        propA: {
+            type: 'one-of',
+            contains: [{
+                properties: {
+                    boolean: {
+                        type: 'boolean',
+                    },
+                },
+            }, {
+                type: 'ModelWithEnum',
+            }, {
+                type: 'ModelWithArray',
+            }, {
+                type: 'ModelWithDictionary',
+            }],
+            isNullable: true,
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$CompositionWithOneOfAnonymous.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithOneOfAnonymous = {
+    properties: {
+        propA: {
+            type: 'one-of',
+            contains: [{
+                properties: {
+                    propA: {
+                        type: 'string',
+                    },
+                },
+            }, {
+                type: 'string',
+            }, {
+                type: 'number',
+            }],
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$DictionaryWithArray.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $DictionaryWithArray = {
+    type: 'dictionary',
+    contains: {
+        type: 'array',
+        contains: {
+            type: 'ModelWithString',
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$DictionaryWithDictionary.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $DictionaryWithDictionary = {
+    type: 'dictionary',
+    contains: {
+        type: 'dictionary',
+        contains: {
+            type: 'string',
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$DictionaryWithProperties.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $DictionaryWithProperties = {
+    type: 'dictionary',
+    contains: {
+        properties: {
+            foo: {
+                type: 'string',
+            },
+            bar: {
+                type: 'string',
+            },
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$DictionaryWithReference.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $DictionaryWithReference = {
+    type: 'dictionary',
+    contains: {
+        type: 'ModelWithString',
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$DictionaryWithString.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $DictionaryWithString = {
+    type: 'dictionary',
+    contains: {
+        type: 'string',
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$EnumFromDescription.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $EnumFromDescription = {
+    type: 'number',
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$EnumWithExtensions.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $EnumWithExtensions = {
+    type: 'Enum',
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$EnumWithNumbers.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $EnumWithNumbers = {
+    type: 'Enum',
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$EnumWithStrings.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $EnumWithStrings = {
+    type: 'Enum',
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelThatExtends.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelThatExtends = {
+    type: 'all-of',
+    contains: [{
+        type: 'ModelWithString',
+    }, {
+        properties: {
+            propExtendsA: {
+                type: 'string',
+            },
+            propExtendsB: {
+                type: 'ModelWithString',
+            },
+        },
+    }],
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelThatExtendsExtends.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelThatExtendsExtends = {
+    type: 'all-of',
+    contains: [{
+        type: 'ModelWithString',
+    }, {
+        type: 'ModelThatExtends',
+    }, {
+        properties: {
+            propExtendsC: {
+                type: 'string',
+            },
+            propExtendsD: {
+                type: 'ModelWithString',
+            },
+        },
+    }],
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithArray.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithArray = {
+    properties: {
+        prop: {
+            type: 'array',
+            contains: {
+                type: 'ModelWithString',
+            },
+        },
+        propWithFile: {
+            type: 'array',
+            contains: {
+                type: 'binary',
+            },
+        },
+        propWithNumber: {
+            type: 'array',
+            contains: {
+                type: 'number',
+            },
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithBoolean.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithBoolean = {
+    properties: {
+        prop: {
+            type: 'boolean',
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithCircularReference.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithCircularReference = {
+    properties: {
+        prop: {
+            type: 'ModelWithCircularReference',
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithDictionary.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithDictionary = {
+    properties: {
+        prop: {
+            type: 'dictionary',
+            contains: {
+                type: 'string',
+            },
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithDuplicateImports.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithDuplicateImports = {
+    properties: {
+        propA: {
+            type: 'ModelWithString',
+        },
+        propB: {
+            type: 'ModelWithString',
+        },
+        propC: {
+            type: 'ModelWithString',
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithDuplicateProperties.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithDuplicateProperties = {
+    properties: {
+        prop: {
+            type: 'ModelWithString',
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithEnum.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithEnum = {
+    properties: {
+        test: {
+            type: 'Enum',
+        },
+        statusCode: {
+            type: 'Enum',
+        },
+        bool: {
+            type: 'boolean',
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithEnumFromDescription.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithEnumFromDescription = {
+    properties: {
+        test: {
+            type: 'Enum',
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithInteger.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithInteger = {
+    properties: {
+        prop: {
+            type: 'number',
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithNestedEnums.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithNestedEnums = {
+    properties: {
+        dictionaryWithEnum: {
+            type: 'dictionary',
+            contains: {
+                type: 'Enum',
+            },
+        },
+        dictionaryWithEnumFromDescription: {
+            type: 'dictionary',
+            contains: {
+                type: 'Enum',
+            },
+        },
+        arrayWithEnum: {
+            type: 'array',
+            contains: {
+                type: 'Enum',
+            },
+        },
+        arrayWithDescription: {
+            type: 'array',
+            contains: {
+                type: 'Enum',
+            },
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithNestedProperties.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithNestedProperties = {
+    properties: {
+        first: {
+            properties: {
+                second: {
+                    properties: {
+                        third: {
+                            type: 'string',
+                            isReadOnly: true,
+                            isRequired: true,
+                            isNullable: true,
+                        },
+                    },
+                    isReadOnly: true,
+                    isRequired: true,
+                    isNullable: true,
+                },
+            },
+            isReadOnly: true,
+            isRequired: true,
+            isNullable: true,
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithNullableString.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithNullableString = {
+    properties: {
+        nullableProp1: {
+            type: 'string',
+            isNullable: true,
+        },
+        nullableRequiredProp1: {
+            type: 'string',
+            isRequired: true,
+            isNullable: true,
+        },
+        nullableProp2: {
+            type: 'string',
+            isNullable: true,
+        },
+        nullableRequiredProp2: {
+            type: 'string',
+            isRequired: true,
+            isNullable: true,
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithOrderedProperties.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithOrderedProperties = {
+    properties: {
+        zebra: {
+            type: 'string',
+        },
+        apple: {
+            type: 'string',
+        },
+        hawaii: {
+            type: 'string',
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithPattern.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithPattern = {
+    properties: {
+        key: {
+            type: 'string',
+            isRequired: true,
+            maxLength: 64,
+            pattern: '^[a-zA-Z0-9_]*$',
+        },
+        name: {
+            type: 'string',
+            isRequired: true,
+            maxLength: 255,
+        },
+        enabled: {
+            type: 'boolean',
+            isReadOnly: true,
+        },
+        modified: {
+            type: 'string',
+            isReadOnly: true,
+            format: 'date-time',
+        },
+        id: {
+            type: 'string',
+            pattern: '^\\\\\\\\d{2}-\\\\\\\\d{3}-\\\\\\\\d{4}$',
+        },
+        text: {
+            type: 'string',
+            pattern: '^\\\\\\\\w+$',
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithProperties.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithProperties = {
+    properties: {
+        required: {
+            type: 'string',
+            isRequired: true,
+        },
+        requiredAndReadOnly: {
+            type: 'string',
+            isReadOnly: true,
+            isRequired: true,
+        },
+        requiredAndNullable: {
+            type: 'string',
+            isRequired: true,
+            isNullable: true,
+        },
+        string: {
+            type: 'string',
+        },
+        number: {
+            type: 'number',
+        },
+        boolean: {
+            type: 'boolean',
+        },
+        reference: {
+            type: 'ModelWithString',
+        },
+        'property with space': {
+            type: 'string',
+        },
+        default: {
+            type: 'string',
+        },
+        try: {
+            type: 'string',
+        },
+        '@namespace.string': {
+            type: 'string',
+            isReadOnly: true,
+        },
+        '@namespace.integer': {
+            type: 'number',
+            isReadOnly: true,
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithReference.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithReference = {
+    properties: {
+        prop: {
+            type: 'ModelWithProperties',
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$ModelWithString.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithString = {
+    properties: {
+        prop: {
+            type: 'string',
+        },
+    },
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$MultilineComment.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $MultilineComment = {
+    type: 'number',
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$SimpleBoolean.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $SimpleBoolean = {
+    type: 'boolean',
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$SimpleFile.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $SimpleFile = {
+    type: 'binary',
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$SimpleInteger.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $SimpleInteger = {
+    type: 'number',
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$SimpleReference.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $SimpleReference = {
+    type: 'ModelWithString',
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$SimpleString.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $SimpleString = {
+    type: 'string',
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/schemas/$SimpleStringWithPattern.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $SimpleStringWithPattern = {
+    type: 'string',
+    maxLength: 64,
+    pattern: '^[a-zA-Z0-9_]*$',
+};"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/services/CollectionFormatService.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { request as __request } from '../core/request';
+import { OpenAPI } from '../core/OpenAPI';
+
+export class CollectionFormatService {
+
+    /**
+     * @param parameterArrayCsv This is an array parameter that is send as csv format (comma-separated values)
+     * @param parameterArraySsv This is an array parameter that is send as ssv format (space-separated values)
+     * @param parameterArrayTsv This is an array parameter that is send as tsv format (tab-separated values)
+     * @param parameterArrayPipes This is an array parameter that is send as pipes format (pipe-separated values)
+     * @param parameterArrayMulti This is an array parameter that is send as multi format (multiple parameter instances)
+     * @throws ApiError
+     */
+    public static collectionFormat(
+        parameterArrayCsv: Array<string> | null,
+        parameterArraySsv: Array<string> | null,
+        parameterArrayTsv: Array<string> | null,
+        parameterArrayPipes: Array<string> | null,
+        parameterArrayMulti: Array<string> | null,
+    ): CancelablePromise<void> {
+        return __request({
+            method: 'GET',
+            path: \`/api/v\${OpenAPI.VERSION}/collectionFormat\`,
+            query: {
+                'parameterArrayCSV': parameterArrayCsv,
+                'parameterArraySSV': parameterArraySsv,
+                'parameterArrayTSV': parameterArrayTsv,
+                'parameterArrayPipes': parameterArrayPipes,
+                'parameterArrayMulti': parameterArrayMulti,
+            },
+        });
+    }
+
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/services/ComplexService.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithArray } from '../models/ModelWithArray';
+import type { ModelWithDictionary } from '../models/ModelWithDictionary';
+import type { ModelWithEnum } from '../models/ModelWithEnum';
+import type { ModelWithString } from '../models/ModelWithString';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { request as __request } from '../core/request';
+import { OpenAPI } from '../core/OpenAPI';
+
+export class ComplexService {
+
+    /**
+     * @param parameterObject Parameter containing object
+     * @param parameterReference Parameter containing reference
+     * @returns ModelWithString Successful response
+     * @throws ApiError
+     */
+    public static complexTypes(
+        parameterObject: {
+            first?: {
+                second?: {
+                    third?: string;
+                };
+            };
+        },
+        parameterReference: ModelWithString,
+    ): CancelablePromise<Array<ModelWithString>> {
+        return __request({
+            method: 'GET',
+            path: \`/api/v\${OpenAPI.VERSION}/complex\`,
+            query: {
+                'parameterObject': parameterObject,
+                'parameterReference': parameterReference,
+            },
+            errors: {
+                400: \`400 server error\`,
+                500: \`500 server error\`,
+            },
+        });
+    }
+
+    /**
+     * @param id
+     * @param requestBody
+     * @returns ModelWithString Success
+     * @throws ApiError
+     */
+    public static complexParams(
+        id: number,
+        requestBody?: {
+            readonly key: string | null;
+            name: string | null;
+            enabled?: boolean;
+            readonly type: 'Monkey' | 'Horse' | 'Bird';
+            listOfModels?: Array<ModelWithString> | null;
+            listOfStrings?: Array<string> | null;
+            parameters: (ModelWithString | ModelWithEnum | ModelWithArray | ModelWithDictionary);
+            readonly user?: {
+                readonly id?: number;
+                readonly name?: string | null;
+            };
+        },
+    ): CancelablePromise<ModelWithString> {
+        return __request({
+            method: 'PUT',
+            path: \`/api/v\${OpenAPI.VERSION}/complex/\${id}\`,
+            body: requestBody,
+            mediaType: 'application/json-patch+json',
+        });
+    }
+
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/services/DefaultsService.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from '../models/ModelWithString';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { request as __request } from '../core/request';
+import { OpenAPI } from '../core/OpenAPI';
+
+export class DefaultsService {
+
+    /**
+     * @param parameterString This is a simple string with default value
+     * @param parameterNumber This is a simple number with default value
+     * @param parameterBoolean This is a simple boolean with default value
+     * @param parameterEnum This is a simple enum with default value
+     * @param parameterModel This is a simple model with default value
+     * @throws ApiError
+     */
+    public static callWithDefaultParameters(
+        parameterString: string | null = 'Hello World!',
+        parameterNumber: number | null = 123,
+        parameterBoolean: boolean | null = true,
+        parameterEnum: 'Success' | 'Warning' | 'Error' = 'Success',
+        parameterModel: ModelWithString | null = {
+            \\"prop\\": \\"Hello World!\\"
+        },
+    ): CancelablePromise<void> {
+        return __request({
+            method: 'GET',
+            path: \`/api/v\${OpenAPI.VERSION}/defaults\`,
+            query: {
+                'parameterString': parameterString,
+                'parameterNumber': parameterNumber,
+                'parameterBoolean': parameterBoolean,
+                'parameterEnum': parameterEnum,
+                'parameterModel': parameterModel,
+            },
+        });
+    }
+
+    /**
+     * @param parameterString This is a simple string that is optional with default value
+     * @param parameterNumber This is a simple number that is optional with default value
+     * @param parameterBoolean This is a simple boolean that is optional with default value
+     * @param parameterEnum This is a simple enum that is optional with default value
+     * @param parameterModel This is a simple model that is optional with default value
+     * @throws ApiError
+     */
+    public static callWithDefaultOptionalParameters(
+        parameterString: string = 'Hello World!',
+        parameterNumber: number = 123,
+        parameterBoolean: boolean = true,
+        parameterEnum: 'Success' | 'Warning' | 'Error' = 'Success',
+        parameterModel: ModelWithString = {
+            \\"prop\\": \\"Hello World!\\"
+        },
+    ): CancelablePromise<void> {
+        return __request({
+            method: 'POST',
+            path: \`/api/v\${OpenAPI.VERSION}/defaults\`,
+            query: {
+                'parameterString': parameterString,
+                'parameterNumber': parameterNumber,
+                'parameterBoolean': parameterBoolean,
+                'parameterEnum': parameterEnum,
+                'parameterModel': parameterModel,
+            },
+        });
+    }
+
+    /**
+     * @param parameterStringWithNoDefault This is a string with no default
+     * @param parameterOptionalStringWithDefault This is a optional string with default
+     * @param parameterOptionalStringWithEmptyDefault This is a optional string with empty default
+     * @param parameterOptionalStringWithNoDefault This is a optional string with no default
+     * @param parameterStringWithDefault This is a string with default
+     * @param parameterStringWithEmptyDefault This is a string with empty default
+     * @throws ApiError
+     */
+    public static callToTestOrderOfParams(
+        parameterStringWithNoDefault: string,
+        parameterOptionalStringWithDefault: string = 'Hello World!',
+        parameterOptionalStringWithEmptyDefault: string = '',
+        parameterOptionalStringWithNoDefault?: string,
+        parameterStringWithDefault: string = 'Hello World!',
+        parameterStringWithEmptyDefault: string = '',
+    ): CancelablePromise<void> {
+        return __request({
+            method: 'PUT',
+            path: \`/api/v\${OpenAPI.VERSION}/defaults\`,
+            query: {
+                'parameterOptionalStringWithDefault': parameterOptionalStringWithDefault,
+                'parameterOptionalStringWithEmptyDefault': parameterOptionalStringWithEmptyDefault,
+                'parameterOptionalStringWithNoDefault': parameterOptionalStringWithNoDefault,
+                'parameterStringWithDefault': parameterStringWithDefault,
+                'parameterStringWithEmptyDefault': parameterStringWithEmptyDefault,
+                'parameterStringWithNoDefault': parameterStringWithNoDefault,
+            },
+        });
+    }
+
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/services/DuplicateService.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { request as __request } from '../core/request';
+import { OpenAPI } from '../core/OpenAPI';
+
+export class DuplicateService {
+
+    /**
+     * @throws ApiError
+     */
+    public static duplicateName(): CancelablePromise<void> {
+        return __request({
+            method: 'GET',
+            path: \`/api/v\${OpenAPI.VERSION}/duplicate\`,
+        });
+    }
+
+    /**
+     * @throws ApiError
+     */
+    public static duplicateName1(): CancelablePromise<void> {
+        return __request({
+            method: 'POST',
+            path: \`/api/v\${OpenAPI.VERSION}/duplicate\`,
+        });
+    }
+
+    /**
+     * @throws ApiError
+     */
+    public static duplicateName2(): CancelablePromise<void> {
+        return __request({
+            method: 'PUT',
+            path: \`/api/v\${OpenAPI.VERSION}/duplicate\`,
+        });
+    }
+
+    /**
+     * @throws ApiError
+     */
+    public static duplicateName3(): CancelablePromise<void> {
+        return __request({
+            method: 'DELETE',
+            path: \`/api/v\${OpenAPI.VERSION}/duplicate\`,
+        });
+    }
+
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/services/FormDataService.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from '../models/ModelWithString';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { request as __request } from '../core/request';
+import { OpenAPI } from '../core/OpenAPI';
+
+export class FormDataService {
+
+    /**
+     * @param parameter This is a reusable parameter
+     * @param formData A reusable request body
+     * @throws ApiError
+     */
+    public static postFormDataService(
+        parameter?: string,
+        formData?: ModelWithString,
+    ): CancelablePromise<void> {
+        return __request({
+            method: 'POST',
+            path: \`/api/v\${OpenAPI.VERSION}/formData/\`,
+            query: {
+                'parameter': parameter,
+            },
+            formData: formData,
+            mediaType: 'multipart/form-data',
+        });
+    }
+
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/services/HeaderService.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { request as __request } from '../core/request';
+import { OpenAPI } from '../core/OpenAPI';
+
+export class HeaderService {
+
+    /**
+     * @returns string Successful response
+     * @throws ApiError
+     */
+    public static callWithResultFromHeader(): CancelablePromise<string> {
+        return __request({
+            method: 'POST',
+            path: \`/api/v\${OpenAPI.VERSION}/header\`,
+            responseHeader: 'operation-location',
+            errors: {
+                400: \`400 server error\`,
+                500: \`500 server error\`,
+            },
+        });
+    }
+
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/services/MultipartService.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { request as __request } from '../core/request';
+import { OpenAPI } from '../core/OpenAPI';
+
+export class MultipartService {
+
+    /**
+     * @returns any OK
+     * @throws ApiError
+     */
+    public static multipartResponse(): CancelablePromise<{
+        file?: Buffer | ArrayBuffer | ArrayBufferView;
+        metadata?: {
+            foo?: string;
+            bar?: string;
+        };
+    }> {
+        return __request({
+            method: 'GET',
+            path: \`/api/v\${OpenAPI.VERSION}/multipart\`,
+        });
+    }
+
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/services/NoContentService.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { request as __request } from '../core/request';
+import { OpenAPI } from '../core/OpenAPI';
+
+export class NoContentService {
+
+    /**
+     * @returns void
+     * @throws ApiError
+     */
+    public static callWithNoContentResponse(): CancelablePromise<void> {
+        return __request({
+            method: 'GET',
+            path: \`/api/v\${OpenAPI.VERSION}/no-content\`,
+        });
+    }
+
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/services/ParametersService.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from '../models/ModelWithString';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { request as __request } from '../core/request';
+import { OpenAPI } from '../core/OpenAPI';
+
+export class ParametersService {
+
+    /**
+     * @param parameterHeader This is the parameter that goes into the header
+     * @param parameterQuery This is the parameter that goes into the query params
+     * @param parameterForm This is the parameter that goes into the form data
+     * @param parameterCookie This is the parameter that goes into the cookie
+     * @param parameterPath This is the parameter that goes into the path
+     * @param requestBody This is the parameter that goes into the body
+     * @throws ApiError
+     */
+    public static callWithParameters(
+        parameterHeader: string | null,
+        parameterQuery: string | null,
+        parameterForm: string | null,
+        parameterCookie: string | null,
+        parameterPath: string | null,
+        requestBody: ModelWithString | null,
+    ): CancelablePromise<void> {
+        return __request({
+            method: 'POST',
+            path: \`/api/v\${OpenAPI.VERSION}/parameters/\${parameterPath}\`,
+            cookies: {
+                'parameterCookie': parameterCookie,
+            },
+            headers: {
+                'parameterHeader': parameterHeader,
+            },
+            query: {
+                'parameterQuery': parameterQuery,
+            },
+            formData: {
+                'parameterForm': parameterForm,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+    /**
+     * @param parameterHeader This is the parameter that goes into the request header
+     * @param parameterQuery This is the parameter that goes into the request query params
+     * @param parameterForm This is the parameter that goes into the request form data
+     * @param parameterCookie This is the parameter that goes into the cookie
+     * @param requestBody This is the parameter that goes into the body
+     * @param parameterPath1 This is the parameter that goes into the path
+     * @param parameterPath2 This is the parameter that goes into the path
+     * @param parameterPath3 This is the parameter that goes into the path
+     * @param _default This is the parameter with a reserved keyword
+     * @throws ApiError
+     */
+    public static callWithWeirdParameterNames(
+        parameterHeader: string | null,
+        parameterQuery: string | null,
+        parameterForm: string | null,
+        parameterCookie: string | null,
+        requestBody: ModelWithString | null,
+        parameterPath1?: string,
+        parameterPath2?: string,
+        parameterPath3?: string,
+        _default?: string,
+    ): CancelablePromise<void> {
+        return __request({
+            method: 'POST',
+            path: \`/api/v\${OpenAPI.VERSION}/parameters/\${parameterPath1}/\${parameterPath2}/\${parameterPath3}\`,
+            cookies: {
+                'PARAMETER-COOKIE': parameterCookie,
+            },
+            headers: {
+                'parameter.header': parameterHeader,
+            },
+            query: {
+                'default': _default,
+                'parameter-query': parameterQuery,
+            },
+            formData: {
+                'parameter_form': parameterForm,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+    /**
+     * @param requestBody This is a required parameter
+     * @param parameter This is an optional parameter
+     * @throws ApiError
+     */
+    public static getCallWithOptionalParam(
+        requestBody: ModelWithString,
+        parameter?: string,
+    ): CancelablePromise<void> {
+        return __request({
+            method: 'GET',
+            path: \`/api/v\${OpenAPI.VERSION}/parameters/\`,
+            query: {
+                'parameter': parameter,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+    /**
+     * @param parameter This is a required parameter
+     * @param requestBody This is an optional parameter
+     * @throws ApiError
+     */
+    public static postCallWithOptionalParam(
+        parameter: string,
+        requestBody?: ModelWithString,
+    ): CancelablePromise<void> {
+        return __request({
+            method: 'POST',
+            path: \`/api/v\${OpenAPI.VERSION}/parameters/\`,
+            query: {
+                'parameter': parameter,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/services/RequestBodyService.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from '../models/ModelWithString';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { request as __request } from '../core/request';
+import { OpenAPI } from '../core/OpenAPI';
+
+export class RequestBodyService {
+
+    /**
+     * @param parameter This is a reusable parameter
+     * @param requestBody A reusable request body
+     * @throws ApiError
+     */
+    public static postRequestBodyService(
+        parameter?: string,
+        requestBody?: ModelWithString,
+    ): CancelablePromise<void> {
+        return __request({
+            method: 'POST',
+            path: \`/api/v\${OpenAPI.VERSION}/requestBody/\`,
+            query: {
+                'parameter': parameter,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/services/ResponseService.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelThatExtends } from '../models/ModelThatExtends';
+import type { ModelThatExtendsExtends } from '../models/ModelThatExtendsExtends';
+import type { ModelWithString } from '../models/ModelWithString';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { request as __request } from '../core/request';
+import { OpenAPI } from '../core/OpenAPI';
+
+export class ResponseService {
+
+    /**
+     * @returns ModelWithString
+     * @throws ApiError
+     */
+    public static callWithResponse(): CancelablePromise<ModelWithString> {
+        return __request({
+            method: 'GET',
+            path: \`/api/v\${OpenAPI.VERSION}/response\`,
+        });
+    }
+
+    /**
+     * @returns ModelWithString Message for default response
+     * @throws ApiError
+     */
+    public static callWithDuplicateResponses(): CancelablePromise<ModelWithString> {
+        return __request({
+            method: 'POST',
+            path: \`/api/v\${OpenAPI.VERSION}/response\`,
+            errors: {
+                500: \`Message for 500 error\`,
+                501: \`Message for 501 error\`,
+                502: \`Message for 502 error\`,
+            },
+        });
+    }
+
+    /**
+     * @returns any Message for 200 response
+     * @returns ModelWithString Message for default response
+     * @returns ModelThatExtends Message for 201 response
+     * @returns ModelThatExtendsExtends Message for 202 response
+     * @throws ApiError
+     */
+    public static callWithResponses(): CancelablePromise<{
+        readonly '@namespace.string'?: string;
+        readonly '@namespace.integer'?: number;
+        readonly value?: Array<ModelWithString>;
+    } | ModelWithString | ModelThatExtends | ModelThatExtendsExtends> {
+        return __request({
+            method: 'PUT',
+            path: \`/api/v\${OpenAPI.VERSION}/response\`,
+            errors: {
+                500: \`Message for 500 error\`,
+                501: \`Message for 501 error\`,
+                502: \`Message for 502 error\`,
+            },
+        });
+    }
+
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/services/SimpleService.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { request as __request } from '../core/request';
+import { OpenAPI } from '../core/OpenAPI';
+
+export class SimpleService {
+
+    /**
+     * @throws ApiError
+     */
+    public static getCallWithoutParametersAndResponse(): CancelablePromise<void> {
+        return __request({
+            method: 'GET',
+            path: \`/api/v\${OpenAPI.VERSION}/simple\`,
+        });
+    }
+
+    /**
+     * @throws ApiError
+     */
+    public static putCallWithoutParametersAndResponse(): CancelablePromise<void> {
+        return __request({
+            method: 'PUT',
+            path: \`/api/v\${OpenAPI.VERSION}/simple\`,
+        });
+    }
+
+    /**
+     * @throws ApiError
+     */
+    public static postCallWithoutParametersAndResponse(): CancelablePromise<void> {
+        return __request({
+            method: 'POST',
+            path: \`/api/v\${OpenAPI.VERSION}/simple\`,
+        });
+    }
+
+    /**
+     * @throws ApiError
+     */
+    public static deleteCallWithoutParametersAndResponse(): CancelablePromise<void> {
+        return __request({
+            method: 'DELETE',
+            path: \`/api/v\${OpenAPI.VERSION}/simple\`,
+        });
+    }
+
+    /**
+     * @throws ApiError
+     */
+    public static optionsCallWithoutParametersAndResponse(): CancelablePromise<void> {
+        return __request({
+            method: 'OPTIONS',
+            path: \`/api/v\${OpenAPI.VERSION}/simple\`,
+        });
+    }
+
+    /**
+     * @throws ApiError
+     */
+    public static headCallWithoutParametersAndResponse(): CancelablePromise<void> {
+        return __request({
+            method: 'HEAD',
+            path: \`/api/v\${OpenAPI.VERSION}/simple\`,
+        });
+    }
+
+    /**
+     * @throws ApiError
+     */
+    public static patchCallWithoutParametersAndResponse(): CancelablePromise<void> {
+        return __request({
+            method: 'PATCH',
+            path: \`/api/v\${OpenAPI.VERSION}/simple\`,
+        });
+    }
+
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/services/TypesService.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { request as __request } from '../core/request';
+import { OpenAPI } from '../core/OpenAPI';
+
+export class TypesService {
+
+    /**
+     * @param parameterArray This is an array parameter
+     * @param parameterDictionary This is a dictionary parameter
+     * @param parameterEnum This is an enum parameter
+     * @param parameterNumber This is a number parameter
+     * @param parameterString This is a string parameter
+     * @param parameterBoolean This is a boolean parameter
+     * @param parameterObject This is an object parameter
+     * @param id This is a number parameter
+     * @returns number Response is a simple number
+     * @returns string Response is a simple string
+     * @returns boolean Response is a simple boolean
+     * @returns any Response is a simple object
+     * @throws ApiError
+     */
+    public static types(
+        parameterArray: Array<string> | null,
+        parameterDictionary: any,
+        parameterEnum: 'Success' | 'Warning' | 'Error' | null,
+        parameterNumber: number = 123,
+        parameterString: string = 'default',
+        parameterBoolean: boolean = true,
+        parameterObject: any = null,
+        id?: number,
+    ): CancelablePromise<number | string | boolean | any> {
+        return __request({
+            method: 'GET',
+            path: \`/api/v\${OpenAPI.VERSION}/types\`,
+            query: {
+                'parameterNumber': parameterNumber,
+                'parameterString': parameterString,
+                'parameterBoolean': parameterBoolean,
+                'parameterObject': parameterObject,
+                'parameterArray': parameterArray,
+                'parameterDictionary': parameterDictionary,
+                'parameterEnum': parameterEnum,
+            },
+        });
+    }
+
+}"
+`;
+
+exports[`v3 should generate for node client: ./test/generated/v3-node/services/UploadService.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { request as __request } from '../core/request';
+import { OpenAPI } from '../core/OpenAPI';
+
+export class UploadService {
+
+    /**
+     * @param file Supply a file reference for upload
+     * @returns boolean
+     * @throws ApiError
+     */
+    public static uploadFile(
+        file: Buffer | ArrayBuffer | ArrayBufferView,
+    ): CancelablePromise<boolean> {
+        return __request({
+            method: 'POST',
+            path: \`/api/v\${OpenAPI.VERSION}/upload\`,
+            formData: {
+                'file': file,
+            },
+        });
+    }
+
+}"
+`;
+
 exports[`v3 should generate: ./test/generated/v3/core/ApiError.ts 1`] = `
 "/* istanbul ignore file */
 /* tslint:disable */

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -44,4 +44,23 @@ describe('v3', () => {
             expect(content).toMatchSnapshot(file);
         });
     });
+
+    it('should generate for node client', async () => {
+        await OpenAPI.generate({
+            input: './test/spec/v3.json',
+            output: './test/generated/v3-node/',
+            httpClient: OpenAPI.HttpClient.NODE,
+            useOptions: false,
+            useUnionTypes: false,
+            exportCore: true,
+            exportSchemas: true,
+            exportModels: true,
+            exportServices: true,
+        });
+
+        glob.sync('./test/generated/v3-node/**/*.ts').forEach(file => {
+            const content = fs.readFileSync(file, 'utf8').toString();
+            expect(content).toMatchSnapshot(file);
+        });
+    });
 });


### PR DESCRIPTION
Hey, thank you for this amazing package! But after upgrading to the latest version, I ran into this error:
```
 ReferenceError: Blob is not defined
[2021-11-08T15:06:31.311Z]     at isBlob (/usr/src/dist/core/request.js:55:29)
[2021-11-08T15:06:31.311Z]     at getRequestBody (/usr/src/dist/core/request.js:161:44)
```

Looks like we don't import `Blob` whilst using `isBlob` in node template.

This PR will import missing `Blob` to fix this issue. Note that we might need to move `Blob` import to `fetch-blob` later when this package support node-fetch v3