### PR TITLE
Handle empty tags

### DIFF
--- a/src/openApi/v3/parser/getServices.spec.ts
+++ b/src/openApi/v3/parser/getServices.spec.ts
@@ -1,0 +1,18 @@
+import { getServices } from './getServices';
+
+describe('getServices', () => {
+    it('should create a unnamed service if tags are empty', () => {
+        const services = getServices({
+            openapi: '3',
+            info: { title: 'x', version: '1' },
+            paths: {
+                '/api/trips': {
+                    get: { tags: [], responses: { 200: { description: 'X' }, default: { description: 'default' } } },
+                },
+            },
+        });
+
+        expect(services).toHaveLength(1);
+        expect(services[0].name).toEqual('Unnamed');
+    });
+});

--- a/src/openApi/v3/parser/getServices.ts
+++ b/src/openApi/v3/parser/getServices.ts
@@ -28,7 +28,8 @@ export function getServices(openApi: OpenApi): Service[] {
                         case 'patch':
                             // Each method contains an OpenAPI operation, we parse the operation
                             const op = path[method]!;
-                            const tags = op.tags?.filter(unique) || ['Service'];
+                            const uniqueTags = op.tags?.filter(unique);
+                            const tags = uniqueTags?.length ? uniqueTags : ['Unnamed'];
                             tags.forEach(tag => {
                                 const operation = getOperation(openApi, url, method, tag, op, pathParams);
 


### PR DESCRIPTION
Before this change, if your OpenAPI spec had an empty `tags` property, the service file would not be created.

After this change, the behaviour in this scenario is the same as if there was no tags property at all.

One thing to note (and I'm happy to revert it if you don't think its better), is that I've changed the default tag from "Service" to "Unnamed". The thinking behind this is that `UnnamedService` is a better name to use than `ServiceService`.