### PR TITLE
Optimize redundant operationName naming

### DIFF
--- a/src/openApi/v3/parser/getOperation.ts
+++ b/src/openApi/v3/parser/getOperation.ts
@@ -26,7 +26,13 @@ export function getOperation(
 ): Operation {
     const serviceName = getServiceName(tag);
     const operationNameFallback = `${method}${serviceName}`;
-    const operationName = getOperationName(op.operationId || operationNameFallback);
+    
+        // Remove possible redundant serviceName from operationId before generating operationName
+    let operationId = op.operationId;
+    if (operationId?.startsWith(serviceName + '_')) {
+        operationId = operationId.split(serviceName + '_')[1];
+    }
+    const operationName = getOperationName(operationId || operationNameFallback);
     const operationPath = getOperationPath(url);
 
     // Create a new operation object for this method.


### PR DESCRIPTION
Simple implementation example of issue #886. Currently just implementing in OpenApi V3 parser.

Possible adjustments:
- Add runtime flag (--nswag-operationids) for doing this mutation of method names
- Check if `openApi["x-generator"].startsWith('NSwag')`  before running mutation, as an extra layer of precaution.

**Original service class without this fix:**
```
export class NotificationsService {

    /**
     * @returns Notification 
     * @throws ApiError
     */
    public static notificationsGetActiveNotifications(): CancelablePromise<Array<Notification>> {
        return __request({
            method: 'GET',
            path: `/api/Notifications/active`,
        });
    }

}
```

**With this fix:**
```
export class NotificationsService {

    /**
     * @returns Notification 
     * @throws ApiError
     */
    public static getActiveNotifications(): CancelablePromise<Array<Notification>> {
        return __request({
            method: 'GET',
            path: `/api/Notifications/active`,
        });
    }

}
```