### PR TITLE
Fix client compilation error in base64()

### DIFF
--- a/src/templates/core/functions/base64.hbs
+++ b/src/templates/core/functions/base64.hbs
@@ -2,6 +2,7 @@ function base64(str: string): string {
     try {
         return btoa(str);
     } catch (err) {
+        // @ts-ignore
         return Buffer.from(str).toString('base64');
     }
 }


### PR DESCRIPTION
Hi there, a very small pull request that would help me a lot

## Context

The base64 function tries using the btoa function and falls back to
using Buffer if btoa is not available.

## Problem

In the context of a dom, you have btoa, and you may not necessarily have
Buffer, and in the case the fallback branch creates a compilation error
"TS2591: Cannot find name 'Buffer'."

## Solution

Add a @ts-ignore in the fallback branch because we will always have
either btoa or Buffer available in the forseable future.