### PR TITLE
Make BaseHttpRequest abstract

### DIFF
--- a/src/templates/core/BaseHttpRequest.hbs
+++ b/src/templates/core/BaseHttpRequest.hbs
@@ -12,7 +12,7 @@ import type { CancelablePromise } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
 {{/equals}}
 
-export class BaseHttpRequest {
+export abstract class BaseHttpRequest {
 
 	{{#equals @root.httpClient 'angular'}}
 	constructor(
@@ -24,12 +24,8 @@ export class BaseHttpRequest {
 	{{/equals}}
 
 	{{#equals @root.httpClient 'angular'}}
-	public request<T>(options: ApiRequestOptions): Observable<T> {
-		throw new Error('Not Implemented');
-	}
+	public abstract request<T>(options: ApiRequestOptions): Observable<T>;
 	{{else}}
-	public request<T>(options: ApiRequestOptions): CancelablePromise<T> {
-		throw new Error('Not Implemented');
-	}
+	public abstract request<T>(options: ApiRequestOptions): CancelablePromise<T>;
 	{{/equals}}
 }


### PR DESCRIPTION
Makes `BaseHttpRequest` abstract:

* it's (at least to my understanding) obviously not meant for direct instantiation
* the current version will trigger a TS compile error `TS6133` when option `noUnusedParameters: true` is set for the unused `options` argument
* (alternatively, this could be fixed by renaming it to `_options`)