### PR TITLE
Fixes a bug that prevented using complex dictionaries within compositions

### DIFF
--- a/src/openApi/v3/parser/getModelComposition.ts
+++ b/src/openApi/v3/parser/getModelComposition.ts
@@ -31,8 +31,9 @@ export const getModelComposition = (
             const hasProperties = model.properties.length;
             const hasEnums = model.enums.length;
             const isObject = model.type === 'any';
+            const isDictionary = model.export === 'dictionary';
             const isEmpty = isObject && !hasProperties && !hasEnums;
-            return !isEmpty;
+            return !isEmpty || isDictionary;
         })
         .forEach(model => {
             composition.imports.push(...model.imports);

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -3507,7 +3507,10 @@ export type { CompositionWithAnyOf } from './models/CompositionWithAnyOf';
 export type { CompositionWithAnyOfAndNullable } from './models/CompositionWithAnyOfAndNullable';
 export type { CompositionWithAnyOfAnonymous } from './models/CompositionWithAnyOfAnonymous';
 export type { CompositionWithOneOf } from './models/CompositionWithOneOf';
+export type { CompositionWithOneOfAndComplexArrayDictionary } from './models/CompositionWithOneOfAndComplexArrayDictionary';
 export type { CompositionWithOneOfAndNullable } from './models/CompositionWithOneOfAndNullable';
+export type { CompositionWithOneOfAndSimpleArrayDictionary } from './models/CompositionWithOneOfAndSimpleArrayDictionary';
+export type { CompositionWithOneOfAndSimpleDictionary } from './models/CompositionWithOneOfAndSimpleDictionary';
 export type { CompositionWithOneOfAnonymous } from './models/CompositionWithOneOfAnonymous';
 export type { CompositionWithOneOfDiscriminator } from './models/CompositionWithOneOfDiscriminator';
 export type { DictionaryWithArray } from './models/DictionaryWithArray';
@@ -3568,7 +3571,10 @@ export { $CompositionWithAnyOf } from './schemas/$CompositionWithAnyOf';
 export { $CompositionWithAnyOfAndNullable } from './schemas/$CompositionWithAnyOfAndNullable';
 export { $CompositionWithAnyOfAnonymous } from './schemas/$CompositionWithAnyOfAnonymous';
 export { $CompositionWithOneOf } from './schemas/$CompositionWithOneOf';
+export { $CompositionWithOneOfAndComplexArrayDictionary } from './schemas/$CompositionWithOneOfAndComplexArrayDictionary';
 export { $CompositionWithOneOfAndNullable } from './schemas/$CompositionWithOneOfAndNullable';
+export { $CompositionWithOneOfAndSimpleArrayDictionary } from './schemas/$CompositionWithOneOfAndSimpleArrayDictionary';
+export { $CompositionWithOneOfAndSimpleDictionary } from './schemas/$CompositionWithOneOfAndSimpleDictionary';
 export { $CompositionWithOneOfAnonymous } from './schemas/$CompositionWithOneOfAnonymous';
 export { $CompositionWithOneOfDiscriminator } from './schemas/$CompositionWithOneOfDiscriminator';
 export { $DictionaryWithArray } from './schemas/$DictionaryWithArray';
@@ -3902,6 +3908,20 @@ export type CompositionWithOneOf = {
 "
 `;
 
+exports[`v3 should generate: ./test/generated/v3/models/CompositionWithOneOfAndComplexArrayDictionary.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model that contains a dictionary of complex arrays (composited) within composition
+ */
+export type CompositionWithOneOfAndComplexArrayDictionary = {
+    propA?: (boolean | Record<string, Array<(number | string)>>);
+};
+"
+`;
+
 exports[`v3 should generate: ./test/generated/v3/models/CompositionWithOneOfAndNullable.ts 1`] = `
 "/* istanbul ignore file */
 /* tslint:disable */
@@ -3918,6 +3938,34 @@ export type CompositionWithOneOfAndNullable = {
     propA?: ({
         boolean?: boolean;
     } | ModelWithEnum | ModelWithArray | ModelWithDictionary) | null;
+};
+"
+`;
+
+exports[`v3 should generate: ./test/generated/v3/models/CompositionWithOneOfAndSimpleArrayDictionary.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model that contains a dictionary of simple arrays within composition
+ */
+export type CompositionWithOneOfAndSimpleArrayDictionary = {
+    propA?: (boolean | Record<string, Array<boolean>>);
+};
+"
+`;
+
+exports[`v3 should generate: ./test/generated/v3/models/CompositionWithOneOfAndSimpleDictionary.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model that contains a simple dictionary within composition
+ */
+export type CompositionWithOneOfAndSimpleDictionary = {
+    propA?: (boolean | Record<string, number>);
 };
 "
 `;
@@ -4928,6 +4976,36 @@ export const $CompositionWithOneOf = {
 } as const;"
 `;
 
+exports[`v3 should generate: ./test/generated/v3/schemas/$CompositionWithOneOfAndComplexArrayDictionary.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithOneOfAndComplexArrayDictionary = {
+    description: \`This is a model that contains a dictionary of complex arrays (composited) within composition\`,
+    properties: {
+        propA: {
+            type: 'one-of',
+            contains: [{
+                type: 'boolean',
+            }, {
+                type: 'dictionary',
+                contains: {
+                    type: 'array',
+                    contains: {
+                        type: 'one-of',
+                        contains: [{
+                            type: 'number',
+                        }, {
+                            type: 'string',
+                        }],
+                    },
+                },
+            }],
+        },
+    },
+} as const;"
+`;
+
 exports[`v3 should generate: ./test/generated/v3/schemas/$CompositionWithOneOfAndNullable.ts 1`] = `
 "/* istanbul ignore file */
 /* tslint:disable */
@@ -4951,6 +5029,53 @@ export const $CompositionWithOneOfAndNullable = {
                 type: 'ModelWithDictionary',
             }],
             isNullable: true,
+        },
+    },
+} as const;"
+`;
+
+exports[`v3 should generate: ./test/generated/v3/schemas/$CompositionWithOneOfAndSimpleArrayDictionary.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithOneOfAndSimpleArrayDictionary = {
+    description: \`This is a model that contains a dictionary of simple arrays within composition\`,
+    properties: {
+        propA: {
+            type: 'one-of',
+            contains: [{
+                type: 'boolean',
+            }, {
+                type: 'dictionary',
+                contains: {
+                    type: 'array',
+                    contains: {
+                        type: 'boolean',
+                    },
+                },
+            }],
+        },
+    },
+} as const;"
+`;
+
+exports[`v3 should generate: ./test/generated/v3/schemas/$CompositionWithOneOfAndSimpleDictionary.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithOneOfAndSimpleDictionary = {
+    description: \`This is a model that contains a simple dictionary within composition\`,
+    properties: {
+        propA: {
+            type: 'one-of',
+            contains: [{
+                type: 'boolean',
+            }, {
+                type: 'dictionary',
+                contains: {
+                    type: 'number',
+                },
+            }],
         },
     },
 } as const;"

--- a/test/spec/v3.json
+++ b/test/spec/v3.json
@@ -2064,6 +2064,76 @@
                     }
                 }
             },
+            "CompositionWithOneOfAndSimpleDictionary": {
+                "description": "This is a model that contains a simple dictionary within composition",
+                "type": "object",
+                "properties": {
+                    "propA": {
+                        "oneOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "number"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "CompositionWithOneOfAndSimpleArrayDictionary": {
+                "description": "This is a model that contains a dictionary of simple arrays within composition",
+                "type": "object",
+                "properties": {
+                    "propA": {
+                        "oneOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "CompositionWithOneOfAndComplexArrayDictionary": {
+                "description": "This is a model that contains a dictionary of complex arrays (composited) within composition",
+                "type": "object",
+                "properties": {
+                    "propA": {
+                        "oneOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "array",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
             "CompositionWithAllOfAndNullable": {
                 "description": "This is a model with one property with a 'all of' relationship",
                 "type": "object",


### PR DESCRIPTION
Fixes #964.

In case of "simple" dictionary (`Record<string, number>` or `Record<string,array<number>>`, model.type was set to `number` in `parser/getModel.ts` function. But in case of composite, `type` was  not explicitly set and defaulted to `any`.

I didn't want to change this type in the `getModel` function, as it might have some other implications, so I just added another check in when to ignore a model within composition.

Added 3 more test objects to the suite, so it covers all three cases.