### PR TITLE
Add support for empty model properties that are valid in OpenAPI

### DIFF
--- a/src/openApi/v3/parser/escapeName.ts
+++ b/src/openApi/v3/parser/escapeName.ts
@@ -1,5 +1,5 @@
 export const escapeName = (value: string): string => {
-    if (value) {
+    if (value || value === '') {
         const validName = /^[a-zA-Z_$][\w$]+$/g.test(value);
         if (!validName) {
             return `'${value}'`;


### PR DESCRIPTION
Generate valid typescript definitions for models with empty properties

YAML example:
```yaml
FooBarModel:
  type: object
  required:
  - all
  properties:
    all: !ref self.AnotherModel
    foo: !ref self.AnotherModel
    bar: !ref self.AnotherModel
    '': !ref self.AnotherModel
```

Example above generates invalid TS type in current implementation because empty string is not escaped:
```typescript
export type FooBarModel = {
  all: AnotherModel;
  clay?: AnotherModel;
  hardcourt?: AnotherModel;
  indoor?: AnotherModel;
  grass?: AnotherModel;
  ?: AnotherModel;
};
```

What It should generate:
```typescript
export type FooBarModel = {
    all: AnotherModel;
    clay?: AnotherModel;
    hardcourt?: AnotherModel;
    indoor?: AnotherModel;
    grass?: AnotherModel;
    ''?: AnotherModel;
};
```

