### PR TITLE
Fix: Add missing postfix field to options typedef

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,6 +15,7 @@ export type Options = {
     exportServices?: boolean;
     exportModels?: boolean;
     exportSchemas?: boolean;
+    postfix?: string;
     request?: string;
     write?: boolean;
 };


### PR DESCRIPTION
https://github.com/ferdikoomen/openapi-typescript-codegen/issues/934

the following field is currently available in cli interface as:
`    --postfix <value>         Service name postfix (default: "Service")`

and in project src at https://github.com/ferdikoomen/openapi-typescript-codegen/blob/00cb70bdda17c7be2322551f5fd9b028438b49d0/src/index.ts#L23

but isn't available in typedefs.

Thanks!