### PR TITLE
Extension options for generated service classes

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -28,21 +28,21 @@ const params = program
 const OpenAPI = require(path.resolve(__dirname, '../dist/index.js'));
 
 const genereteParams = {
-    input: program.input,
-    output: program.output,
-    httpClient: program.client,
-    useOptions: program.useOptions,
-    useUnionTypes: program.useUnionTypes,
-    exportCore: JSON.parse(program.exportCore) === true,
-    exportServices: JSON.parse(program.exportServices) === true,
-    exportModels: JSON.parse(program.exportModels) === true,
-    exportSchemas: JSON.parse(program.exportSchemas) === true,
+    input: params.input,
+    output: params.output,
+    httpClient: params.client,
+    useOptions: params.useOptions,
+    useUnionTypes: params.useUnionTypes,
+    exportCore: JSON.parse(params.exportCore) === true,
+    exportServices: JSON.parse(params.exportServices) === true,
+    exportModels: JSON.parse(params.exportModels) === true,
+    exportSchemas: JSON.parse(params.exportSchemas) === true,
     postfix: params.postfix,
     request: params.request,
 };
 
-if (program.serviceOptions) {
-    genereteParams.serviceOptions = require(path.resolve(__dirname, '../../', program.serviceOptions));
+if (params.serviceOptions) {
+    genereteParams.serviceOptions = require(path.resolve(process.cwd(), params.serviceOptions));
 }
 
 if (OpenAPI) {

--- a/bin/index.js
+++ b/bin/index.js
@@ -21,25 +21,32 @@ const params = program
     .option('--exportSchemas <value>', 'Write schemas to disk', false)
     .option('--postfix <value>', 'Service name postfix', 'Service')
     .option('--request <value>', 'Path to custom request file')
+    .option('-so, --serviceOptions <value>, Service options path')
     .parse(process.argv)
     .opts();
 
 const OpenAPI = require(path.resolve(__dirname, '../dist/index.js'));
 
+const genereteParams = {
+    input: program.input,
+    output: program.output,
+    httpClient: program.client,
+    useOptions: program.useOptions,
+    useUnionTypes: program.useUnionTypes,
+    exportCore: JSON.parse(program.exportCore) === true,
+    exportServices: JSON.parse(program.exportServices) === true,
+    exportModels: JSON.parse(program.exportModels) === true,
+    exportSchemas: JSON.parse(program.exportSchemas) === true,
+    postfix: params.postfix,
+    request: params.request,
+};
+
+if (program.serviceOptions) {
+    genereteParams.serviceOptions = require(path.resolve(__dirname, '../../', program.serviceOptions));
+}
+
 if (OpenAPI) {
-    OpenAPI.generate({
-        input: params.input,
-        output: params.output,
-        httpClient: params.client,
-        useOptions: params.useOptions,
-        useUnionTypes: params.useUnionTypes,
-        exportCore: JSON.parse(params.exportCore) === true,
-        exportServices: JSON.parse(params.exportServices) === true,
-        exportModels: JSON.parse(params.exportModels) === true,
-        exportSchemas: JSON.parse(params.exportSchemas) === true,
-        postfix: params.postfix,
-        request: params.request,
-    })
+    OpenAPI.generate(genereteParams)
         .then(() => {
             process.exit(0);
         })

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,17 @@ import { writeClient } from './utils/writeClient';
 
 export { HttpClient } from './HttpClient';
 
-export type Options = {
+export interface ServiceOptions {
+    serviceImports?: string;
+    serviceConstructor?: string;
+    serviceDecorator?: string;
+    staticMethods?: boolean;
+}
+
+export interface Options {
     input: string | Record<string, any>;
     output: string;
+    serviceOptions?: ServiceOptions;
     httpClient?: HttpClient;
     useOptions?: boolean;
     useUnionTypes?: boolean;
@@ -23,7 +31,7 @@ export type Options = {
     postfix?: string;
     request?: string;
     write?: boolean;
-};
+}
 
 /**
  * Generate the OpenAPI client. This method will read the OpenAPI specification and based on the
@@ -55,6 +63,9 @@ export async function generate({
     postfix = 'Service',
     request,
     write = true,
+    serviceOptions = {
+        staticMethods: true,
+    },
 }: Options): Promise<void> {
     const openApi = isString(input) ? await getOpenApiSpec(input) : input;
     const openApiVersion = getOpenApiVersion(openApi);
@@ -81,6 +92,7 @@ export async function generate({
                 exportModels,
                 exportSchemas,
                 postfix,
+                serviceOptions,
                 request
             );
             break;
@@ -102,6 +114,7 @@ export async function generate({
                 exportModels,
                 exportSchemas,
                 postfix,
+                serviceOptions,
                 request
             );
             break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export interface ServiceOptions {
     serviceConstructor?: string;
     serviceDecorator?: string;
     staticMethods?: boolean;
+    serviceRequestContext?: string;
 }
 
 export interface Options {

--- a/src/templates/core/ApiRequestOptions.hbs
+++ b/src/templates/core/ApiRequestOptions.hbs
@@ -11,4 +11,5 @@ export type ApiRequestOptions = {
     readonly mediaType?: string;
     readonly responseHeader?: string;
     readonly errors?: Record<number, string>;
+    readonly context?: any;
 }

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -10,8 +10,17 @@ import { request as __request } from '../core/request';
 {{#if @root.useVersion}}
 import { OpenAPI } from '../core/OpenAPI';
 {{/if}}
+{{#if @root.serviceImports}}
+{{@root.serviceImports}}
+{{/if}}
 
+{{#if @root.serviceDecorator}}
+{{@root.serviceDecorator}}
+{{/if}}
 export class {{{name}}}{{{@root.postfix}}} {
+    {{#if @root.serviceConstructor}}
+    {{@root.serviceConstructor}}
+    {{/if}}
 
     {{#each operations}}
     /**
@@ -36,7 +45,7 @@ export class {{{name}}}{{{@root.postfix}}} {
     {{/each}}
      * @throws ApiError
      */
-    public static {{{name}}}({{>parameters}}): CancelablePromise<{{>result}}> {
+    public{{#if @root.staticMethods}} static{{/if}} {{{name}}}({{>parameters}}): CancelablePromise<{{>result}}> {
         return __request({
             method: '{{{method}}}',
             path: `{{{path}}}`,
@@ -88,6 +97,9 @@ export class {{{name}}}{{{@root.postfix}}} {
                 {{{code}}}: `{{{description}}}`,
                 {{/each}}
             },
+            {{/if}}
+            {{#if @root.serviceRequestContext}}
+            context: {{@root.serviceRequestContext}},
             {{/if}}
         });
     }

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -45,8 +45,8 @@ export class {{{name}}}{{{@root.postfix}}} {
     {{/each}}
      * @throws ApiError
      */
-    public{{#if @root.staticMethods}} static{{/if}} {{{name}}}({{>parameters}}): CancelablePromise<{{>result}}> {
-        return __request({
+    public{{#if @root.staticMethods}} static{{/if}} {{{name}}}({{>parameters}}) {
+        return __request<{{>result}}>({
             method: '{{{method}}}',
             path: `{{{path}}}`,
             {{#if parametersCookie}}

--- a/src/utils/writeClient.spec.ts
+++ b/src/utils/writeClient.spec.ts
@@ -32,7 +32,7 @@ describe('writeClient', () => {
             },
         };
 
-        await writeClient(client, templates, './dist', HttpClient.FETCH, false, false, true, true, true, true, '');
+        await writeClient(client, templates, './dist', HttpClient.FETCH, false, false, true, true, true, true, '', {});
 
         expect(rmdir).toBeCalled();
         expect(mkdir).toBeCalled();

--- a/src/utils/writeClient.ts
+++ b/src/utils/writeClient.ts
@@ -2,6 +2,7 @@ import { resolve } from 'path';
 
 import type { Client } from '../client/interfaces/Client';
 import { HttpClient } from '../HttpClient';
+import { ServiceOptions } from '../index';
 import { mkdir, rmdir } from './fileSystem';
 import { isSubDirectory } from './isSubdirectory';
 import { Templates } from './registerHandlebarTemplates';
@@ -39,6 +40,7 @@ export async function writeClient(
     exportModels: boolean,
     exportSchemas: boolean,
     postfix: string,
+    serviceOptions: ServiceOptions,
     request?: string
 ): Promise<void> {
     const outputPath = resolve(process.cwd(), output);
@@ -67,7 +69,8 @@ export async function writeClient(
             httpClient,
             useUnionTypes,
             useOptions,
-            postfix
+            postfix,
+            serviceOptions
         );
     }
 

--- a/src/utils/writeClientServices.spec.ts
+++ b/src/utils/writeClientServices.spec.ts
@@ -33,7 +33,7 @@ describe('writeClientServices', () => {
             },
         };
 
-        await writeClientServices(services, templates, '/', HttpClient.FETCH, false, false, 'Service');
+        await writeClientServices(services, templates, '/', HttpClient.FETCH, false, false, 'Service', {});
 
         expect(writeFile).toBeCalledWith('/UserService.ts', 'service');
     });

--- a/src/utils/writeClientServices.ts
+++ b/src/utils/writeClientServices.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path';
-import { ServiceOptions } from '..';
 
+import { ServiceOptions } from '..';
 import type { Service } from '../client/interfaces/Service';
 import { HttpClient } from '../HttpClient';
 import { writeFile } from './fileSystem';

--- a/src/utils/writeClientServices.ts
+++ b/src/utils/writeClientServices.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'path';
+import { ServiceOptions } from '..';
 
 import type { Service } from '../client/interfaces/Service';
 import { HttpClient } from '../HttpClient';
@@ -25,7 +26,8 @@ export async function writeClientServices(
     httpClient: HttpClient,
     useUnionTypes: boolean,
     useOptions: boolean,
-    postfix: string
+    postfix: string,
+    serviceOptions: ServiceOptions
 ): Promise<void> {
     for (const service of services) {
         const file = resolve(outputPath, `${service.name}${postfix}.ts`);
@@ -37,6 +39,7 @@ export async function writeClientServices(
             useVersion,
             useOptions,
             postfix,
+            ...serviceOptions,
         });
         await writeFile(file, format(templateResult));
     }

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -39,6 +39,7 @@ export type ApiRequestOptions = {
     readonly mediaType?: string;
     readonly responseHeader?: string;
     readonly errors?: Record<number, string>;
+    readonly context?: any;
 }"
 `;
 
@@ -2021,8 +2022,8 @@ export class CollectionFormatService {
         parameterArrayTsv: Array<string>,
         parameterArrayPipes: Array<string>,
         parameterArrayMulti: Array<string>,
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/collectionFormat\`,
             query: {
@@ -2064,8 +2065,8 @@ export class ComplexService {
             };
         },
         parameterReference: ModelWithString,
-    ): CancelablePromise<Array<ModelWithString>> {
-        return __request({
+    ) {
+        return __request<Array<ModelWithString>>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/complex\`,
             query: {
@@ -2109,8 +2110,8 @@ export class DefaultsService {
         parameterModel: ModelWithString = {
             \\"prop\\": \\"Hello World!\\"
         },
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/defaults\`,
             query: {
@@ -2139,8 +2140,8 @@ export class DefaultsService {
         parameterModel: ModelWithString = {
             \\"prop\\": \\"Hello World!\\"
         },
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/defaults\`,
             query: {
@@ -2173,8 +2174,8 @@ export class DefaultsService {
         parameterStringWithEmptyDefault: string = '',
         parameterStringNullableWithNoDefault?: string | null,
         parameterStringNullableWithDefault: string | null = null,
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'PUT',
             path: \`/api/v\${OpenAPI.VERSION}/defaults\`,
             query: {
@@ -2206,8 +2207,8 @@ export class DuplicateService {
     /**
      * @throws ApiError
      */
-    public static duplicateName(): CancelablePromise<void> {
-        return __request({
+    public static duplicateName() {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/duplicate\`,
         });
@@ -2216,8 +2217,8 @@ export class DuplicateService {
     /**
      * @throws ApiError
      */
-    public static duplicateName1(): CancelablePromise<void> {
-        return __request({
+    public static duplicateName1() {
+        return __request<void>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/duplicate\`,
         });
@@ -2226,8 +2227,8 @@ export class DuplicateService {
     /**
      * @throws ApiError
      */
-    public static duplicateName2(): CancelablePromise<void> {
-        return __request({
+    public static duplicateName2() {
+        return __request<void>({
             method: 'PUT',
             path: \`/api/v\${OpenAPI.VERSION}/duplicate\`,
         });
@@ -2236,8 +2237,8 @@ export class DuplicateService {
     /**
      * @throws ApiError
      */
-    public static duplicateName3(): CancelablePromise<void> {
-        return __request({
+    public static duplicateName3() {
+        return __request<void>({
             method: 'DELETE',
             path: \`/api/v\${OpenAPI.VERSION}/duplicate\`,
         });
@@ -2263,8 +2264,8 @@ export class ErrorService {
      */
     public static testErrorCode(
         status: string,
-    ): CancelablePromise<any> {
-        return __request({
+    ) {
+        return __request<any>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/error\`,
             query: {
@@ -2296,8 +2297,8 @@ export class HeaderService {
      * @returns string Successful response
      * @throws ApiError
      */
-    public static callWithResultFromHeader(): CancelablePromise<string> {
-        return __request({
+    public static callWithResultFromHeader() {
+        return __request<string>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/header\`,
             responseHeader: 'operation-location',
@@ -2325,8 +2326,8 @@ export class MultipleTags1Service {
      * @returns void
      * @throws ApiError
      */
-    public static dummyA(): CancelablePromise<void> {
-        return __request({
+    public static dummyA() {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/multiple-tags/a\`,
         });
@@ -2336,8 +2337,8 @@ export class MultipleTags1Service {
      * @returns void
      * @throws ApiError
      */
-    public static dummyB(): CancelablePromise<void> {
-        return __request({
+    public static dummyB() {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/multiple-tags/b\`,
         });
@@ -2360,8 +2361,8 @@ export class MultipleTags2Service {
      * @returns void
      * @throws ApiError
      */
-    public static dummyA(): CancelablePromise<void> {
-        return __request({
+    public static dummyA() {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/multiple-tags/a\`,
         });
@@ -2371,8 +2372,8 @@ export class MultipleTags2Service {
      * @returns void
      * @throws ApiError
      */
-    public static dummyB(): CancelablePromise<void> {
-        return __request({
+    public static dummyB() {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/multiple-tags/b\`,
         });
@@ -2395,8 +2396,8 @@ export class MultipleTags3Service {
      * @returns void
      * @throws ApiError
      */
-    public static dummyB(): CancelablePromise<void> {
-        return __request({
+    public static dummyB() {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/multiple-tags/b\`,
         });
@@ -2419,8 +2420,8 @@ export class NoContentService {
      * @returns void
      * @throws ApiError
      */
-    public static callWithNoContentResponse(): CancelablePromise<void> {
-        return __request({
+    public static callWithNoContentResponse() {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/no-content\`,
         });
@@ -2453,8 +2454,8 @@ export class ParametersService {
         parameterForm: string,
         parameterBody: string,
         parameterPath: string,
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/parameters/\${parameterPath}\`,
             headers: {
@@ -2490,8 +2491,8 @@ export class ParametersService {
         parameterPath2?: string,
         parameterPath3?: string,
         _default?: string,
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/parameters/\${parameterPath1}/\${parameterPath2}/\${parameterPath3}\`,
             headers: {
@@ -2528,8 +2529,8 @@ export class ResponseService {
      * @returns ModelWithString Message for default response
      * @throws ApiError
      */
-    public static callWithResponse(): CancelablePromise<ModelWithString> {
-        return __request({
+    public static callWithResponse() {
+        return __request<ModelWithString>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/response\`,
         });
@@ -2539,8 +2540,8 @@ export class ResponseService {
      * @returns ModelWithString Message for default response
      * @throws ApiError
      */
-    public static callWithDuplicateResponses(): CancelablePromise<ModelWithString> {
-        return __request({
+    public static callWithDuplicateResponses() {
+        return __request<ModelWithString>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/response\`,
             errors: {
@@ -2558,12 +2559,12 @@ export class ResponseService {
      * @returns ModelThatExtendsExtends Message for 202 response
      * @throws ApiError
      */
-    public static callWithResponses(): CancelablePromise<{
-        readonly '@namespace.string'?: string;
-        readonly '@namespace.integer'?: number;
-        readonly value?: Array<ModelWithString>;
-    } | ModelWithString | ModelThatExtends | ModelThatExtendsExtends> {
-        return __request({
+    public static callWithResponses() {
+        return __request<{
+            readonly '@namespace.string'?: string;
+            readonly '@namespace.integer'?: number;
+            readonly value?: Array<ModelWithString>;
+        } | ModelWithString | ModelThatExtends | ModelThatExtendsExtends>({
             method: 'PUT',
             path: \`/api/v\${OpenAPI.VERSION}/response\`,
             errors: {
@@ -2590,8 +2591,8 @@ export class SimpleService {
     /**
      * @throws ApiError
      */
-    public static getCallWithoutParametersAndResponse(): CancelablePromise<void> {
-        return __request({
+    public static getCallWithoutParametersAndResponse() {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/simple\`,
         });
@@ -2600,8 +2601,8 @@ export class SimpleService {
     /**
      * @throws ApiError
      */
-    public static putCallWithoutParametersAndResponse(): CancelablePromise<void> {
-        return __request({
+    public static putCallWithoutParametersAndResponse() {
+        return __request<void>({
             method: 'PUT',
             path: \`/api/v\${OpenAPI.VERSION}/simple\`,
         });
@@ -2610,8 +2611,8 @@ export class SimpleService {
     /**
      * @throws ApiError
      */
-    public static postCallWithoutParametersAndResponse(): CancelablePromise<void> {
-        return __request({
+    public static postCallWithoutParametersAndResponse() {
+        return __request<void>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/simple\`,
         });
@@ -2620,8 +2621,8 @@ export class SimpleService {
     /**
      * @throws ApiError
      */
-    public static deleteCallWithoutParametersAndResponse(): CancelablePromise<void> {
-        return __request({
+    public static deleteCallWithoutParametersAndResponse() {
+        return __request<void>({
             method: 'DELETE',
             path: \`/api/v\${OpenAPI.VERSION}/simple\`,
         });
@@ -2630,8 +2631,8 @@ export class SimpleService {
     /**
      * @throws ApiError
      */
-    public static optionsCallWithoutParametersAndResponse(): CancelablePromise<void> {
-        return __request({
+    public static optionsCallWithoutParametersAndResponse() {
+        return __request<void>({
             method: 'OPTIONS',
             path: \`/api/v\${OpenAPI.VERSION}/simple\`,
         });
@@ -2640,8 +2641,8 @@ export class SimpleService {
     /**
      * @throws ApiError
      */
-    public static headCallWithoutParametersAndResponse(): CancelablePromise<void> {
-        return __request({
+    public static headCallWithoutParametersAndResponse() {
+        return __request<void>({
             method: 'HEAD',
             path: \`/api/v\${OpenAPI.VERSION}/simple\`,
         });
@@ -2650,8 +2651,8 @@ export class SimpleService {
     /**
      * @throws ApiError
      */
-    public static patchCallWithoutParametersAndResponse(): CancelablePromise<void> {
-        return __request({
+    public static patchCallWithoutParametersAndResponse() {
+        return __request<void>({
             method: 'PATCH',
             path: \`/api/v\${OpenAPI.VERSION}/simple\`,
         });
@@ -2694,8 +2695,8 @@ export class TypesService {
         parameterBoolean: boolean = true,
         parameterObject: any = null,
         id?: number,
-    ): CancelablePromise<number | string | boolean | any> {
-        return __request({
+    ) {
+        return __request<number | string | boolean | any>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/types\`,
             query: {
@@ -2752,6 +2753,7 @@ export type ApiRequestOptions = {
     readonly mediaType?: string;
     readonly responseHeader?: string;
     readonly errors?: Record<number, string>;
+    readonly context?: any;
 }"
 `;
 
@@ -5311,8 +5313,8 @@ export class CollectionFormatService {
         parameterArrayTsv: Array<string> | null,
         parameterArrayPipes: Array<string> | null,
         parameterArrayMulti: Array<string> | null,
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/collectionFormat\`,
             query: {
@@ -5357,8 +5359,8 @@ export class ComplexService {
             };
         },
         parameterReference: ModelWithString,
-    ): CancelablePromise<Array<ModelWithString>> {
-        return __request({
+    ) {
+        return __request<Array<ModelWithString>>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/complex\`,
             query: {
@@ -5393,8 +5395,8 @@ export class ComplexService {
                 readonly name?: string | null;
             };
         },
-    ): CancelablePromise<ModelWithString> {
-        return __request({
+    ) {
+        return __request<ModelWithString>({
             method: 'PUT',
             path: \`/api/v\${OpenAPI.VERSION}/complex/\${id}\`,
             body: requestBody,
@@ -5432,8 +5434,8 @@ export class DefaultsService {
         parameterModel: ModelWithString | null = {
             \\"prop\\": \\"Hello World!\\"
         },
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/defaults\`,
             query: {
@@ -5462,8 +5464,8 @@ export class DefaultsService {
         parameterModel: ModelWithString = {
             \\"prop\\": \\"Hello World!\\"
         },
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/defaults\`,
             query: {
@@ -5496,8 +5498,8 @@ export class DefaultsService {
         parameterStringWithEmptyDefault: string = '',
         parameterStringNullableWithNoDefault?: string | null,
         parameterStringNullableWithDefault: string | null = null,
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'PUT',
             path: \`/api/v\${OpenAPI.VERSION}/defaults\`,
             query: {
@@ -5529,8 +5531,8 @@ export class DuplicateService {
     /**
      * @throws ApiError
      */
-    public static duplicateName(): CancelablePromise<void> {
-        return __request({
+    public static duplicateName() {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/duplicate\`,
         });
@@ -5539,8 +5541,8 @@ export class DuplicateService {
     /**
      * @throws ApiError
      */
-    public static duplicateName1(): CancelablePromise<void> {
-        return __request({
+    public static duplicateName1() {
+        return __request<void>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/duplicate\`,
         });
@@ -5549,8 +5551,8 @@ export class DuplicateService {
     /**
      * @throws ApiError
      */
-    public static duplicateName2(): CancelablePromise<void> {
-        return __request({
+    public static duplicateName2() {
+        return __request<void>({
             method: 'PUT',
             path: \`/api/v\${OpenAPI.VERSION}/duplicate\`,
         });
@@ -5559,8 +5561,8 @@ export class DuplicateService {
     /**
      * @throws ApiError
      */
-    public static duplicateName3(): CancelablePromise<void> {
-        return __request({
+    public static duplicateName3() {
+        return __request<void>({
             method: 'DELETE',
             path: \`/api/v\${OpenAPI.VERSION}/duplicate\`,
         });
@@ -5586,8 +5588,8 @@ export class ErrorService {
      */
     public static testErrorCode(
         status: number,
-    ): CancelablePromise<any> {
-        return __request({
+    ) {
+        return __request<any>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/error\`,
             query: {
@@ -5624,8 +5626,8 @@ export class FormDataService {
     public static postFormData(
         parameter?: string,
         formData?: ModelWithString,
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/formData/\`,
             query: {
@@ -5653,8 +5655,8 @@ export class HeaderService {
      * @returns string Successful response
      * @throws ApiError
      */
-    public static callWithResultFromHeader(): CancelablePromise<string> {
-        return __request({
+    public static callWithResultFromHeader() {
+        return __request<string>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/header\`,
             responseHeader: 'operation-location',
@@ -5688,8 +5690,8 @@ export class MultipartService {
             content?: Blob;
             data?: ModelWithString | null;
         },
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/multipart\`,
             formData: formData,
@@ -5701,14 +5703,14 @@ export class MultipartService {
      * @returns any OK
      * @throws ApiError
      */
-    public static multipartResponse(): CancelablePromise<{
-        file?: Blob;
-        metadata?: {
-            foo?: string;
-            bar?: string;
-        };
-    }> {
-        return __request({
+    public static multipartResponse() {
+        return __request<{
+            file?: Blob;
+            metadata?: {
+                foo?: string;
+                bar?: string;
+            };
+        }>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/multipart\`,
         });
@@ -5731,8 +5733,8 @@ export class MultipleTags1Service {
      * @returns void
      * @throws ApiError
      */
-    public static dummyA(): CancelablePromise<void> {
-        return __request({
+    public static dummyA() {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/multiple-tags/a\`,
         });
@@ -5742,8 +5744,8 @@ export class MultipleTags1Service {
      * @returns void
      * @throws ApiError
      */
-    public static dummyB(): CancelablePromise<void> {
-        return __request({
+    public static dummyB() {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/multiple-tags/b\`,
         });
@@ -5766,8 +5768,8 @@ export class MultipleTags2Service {
      * @returns void
      * @throws ApiError
      */
-    public static dummyA(): CancelablePromise<void> {
-        return __request({
+    public static dummyA() {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/multiple-tags/a\`,
         });
@@ -5777,8 +5779,8 @@ export class MultipleTags2Service {
      * @returns void
      * @throws ApiError
      */
-    public static dummyB(): CancelablePromise<void> {
-        return __request({
+    public static dummyB() {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/multiple-tags/b\`,
         });
@@ -5801,8 +5803,8 @@ export class MultipleTags3Service {
      * @returns void
      * @throws ApiError
      */
-    public static dummyB(): CancelablePromise<void> {
-        return __request({
+    public static dummyB() {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/multiple-tags/b\`,
         });
@@ -5825,8 +5827,8 @@ export class NoContentService {
      * @returns void
      * @throws ApiError
      */
-    public static callWithNoContentResponse(): CancelablePromise<void> {
-        return __request({
+    public static callWithNoContentResponse() {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/no-content\`,
         });
@@ -5862,8 +5864,8 @@ export class ParametersService {
         parameterCookie: string | null,
         parameterPath: string | null,
         requestBody: ModelWithString | null,
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/parameters/\${parameterPath}\`,
             cookies: {
@@ -5905,8 +5907,8 @@ export class ParametersService {
         parameterPath2?: string,
         parameterPath3?: string,
         _default?: string,
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/parameters/\${parameterPath1}/\${parameterPath2}/\${parameterPath3}\`,
             cookies: {
@@ -5935,8 +5937,8 @@ export class ParametersService {
     public static getCallWithOptionalParam(
         requestBody: ModelWithString,
         parameter?: string,
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/parameters/\`,
             query: {
@@ -5955,8 +5957,8 @@ export class ParametersService {
     public static postCallWithOptionalParam(
         parameter: string,
         requestBody?: ModelWithString,
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/parameters/\`,
             query: {
@@ -5989,8 +5991,8 @@ export class RequestBodyService {
     public static postRequestBody(
         parameter?: string,
         requestBody?: ModelWithString,
-    ): CancelablePromise<void> {
-        return __request({
+    ) {
+        return __request<void>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/requestBody/\`,
             query: {
@@ -6021,8 +6023,8 @@ export class ResponseService {
      * @returns ModelWithString
      * @throws ApiError
      */
-    public static callWithResponse(): CancelablePromise<ModelWithString> {
-        return __request({
+    public static callWithResponse() {
+        return __request<ModelWithString>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/response\`,
         });
@@ -6032,8 +6034,8 @@ export class ResponseService {
      * @returns ModelWithString Message for default response
      * @throws ApiError
      */
-    public static callWithDuplicateResponses(): CancelablePromise<ModelWithString> {
-        return __request({
+    public static callWithDuplicateResponses() {
+        return __request<ModelWithString>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/response\`,
             errors: {
@@ -6051,12 +6053,12 @@ export class ResponseService {
      * @returns ModelThatExtendsExtends Message for 202 response
      * @throws ApiError
      */
-    public static callWithResponses(): CancelablePromise<{
-        readonly '@namespace.string'?: string;
-        readonly '@namespace.integer'?: number;
-        readonly value?: Array<ModelWithString>;
-    } | ModelWithString | ModelThatExtends | ModelThatExtendsExtends> {
-        return __request({
+    public static callWithResponses() {
+        return __request<{
+            readonly '@namespace.string'?: string;
+            readonly '@namespace.integer'?: number;
+            readonly value?: Array<ModelWithString>;
+        } | ModelWithString | ModelThatExtends | ModelThatExtendsExtends>({
             method: 'PUT',
             path: \`/api/v\${OpenAPI.VERSION}/response\`,
             errors: {
@@ -6083,8 +6085,8 @@ export class SimpleService {
     /**
      * @throws ApiError
      */
-    public static getCallWithoutParametersAndResponse(): CancelablePromise<void> {
-        return __request({
+    public static getCallWithoutParametersAndResponse() {
+        return __request<void>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/simple\`,
         });
@@ -6093,8 +6095,8 @@ export class SimpleService {
     /**
      * @throws ApiError
      */
-    public static putCallWithoutParametersAndResponse(): CancelablePromise<void> {
-        return __request({
+    public static putCallWithoutParametersAndResponse() {
+        return __request<void>({
             method: 'PUT',
             path: \`/api/v\${OpenAPI.VERSION}/simple\`,
         });
@@ -6103,8 +6105,8 @@ export class SimpleService {
     /**
      * @throws ApiError
      */
-    public static postCallWithoutParametersAndResponse(): CancelablePromise<void> {
-        return __request({
+    public static postCallWithoutParametersAndResponse() {
+        return __request<void>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/simple\`,
         });
@@ -6113,8 +6115,8 @@ export class SimpleService {
     /**
      * @throws ApiError
      */
-    public static deleteCallWithoutParametersAndResponse(): CancelablePromise<void> {
-        return __request({
+    public static deleteCallWithoutParametersAndResponse() {
+        return __request<void>({
             method: 'DELETE',
             path: \`/api/v\${OpenAPI.VERSION}/simple\`,
         });
@@ -6123,8 +6125,8 @@ export class SimpleService {
     /**
      * @throws ApiError
      */
-    public static optionsCallWithoutParametersAndResponse(): CancelablePromise<void> {
-        return __request({
+    public static optionsCallWithoutParametersAndResponse() {
+        return __request<void>({
             method: 'OPTIONS',
             path: \`/api/v\${OpenAPI.VERSION}/simple\`,
         });
@@ -6133,8 +6135,8 @@ export class SimpleService {
     /**
      * @throws ApiError
      */
-    public static headCallWithoutParametersAndResponse(): CancelablePromise<void> {
-        return __request({
+    public static headCallWithoutParametersAndResponse() {
+        return __request<void>({
             method: 'HEAD',
             path: \`/api/v\${OpenAPI.VERSION}/simple\`,
         });
@@ -6143,8 +6145,8 @@ export class SimpleService {
     /**
      * @throws ApiError
      */
-    public static patchCallWithoutParametersAndResponse(): CancelablePromise<void> {
-        return __request({
+    public static patchCallWithoutParametersAndResponse() {
+        return __request<void>({
             method: 'PATCH',
             path: \`/api/v\${OpenAPI.VERSION}/simple\`,
         });
@@ -6187,8 +6189,8 @@ export class TypesService {
         parameterBoolean: boolean | null = true,
         parameterObject: any = null,
         id?: number,
-    ): CancelablePromise<number | string | boolean | any> {
-        return __request({
+    ) {
+        return __request<number | string | boolean | any>({
             method: 'GET',
             path: \`/api/v\${OpenAPI.VERSION}/types\`,
             query: {
@@ -6223,8 +6225,8 @@ export class UploadService {
      */
     public static uploadFile(
         file: Blob,
-    ): CancelablePromise<boolean> {
-        return __request({
+    ) {
+        return __request<boolean>({
             method: 'POST',
             path: \`/api/v\${OpenAPI.VERSION}/upload\`,
             formData: {

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,15 @@ const generate = async (input, output) => {
         exportServices: true,
         // postfix: 'Api',
         // request: './test/custom/request.ts',
+        // serviceOptions: {
+        //     staticMethods: false,
+        //     serviceImports: `
+        //     import {Injectable} from '@angular/core';
+        //     import {HttpClient} from '@angular/common/http';
+        //     `,
+        //     serviceDecorator: `@Injectable()`,
+        //     serviceConstructor: `constructor(private http: HttpClient) {}`,
+        // },
     });
 };
 


### PR DESCRIPTION
Hey Ferdi! I hope you are doing well!
First I'm very glad to see that this super handy library keeps growing and improving 🚀  Keep up the awesome work!
I'm willing to use this in my new project but it needs a little bit tuning though. So what's not enough already? Well for angular I need to have these generated service classes a little bit different. Btw it works as is also with angular but you need to compromise on angular's http service and dependency injection mechanism which makes angular devs unhappy 😭 . I also appreciate the framework agnostic structure of the current project so I have added few extension points to the exportService template where the user can inject additional code and finally an injectable angular service using http client is possible.

More details see the open issue #936 
