### PR TITLE
Fix: Escape template literal special characters in schema output

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,6 +29,7 @@ const handlebarsPlugin = () => ({
                 knownHelpersOnly: true,
                 knownHelpers: {
                     equals: true,
+                    escapeTemplateLiteral: true,
                     notEquals: true,
                     containsSpaces: true,
                     union: true,

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -85,7 +85,7 @@ export class {{{name}}}{{{@root.postfix}}} {
             {{#if errors}}
             errors: {
                 {{#each errors}}
-                {{{code}}}: `{{{description}}}`,
+                {{{code}}}: `{{{escapeTemplateLiteral description}}}`,
                 {{/each}}
             },
             {{/if}}

--- a/src/templates/partials/schemaComposition.hbs
+++ b/src/templates/partials/schemaComposition.hbs
@@ -1,7 +1,7 @@
 {
     type: '{{export}}',
 {{#if description}}
-    description: `{{{description}}}`,
+    description: `{{{escapeTemplateLiteral description}}}`,
 {{/if}}
     contains: [{{#each properties}}{{>schema}}{{#unless @last}}, {{/unless}}{{/each}}],
 {{#if isReadOnly}}

--- a/src/templates/partials/schemaGeneric.hbs
+++ b/src/templates/partials/schemaGeneric.hbs
@@ -3,7 +3,7 @@
     type: '{{{type}}}',
 {{/if}}
 {{#if description}}
-    description: `{{{description}}}`,
+    description: `{{{escapeTemplateLiteral description}}}`,
 {{/if}}
 {{#if isReadOnly}}
     isReadOnly: {{{isReadOnly}}},

--- a/src/templates/partials/schemaInterface.hbs
+++ b/src/templates/partials/schemaInterface.hbs
@@ -1,6 +1,6 @@
 {
 {{#if description}}
-    description: `{{{description}}}`,
+    description: `{{{escapeTemplateLiteral description}}}`,
 {{/if}}
     properties: {
 {{#if properties}}

--- a/src/utils/registerHandlebarHelpers.ts
+++ b/src/utils/registerHandlebarHelpers.ts
@@ -10,6 +10,11 @@ export function registerHandlebarHelpers(root: {
     useOptions: boolean;
     useUnionTypes: boolean;
 }): void {
+
+    Handlebars.registerHelper('escapeTemplateLiteral', function (value: string): string {
+        return value.replace(/(`|\${)/g, '\\$1');
+    });
+
     Handlebars.registerHelper(
         'equals',
         function (this: any, a: string, b: string, options: Handlebars.HelperOptions): string {

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -3223,6 +3223,7 @@ export type { ArrayWithNumbers } from './models/ArrayWithNumbers';
 export type { ArrayWithProperties } from './models/ArrayWithProperties';
 export type { ArrayWithReferences } from './models/ArrayWithReferences';
 export type { ArrayWithStrings } from './models/ArrayWithStrings';
+export type { CommentWithSpecialCharacters } from './models/CommentWithSpecialCharacters';
 export type { CompositionBaseModel } from './models/CompositionBaseModel';
 export type { CompositionExtendedModel } from './models/CompositionExtendedModel';
 export type { CompositionWithAllOfAndNullable } from './models/CompositionWithAllOfAndNullable';
@@ -3278,6 +3279,7 @@ export { $ArrayWithNumbers } from './schemas/$ArrayWithNumbers';
 export { $ArrayWithProperties } from './schemas/$ArrayWithProperties';
 export { $ArrayWithReferences } from './schemas/$ArrayWithReferences';
 export { $ArrayWithStrings } from './schemas/$ArrayWithStrings';
+export { $CommentWithSpecialCharacters } from './schemas/$CommentWithSpecialCharacters';
 export { $CompositionBaseModel } from './schemas/$CompositionBaseModel';
 export { $CompositionExtendedModel } from './schemas/$CompositionExtendedModel';
 export { $CompositionWithAllOfAndNullable } from './schemas/$CompositionWithAllOfAndNullable';
@@ -3419,6 +3421,17 @@ exports[`v3 should generate: ./test/generated/v3/models/ArrayWithStrings.ts 1`] 
  * This is a simple array with strings
  */
 export type ArrayWithStrings = Array<string>;"
+`;
+
+exports[`v3 should generate: ./test/generated/v3/models/CommentWithSpecialCharacters.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Testing special characters in template string, such as \`backticks\`, \`\`\`multiple backticks\`\`\` and \${expression placeholders}. These should be escaped in the schema output.
+ */
+export type CommentWithSpecialCharacters = number;"
 `;
 
 exports[`v3 should generate: ./test/generated/v3/models/CompositionBaseModel.ts 1`] = `
@@ -4334,6 +4347,16 @@ export const $ArrayWithStrings = {
     contains: {
         type: 'string',
     },
+} as const;"
+`;
+
+exports[`v3 should generate: ./test/generated/v3/schemas/$CommentWithSpecialCharacters.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CommentWithSpecialCharacters = {
+    type: 'number',
+    description: \`Testing special characters in template string, such as \\\\\`backticks\\\\\`, \\\\\`\\\\\`\\\\\`multiple backticks\\\\\`\\\\\`\\\\\` and \\\\\${expression placeholders}. These should be escaped in the schema output.\`,
 } as const;"
 `;
 

--- a/test/spec/v3.json
+++ b/test/spec/v3.json
@@ -1433,6 +1433,10 @@
                 "description": "Testing multiline comments.\nThis must go to the next line.\n\nThis will contain a break.",
                 "type": "integer"
             },
+            "CommentWithSpecialCharacters": {
+                "description": "Testing special characters in template string, such as `backticks`, ```multiple backticks``` and ${expression placeholders}. These should be escaped in the schema output.",
+                "type": "integer"
+            },
             "SimpleInteger": {
                 "description": "This is a simple number",
                 "type": "integer"
@@ -1873,7 +1877,7 @@
                     },
                     "radius": {
                         "type": "number"
-                    } 
+                    }
                 }
             },
             "ModelSquare": {


### PR DESCRIPTION
If someone would use backticks in their description, it would break the generated `$<Schema>.ts` files. Escaping backticks and expression placeholders would alleviate that.