### PR TITLE
Allow optional request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,18 @@ const getToken = async () => {
 OpenAPI.TOKEN = getToken;
 ```
 
+### Additional Http Request parameters
+Sometimes it might be useful to pass additional options to the HttpClient request. For example here we are setting the httpsAgent parameter on the request.
+
+```typescript
+import { OpenAPI } from './generated';
+
+OpenAPI.OTHER_OPTIONS = {
+    // Anything required by the http client you are using (Axios, Fetch, ...)
+    httpsAgent: new https.Agent({ rejectUnauthorized: false }),
+};
+```
+
 ### References
 
 Local references to schema definitions (those beginning with `#/definitions/schemas/`)

--- a/src/templates/core/ApiRequestOptions.hbs
+++ b/src/templates/core/ApiRequestOptions.hbs
@@ -11,4 +11,5 @@ export type ApiRequestOptions = {
     readonly mediaType?: string;
     readonly responseHeader?: string;
     readonly errors?: Record<number, string>;
+    readOnly otherOptions?: Record<string, any>;
 }

--- a/src/templates/core/OpenAPI.hbs
+++ b/src/templates/core/OpenAPI.hbs
@@ -15,6 +15,7 @@ type Config = {
     PASSWORD?: string | Resolver<string>;
     HEADERS?: Headers | Resolver<Headers>;
     ENCODE_PATH?: (path: string) => string;
+    OTHER_OPTIONS?: Record<string, string>;
 }
 
 export const OpenAPI: Config = {
@@ -27,4 +28,5 @@ export const OpenAPI: Config = {
     PASSWORD: undefined,
     HEADERS: undefined,
     ENCODE_PATH: undefined,
+    OTHER_OPTIONS: undefined,
 };

--- a/src/templates/core/axios/sendRequest.hbs
+++ b/src/templates/core/axios/sendRequest.hbs
@@ -15,6 +15,7 @@ async function sendRequest(
         method: options.method,
         withCredentials: OpenAPI.WITH_CREDENTIALS,
         cancelToken: source.token,
+        ...options.otherOptions
     };
 
     onCancel(() => source.cancel('The user aborted a request.'));

--- a/src/templates/core/fetch/sendRequest.hbs
+++ b/src/templates/core/fetch/sendRequest.hbs
@@ -13,6 +13,7 @@ async function sendRequest(
         body: body || formData,
         method: options.method,
         signal: controller.signal,
+        ...options.otherOptions
     };
 
     if (OpenAPI.WITH_CREDENTIALS) {

--- a/src/templates/core/node/sendRequest.hbs
+++ b/src/templates/core/node/sendRequest.hbs
@@ -13,6 +13,7 @@ async function sendRequest(
         method: options.method,
         body: body || formData,
         signal: controller.signal,
+        ...options.otherOptions
     };
 
     onCancel(() => controller.abort());

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -39,6 +39,7 @@ export type ApiRequestOptions = {
     readonly mediaType?: string;
     readonly responseHeader?: string;
     readonly errors?: Record<number, string>;
+    readOnly otherOptions?: Record<string, any>;
 }"
 `;
 
@@ -191,6 +192,7 @@ type Config = {
     PASSWORD?: string | Resolver<string>;
     HEADERS?: Headers | Resolver<Headers>;
     ENCODE_PATH?: (path: string) => string;
+    OTHER_OPTIONS?: Record<string, string>;
 }
 
 export const OpenAPI: Config = {
@@ -203,6 +205,7 @@ export const OpenAPI: Config = {
     PASSWORD: undefined,
     HEADERS: undefined,
     ENCODE_PATH: undefined,
+    OTHER_OPTIONS: undefined,
 };"
 `;
 
@@ -382,6 +385,7 @@ async function sendRequest(
         body: body || formData,
         method: options.method,
         signal: controller.signal,
+        ...options.otherOptions
     };
 
     if (OpenAPI.WITH_CREDENTIALS) {
@@ -2701,6 +2705,7 @@ export type ApiRequestOptions = {
     readonly mediaType?: string;
     readonly responseHeader?: string;
     readonly errors?: Record<number, string>;
+    readOnly otherOptions?: Record<string, any>;
 }"
 `;
 
@@ -2853,6 +2858,7 @@ type Config = {
     PASSWORD?: string | Resolver<string>;
     HEADERS?: Headers | Resolver<Headers>;
     ENCODE_PATH?: (path: string) => string;
+    OTHER_OPTIONS?: Record<string, string>;
 }
 
 export const OpenAPI: Config = {
@@ -2865,6 +2871,7 @@ export const OpenAPI: Config = {
     PASSWORD: undefined,
     HEADERS: undefined,
     ENCODE_PATH: undefined,
+    OTHER_OPTIONS: undefined,
 };"
 `;
 
@@ -3044,6 +3051,7 @@ async function sendRequest(
         body: body || formData,
         method: options.method,
         signal: controller.signal,
+        ...options.otherOptions
     };
 
     if (OpenAPI.WITH_CREDENTIALS) {


### PR DESCRIPTION
I would like to be able to be able to add additional options to ApiRequestOptions which would be set on the http client when making a request. Therefore i'm submitting this PR for your review. thanks

This is to support setting additional options such as the httpsAgent if using axios. For example : -

`OpenAPI.OTHER_OPTIONS = {
    httpsAgent: new https.Agent({ rejectUnauthorized: false }),
  };`
