### PR TITLE
Use type-only imports for `axios`

### DIFF
--- a/src/templates/core/axios/request.hbs
+++ b/src/templates/core/axios/request.hbs
@@ -1,6 +1,6 @@
 {{>header}}
 
-import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios, { AxiosError, type AxiosRequestConfig, type AxiosResponse } from 'axios';
 import FormData from 'form-data';
 
 import { ApiError } from './ApiError';


### PR DESCRIPTION
Hey there! I encountered TypeScript error while using your amazing project: type checker complains about imported types in clients generated for `axios` backend.

<img width="741" alt="Screenshot 2022-05-03 at 17 24 39" src="https://user-images.githubusercontent.com/75225148/166472416-0201d9ef-1b28-47e4-b031-57ba32823635.png">

In this PR I changed the template for request file relevant to `axios`: now `AxiosRequestConfig` and `AxiosResponse` symbols are being imported as types.

Type-only imports: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export