### PR TITLE
Preserve modules and declarations in build & distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     },
     "files": [
         "bin/index.js",
-        "dist/index.js",
+        "dist",
         "types/index.d.ts"
     ],
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "scripts": {
         "clean": "rimraf ./dist ./test/generated ./test/e2e/generated ./samples/generated ./coverage ./node_modules/.cache",
         "build": "rollup --config --environment NODE_ENV:development",
+        "postbuild": "rsync -am --include='*.d.ts' --include='*/' --exclude='*' ./src/ ./dist",
         "build:watch": "rollup --config --environment NODE_ENV:development --watch",
         "release": "rollup --config --environment NODE_ENV:production",
         "validate": "tsc --project tsconfig.json --noEmit",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -57,6 +57,7 @@ const getPlugins = () => {
         handlebarsPlugin(),
         typescript({
             module: 'esnext',
+            declaration: true,
         }),
     ];
     if (process.env.NODE_ENV === 'development') {
@@ -69,8 +70,9 @@ export default {
     input: './src/index.ts',
     output: {
         exports: 'named',
-        file: './dist/index.js',
+        dir: './dist',
         format: 'cjs',
+        preserveModules: true,
     },
     plugins: getPlugins(),
 };


### PR DESCRIPTION
First of all, excellent library, it was a pleasure to work with the parsed meta data from `parse()`. Thanks!

For the services output, I wanted to generate only functions (instead of classes with methods). This is efficient in terms of tree-shakeability of the resulting functions (and hooks). We previously had a solution in which we post-process the output files of this library, but by using `parse()` and the returned meta data directly, we can use our own templates to generate services and hooks very efficiently.

I've read #427. Still, I'd love to propose this PR that results in a non-bundled `dist` folder and the TS declaration files.

As it stands, I believe it's basically negligible in terms of additional costs of maintenance or performance. I've ran all tests and also used this on my own (fairly large) project without issues.

Obviously when people use internal modules from this package things may break when file names and/or structure would change (but personally I'd have no issues with this). As a follow-up you might want to consider exposing (only) the `parse` function(s), allowing to use custom templates with the results. I think this may result in folks using this library in new and interesting ways, without sacrificing the original spirit and intent.

Thanks for considering this, feel free to close it as you see fit. Then I'll likely fork and publish this version if you don't mind.