### PR TITLE
Add description to schema output

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,7 +32,7 @@ const handlebarsPlugin = () => ({
                 preventIndent: true,
                 knownHelpersOnly: true,
                 knownHelpers: {
-                    escapeQuotes: true,
+                    escapeSinglequotes: true,
                     equals: true,
                     notEquals: true,
                     containsSpaces: true,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,6 +32,7 @@ const handlebarsPlugin = () => ({
                 preventIndent: true,
                 knownHelpersOnly: true,
                 knownHelpers: {
+                    escapeQuotes: true,
                     equals: true,
                     notEquals: true,
                     containsSpaces: true,

--- a/src/templates/partials/schemaComposition.hbs
+++ b/src/templates/partials/schemaComposition.hbs
@@ -1,7 +1,7 @@
 {
     type: '{{export}}',
 {{#if description}}
-    description: '{{{escapeQuotes description}}}',
+    description: '{{{escapeSinglequotes description}}}',
 {{/if}}
     contains: [{{#each properties}}{{>schema}}{{#unless @last}}, {{/unless}}{{/each}}],
 {{#if isReadOnly}}

--- a/src/templates/partials/schemaComposition.hbs
+++ b/src/templates/partials/schemaComposition.hbs
@@ -1,5 +1,8 @@
 {
     type: '{{export}}',
+{{#if description}}
+    description: '{{{escapeQuotes description}}}',
+{{/if}}
     contains: [{{#each properties}}{{>schema}}{{#unless @last}}, {{/unless}}{{/each}}],
 {{#if isReadOnly}}
     isReadOnly: {{{isReadOnly}}},

--- a/src/templates/partials/schemaGeneric.hbs
+++ b/src/templates/partials/schemaGeneric.hbs
@@ -2,6 +2,9 @@
 {{#if type}}
     type: '{{{base}}}',
 {{/if}}
+{{#if description}}
+    description: '{{{escapeQuotes description}}}',
+{{/if}}
 {{#if isReadOnly}}
     isReadOnly: {{{isReadOnly}}},
 {{/if}}

--- a/src/templates/partials/schemaGeneric.hbs
+++ b/src/templates/partials/schemaGeneric.hbs
@@ -3,7 +3,7 @@
     type: '{{{base}}}',
 {{/if}}
 {{#if description}}
-    description: '{{{escapeQuotes description}}}',
+    description: '{{{escapeSinglequotes description}}}',
 {{/if}}
 {{#if isReadOnly}}
     isReadOnly: {{{isReadOnly}}},

--- a/src/templates/partials/schemaInterface.hbs
+++ b/src/templates/partials/schemaInterface.hbs
@@ -1,4 +1,7 @@
 {
+{{#if description}}
+    description: '{{{escapeQuotes description}}}',
+{{/if}}
     properties: {
 {{#if properties}}
     {{#each properties}}

--- a/src/templates/partials/schemaInterface.hbs
+++ b/src/templates/partials/schemaInterface.hbs
@@ -1,6 +1,6 @@
 {
 {{#if description}}
-    description: '{{{escapeQuotes description}}}',
+    description: '{{{escapeSinglequotes description}}}',
 {{/if}}
     properties: {
 {{#if properties}}

--- a/src/utils/registerHandlebarHelpers.ts
+++ b/src/utils/registerHandlebarHelpers.ts
@@ -11,7 +11,7 @@ export function registerHandlebarHelpers(root: {
     useUnionTypes: boolean;
 }): void {
     Handlebars.registerHelper('escapeQuotes', function (value: string): string {
-        return value.replace(/(['"])/g, '\\$1');
+        return value.replace(/(')/g, '\\$1');
     });
 
     Handlebars.registerHelper(

--- a/src/utils/registerHandlebarHelpers.ts
+++ b/src/utils/registerHandlebarHelpers.ts
@@ -10,6 +10,10 @@ export function registerHandlebarHelpers(root: {
     useOptions: boolean;
     useUnionTypes: boolean;
 }): void {
+    Handlebars.registerHelper('escapeQuotes', function (value: string): string {
+        return value.replace(/(['"])/g, '\\$1');
+    });
+
     Handlebars.registerHelper(
         'equals',
         function (this: any, a: string, b: string, options: Handlebars.HelperOptions): string {

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -1367,6 +1367,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$Date.ts 1`] = `
 /* eslint-disable */
 export const $Date = {
     type: 'string',
+    description: 'This is a type-only model that defines Date as a string',
 } as const;"
 `;
 
@@ -1449,6 +1450,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$EnumFromDescription.ts
 /* eslint-disable */
 export const $EnumFromDescription = {
     type: 'number',
+    description: 'Success=1,Warning=2,Error=3',
 } as const;"
 `;
 
@@ -1485,6 +1487,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelThatExtends.ts 1`
 /* eslint-disable */
 export const $ModelThatExtends = {
     type: 'all-of',
+    description: 'This is a model that extends another model',
     contains: [{
         type: 'ModelWithString',
     }, {
@@ -1506,6 +1509,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelThatExtendsExtend
 /* eslint-disable */
 export const $ModelThatExtendsExtends = {
     type: 'all-of',
+    description: 'This is a model that extends another model',
     contains: [{
         type: 'ModelWithString',
     }, {
@@ -1528,6 +1532,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithArray.ts 1`] 
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithArray = {
+    description: 'This is a model with one property containing an array',
     properties: {
         prop: {
             type: 'array',
@@ -1556,9 +1561,11 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithBoolean.ts 1`
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithBoolean = {
+    description: 'This is a model with one boolean property',
     properties: {
         prop: {
             type: 'boolean',
+            description: 'This is a simple boolean property',
         },
     },
 } as const;"
@@ -1569,6 +1576,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithCircularRefer
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithCircularReference = {
+    description: 'This is a model with one property containing a circular reference',
     properties: {
         prop: {
             type: 'ModelWithCircularReference',
@@ -1582,6 +1590,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithDictionary.ts
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithDictionary = {
+    description: 'This is a model with one property containing a dictionary',
     properties: {
         prop: {
             type: 'dictionary',
@@ -1598,6 +1607,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithDuplicateImpo
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithDuplicateImports = {
+    description: 'This is a model with duplicated imports',
     properties: {
         propA: {
             type: 'ModelWithString',
@@ -1617,6 +1627,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithDuplicateProp
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithDuplicateProperties = {
+    description: 'This is a model with duplicated properties',
     properties: {
         prop: {
             type: 'ModelWithString',
@@ -1630,6 +1641,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithEnum.ts 1`] =
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithEnum = {
+    description: 'This is a model with one enum',
     properties: {
         test: {
             type: 'Enum',
@@ -1639,6 +1651,7 @@ export const $ModelWithEnum = {
         },
         bool: {
             type: 'boolean',
+            description: 'Simple boolean enum',
         },
     },
 } as const;"
@@ -1649,6 +1662,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithEnumFromDescr
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithEnumFromDescription = {
+    description: 'This is a model with one enum',
     properties: {
         test: {
             type: 'Enum',
@@ -1662,9 +1676,11 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithInteger.ts 1`
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithInteger = {
+    description: 'This is a model with one number property',
     properties: {
         prop: {
             type: 'number',
+            description: 'This is a simple number property',
         },
     },
 } as const;"
@@ -1675,6 +1691,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithNestedEnums.t
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithNestedEnums = {
+    description: 'This is a model with nested enums',
     properties: {
         dictionaryWithEnum: {
             type: 'dictionary',
@@ -1709,6 +1726,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithNestedPropert
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithNestedProperties = {
+    description: 'This is a model with one nested property',
     properties: {
         first: {
             properties: {
@@ -1736,13 +1754,16 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithNullableStrin
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithNullableString = {
+    description: 'This is a model with one string property',
     properties: {
         nullableProp: {
             type: 'string',
+            description: 'This is a simple string property',
             isNullable: true,
         },
         nullableRequiredProp: {
             type: 'string',
+            description: 'This is a simple string property',
             isRequired: true,
             isNullable: true,
         },
@@ -1755,6 +1776,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithOrderedProper
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithOrderedProperties = {
+    description: 'This is a model with ordered properties',
     properties: {
         zebra: {
             type: 'string',
@@ -1774,6 +1796,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithPattern.ts 1`
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithPattern = {
+    description: 'This is a model that contains a some patterns',
     properties: {
         key: {
             type: 'string',
@@ -1812,6 +1835,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithProperties.ts
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithProperties = {
+    description: 'This is a model with one nested property',
     properties: {
         required: {
             type: 'string',
@@ -1860,6 +1884,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithReference.ts 
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithReference = {
+    description: 'This is a model with one property containing a reference',
     properties: {
         prop: {
             type: 'ModelWithProperties',
@@ -1873,9 +1898,11 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$ModelWithString.ts 1`]
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithString = {
+    description: 'This is a model with one string property',
     properties: {
         prop: {
             type: 'string',
+            description: 'This is a simple string property',
         },
     },
 } as const;"
@@ -1887,6 +1914,10 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$MultilineComment.ts 1`
 /* eslint-disable */
 export const $MultilineComment = {
     type: 'number',
+    description: 'Testing multiline comments.
+     * This must go to the next line.
+     *
+     * This will contain a break.',
 } as const;"
 `;
 
@@ -1896,6 +1927,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$SimpleBoolean.ts 1`] =
 /* eslint-disable */
 export const $SimpleBoolean = {
     type: 'boolean',
+    description: 'This is a simple boolean',
 } as const;"
 `;
 
@@ -1905,6 +1937,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$SimpleFile.ts 1`] = `
 /* eslint-disable */
 export const $SimpleFile = {
     type: 'binary',
+    description: 'This is a simple file',
 } as const;"
 `;
 
@@ -1914,6 +1947,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$SimpleInteger.ts 1`] =
 /* eslint-disable */
 export const $SimpleInteger = {
     type: 'number',
+    description: 'This is a simple number',
 } as const;"
 `;
 
@@ -1923,6 +1957,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$SimpleReference.ts 1`]
 /* eslint-disable */
 export const $SimpleReference = {
     type: 'ModelWithString',
+    description: 'This is a simple reference',
 } as const;"
 `;
 
@@ -1932,6 +1967,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$SimpleString.ts 1`] = 
 /* eslint-disable */
 export const $SimpleString = {
     type: 'string',
+    description: 'This is a simple string',
 } as const;"
 `;
 
@@ -1941,6 +1977,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/$SimpleStringWithPatter
 /* eslint-disable */
 export const $SimpleStringWithPattern = {
     type: 'string',
+    description: 'This is a simple string',
     maxLength: 64,
     pattern: '^[a-zA-Z0-9_]*$',
 } as const;"
@@ -4209,6 +4246,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$CompositionBaseModel.t
 /* tslint:disable */
 /* eslint-disable */
 export const $CompositionBaseModel = {
+    description: 'This is a base model with two simple optional properties',
     properties: {
         firstName: {
             type: 'string',
@@ -4226,6 +4264,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$CompositionExtendedMod
 /* eslint-disable */
 export const $CompositionExtendedModel = {
     type: 'all-of',
+    description: 'This is a model that extends the base model',
     contains: [{
         type: 'CompositionBaseModel',
     }, {
@@ -4252,6 +4291,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$CompositionWithAllOfAn
 /* tslint:disable */
 /* eslint-disable */
 export const $CompositionWithAllOfAndNullable = {
+    description: 'This is a model with one property with a \\\\'all of\\\\' relationship',
     properties: {
         propA: {
             type: 'all-of',
@@ -4279,6 +4319,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$CompositionWithAnyOf.t
 /* tslint:disable */
 /* eslint-disable */
 export const $CompositionWithAnyOf = {
+    description: 'This is a model with one property with a \\\\'any of\\\\' relationship',
     properties: {
         propA: {
             type: 'any-of',
@@ -4301,6 +4342,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$CompositionWithAnyOfAn
 /* tslint:disable */
 /* eslint-disable */
 export const $CompositionWithAnyOfAndNullable = {
+    description: 'This is a model with one property with a \\\\'any of\\\\' relationship',
     properties: {
         propA: {
             type: 'any-of',
@@ -4328,10 +4370,12 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$CompositionWithAnyOfAn
 /* tslint:disable */
 /* eslint-disable */
 export const $CompositionWithAnyOfAnonymous = {
+    description: 'This is a model with one property with a \\\\'any of\\\\' relationship where the options are not $ref',
     properties: {
         propA: {
             type: 'any-of',
             contains: [{
+                description: 'Anonymous object type',
                 properties: {
                     propA: {
                         type: 'string',
@@ -4339,8 +4383,10 @@ export const $CompositionWithAnyOfAnonymous = {
                 },
             }, {
                 type: 'string',
+                description: 'Anonymous string type',
             }, {
                 type: 'number',
+                description: 'Anonymous integer type',
             }],
         },
     },
@@ -4352,6 +4398,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$CompositionWithOneOf.t
 /* tslint:disable */
 /* eslint-disable */
 export const $CompositionWithOneOf = {
+    description: 'This is a model with one property with a \\\\'one of\\\\' relationship',
     properties: {
         propA: {
             type: 'one-of',
@@ -4374,6 +4421,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$CompositionWithOneOfAn
 /* tslint:disable */
 /* eslint-disable */
 export const $CompositionWithOneOfAndNullable = {
+    description: 'This is a model with one property with a \\\\'one of\\\\' relationship',
     properties: {
         propA: {
             type: 'one-of',
@@ -4401,10 +4449,12 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$CompositionWithOneOfAn
 /* tslint:disable */
 /* eslint-disable */
 export const $CompositionWithOneOfAnonymous = {
+    description: 'This is a model with one property with a \\\\'one of\\\\' relationship where the options are not $ref',
     properties: {
         propA: {
             type: 'one-of',
             contains: [{
+                description: 'Anonymous object type',
                 properties: {
                     propA: {
                         type: 'string',
@@ -4412,8 +4462,10 @@ export const $CompositionWithOneOfAnonymous = {
                 },
             }, {
                 type: 'string',
+                description: 'Anonymous string type',
             }, {
                 type: 'number',
+                description: 'Anonymous integer type',
             }],
         },
     },
@@ -4499,6 +4551,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$EnumFromDescription.ts
 /* eslint-disable */
 export const $EnumFromDescription = {
     type: 'number',
+    description: 'Success=1,Warning=2,Error=3',
 } as const;"
 `;
 
@@ -4535,6 +4588,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelThatExtends.ts 1`
 /* eslint-disable */
 export const $ModelThatExtends = {
     type: 'all-of',
+    description: 'This is a model that extends another model',
     contains: [{
         type: 'ModelWithString',
     }, {
@@ -4556,6 +4610,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelThatExtendsExtend
 /* eslint-disable */
 export const $ModelThatExtendsExtends = {
     type: 'all-of',
+    description: 'This is a model that extends another model',
     contains: [{
         type: 'ModelWithString',
     }, {
@@ -4578,6 +4633,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithArray.ts 1`] 
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithArray = {
+    description: 'This is a model with one property containing an array',
     properties: {
         prop: {
             type: 'array',
@@ -4606,9 +4662,11 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithBoolean.ts 1`
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithBoolean = {
+    description: 'This is a model with one boolean property',
     properties: {
         prop: {
             type: 'boolean',
+            description: 'This is a simple boolean property',
         },
     },
 } as const;"
@@ -4619,6 +4677,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithCircularRefer
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithCircularReference = {
+    description: 'This is a model with one property containing a circular reference',
     properties: {
         prop: {
             type: 'ModelWithCircularReference',
@@ -4632,6 +4691,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithDictionary.ts
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithDictionary = {
+    description: 'This is a model with one property containing a dictionary',
     properties: {
         prop: {
             type: 'dictionary',
@@ -4648,6 +4708,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithDuplicateImpo
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithDuplicateImports = {
+    description: 'This is a model with duplicated imports',
     properties: {
         propA: {
             type: 'ModelWithString',
@@ -4667,6 +4728,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithDuplicateProp
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithDuplicateProperties = {
+    description: 'This is a model with duplicated properties',
     properties: {
         prop: {
             type: 'ModelWithString',
@@ -4680,6 +4742,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithEnum.ts 1`] =
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithEnum = {
+    description: 'This is a model with one enum',
     properties: {
         test: {
             type: 'Enum',
@@ -4689,6 +4752,7 @@ export const $ModelWithEnum = {
         },
         bool: {
             type: 'boolean',
+            description: 'Simple boolean enum',
         },
     },
 } as const;"
@@ -4699,6 +4763,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithEnumFromDescr
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithEnumFromDescription = {
+    description: 'This is a model with one enum',
     properties: {
         test: {
             type: 'Enum',
@@ -4712,9 +4777,11 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithInteger.ts 1`
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithInteger = {
+    description: 'This is a model with one number property',
     properties: {
         prop: {
             type: 'number',
+            description: 'This is a simple number property',
         },
     },
 } as const;"
@@ -4725,6 +4792,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithNestedEnums.t
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithNestedEnums = {
+    description: 'This is a model with nested enums',
     properties: {
         dictionaryWithEnum: {
             type: 'dictionary',
@@ -4759,6 +4827,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithNestedPropert
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithNestedProperties = {
+    description: 'This is a model with one nested property',
     properties: {
         first: {
             properties: {
@@ -4789,22 +4858,27 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithNullableStrin
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithNullableString = {
+    description: 'This is a model with one string property',
     properties: {
         nullableProp1: {
             type: 'string',
+            description: 'This is a simple string property',
             isNullable: true,
         },
         nullableRequiredProp1: {
             type: 'string',
+            description: 'This is a simple string property',
             isRequired: true,
             isNullable: true,
         },
         nullableProp2: {
             type: 'string',
+            description: 'This is a simple string property',
             isNullable: true,
         },
         nullableRequiredProp2: {
             type: 'string',
+            description: 'This is a simple string property',
             isRequired: true,
             isNullable: true,
         },
@@ -4817,6 +4891,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithOrderedProper
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithOrderedProperties = {
+    description: 'This is a model with ordered properties',
     properties: {
         zebra: {
             type: 'string',
@@ -4836,6 +4911,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithPattern.ts 1`
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithPattern = {
+    description: 'This is a model that contains a some patterns',
     properties: {
         key: {
             type: 'string',
@@ -4874,6 +4950,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithProperties.ts
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithProperties = {
+    description: 'This is a model with one nested property',
     properties: {
         required: {
             type: 'string',
@@ -4927,6 +5004,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithReference.ts 
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithReference = {
+    description: 'This is a model with one property containing a reference',
     properties: {
         prop: {
             type: 'ModelWithProperties',
@@ -4940,9 +5018,11 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithString.ts 1`]
 /* tslint:disable */
 /* eslint-disable */
 export const $ModelWithString = {
+    description: 'This is a model with one string property',
     properties: {
         prop: {
             type: 'string',
+            description: 'This is a simple string property',
         },
     },
 } as const;"
@@ -4954,6 +5034,10 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$MultilineComment.ts 1`
 /* eslint-disable */
 export const $MultilineComment = {
     type: 'number',
+    description: 'Testing multiline comments.
+     * This must go to the next line.
+     *
+     * This will contain a break.',
 } as const;"
 `;
 
@@ -4963,6 +5047,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$SimpleBoolean.ts 1`] =
 /* eslint-disable */
 export const $SimpleBoolean = {
     type: 'boolean',
+    description: 'This is a simple boolean',
 } as const;"
 `;
 
@@ -4972,6 +5057,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$SimpleFile.ts 1`] = `
 /* eslint-disable */
 export const $SimpleFile = {
     type: 'binary',
+    description: 'This is a simple file',
 } as const;"
 `;
 
@@ -4981,6 +5067,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$SimpleInteger.ts 1`] =
 /* eslint-disable */
 export const $SimpleInteger = {
     type: 'number',
+    description: 'This is a simple number',
 } as const;"
 `;
 
@@ -4990,6 +5077,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$SimpleReference.ts 1`]
 /* eslint-disable */
 export const $SimpleReference = {
     type: 'ModelWithString',
+    description: 'This is a simple reference',
 } as const;"
 `;
 
@@ -4999,6 +5087,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$SimpleString.ts 1`] = 
 /* eslint-disable */
 export const $SimpleString = {
     type: 'string',
+    description: 'This is a simple string',
 } as const;"
 `;
 
@@ -5008,6 +5097,7 @@ exports[`v3 should generate: ./test/generated/v3/schemas/$SimpleStringWithPatter
 /* eslint-disable */
 export const $SimpleStringWithPattern = {
     type: 'string',
+    description: 'This is a simple string',
     isNullable: true,
     maxLength: 64,
     pattern: '^[a-zA-Z0-9_]*$',


### PR DESCRIPTION
As mentioned in the README, the [Export Schemas](https://github.com/ferdikoomen/openapi-typescript-codegen#runtime-schemas---exportschemas) option is really helpful when creating forms driven by OpenAPI spec. 
However, I feel that it would be even more helpful when the description is available in the schema output as well, so it can be used as a label.
