### PR TITLE
Pdf file request with response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## unreleased
+### Fixed
+- Fixed binary response type to process as a Blob rather than text/string (#986)
+- Use type-only imports for axios (#1037)
+
 ## [0.22.0] - 2022-04-26
 ### Fixed
 - Upgraded dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 
 ## unreleased
+### Added
+- Added `requestApiResult` as additional request function
+### Changed
+- Changed ApiResult to be generic and also contain response header
 ### Fixed
 - Fixed binary response type to process as a Blob rather than text/string (#986)
 - Use type-only imports for axios (#1037)

--- a/src/openApi/v2/parser/getOperation.ts
+++ b/src/openApi/v2/parser/getOperation.ts
@@ -1,5 +1,6 @@
 import type { Operation } from '../../../client/interfaces/Operation';
 import type { OperationParameters } from '../../../client/interfaces/OperationParameters';
+import type { OperationResponse } from '../../../client/interfaces/OperationResponse';
 import type { OpenApi } from '../interfaces/OpenApi';
 import type { OpenApiOperation } from '../interfaces/OpenApiOperation';
 import { getOperationErrors } from './getOperationErrors';
@@ -10,6 +11,10 @@ import { getOperationResponses } from './getOperationResponses';
 import { getOperationResults } from './getOperationResults';
 import { getServiceName } from './getServiceName';
 import { sortByRequired } from './sortByRequired';
+
+const getOperationResultsWithoutHeader = (operationResults: OperationResponse[]) => {
+    return operationResults.filter(operationResult => operationResult.in !== 'header');
+};
 
 export const getOperation = (
     openApi: OpenApi,
@@ -63,8 +68,9 @@ export const getOperation = (
         const operationResults = getOperationResults(operationResponses);
         operation.errors = getOperationErrors(operationResponses);
         operation.responseHeader = getOperationResponseHeader(operationResults);
+        const operationResultsWithoutHeader = getOperationResultsWithoutHeader(operationResults);
 
-        operationResults.forEach(operationResult => {
+        operationResultsWithoutHeader.forEach(operationResult => {
             operation.results.push(operationResult);
             operation.imports.push(...operationResult.imports);
         });

--- a/src/openApi/v2/parser/getOperationResponse.ts
+++ b/src/openApi/v2/parser/getOperationResponse.ts
@@ -7,12 +7,8 @@ import { getModel } from './getModel';
 import { getRef } from './getRef';
 import { getType } from './getType';
 
-export const getOperationResponse = (
-    openApi: OpenApi,
-    response: OpenApiResponse,
-    responseCode: number
-): OperationResponse => {
-    const operationResponse: OperationResponse = {
+const getDefaultOperationResponse = (responseCode: number, response: OpenApiResponse): OperationResponse => {
+    return {
         in: 'response',
         name: '',
         code: responseCode,
@@ -31,6 +27,14 @@ export const getOperationResponse = (
         enums: [],
         properties: [],
     };
+};
+
+export const getOperationResponseContent = (
+    openApi: OpenApi,
+    response: OpenApiResponse,
+    responseCode: number
+): OperationResponse => {
+    const operationResponse = getDefaultOperationResponse(responseCode, response);
 
     // If this response has a schema, then we need to check two things:
     // if this is a reference then the parameter is just the 'name' of
@@ -80,6 +84,15 @@ export const getOperationResponse = (
             return operationResponse;
         }
     }
+    return operationResponse;
+};
+
+export const getOperationResponseHeaders = (
+    openApi: OpenApi,
+    response: OpenApiResponse,
+    responseCode: number
+): OperationResponse | null => {
+    const operationResponse = getDefaultOperationResponse(responseCode, response);
 
     // We support basic properties from response headers, since both
     // fetch and XHR client just support string types.
@@ -94,6 +107,5 @@ export const getOperationResponse = (
             }
         }
     }
-
-    return operationResponse;
+    return null;
 };

--- a/src/openApi/v2/parser/getOperationResponses.ts
+++ b/src/openApi/v2/parser/getOperationResponses.ts
@@ -2,7 +2,7 @@ import type { OperationResponse } from '../../../client/interfaces/OperationResp
 import type { OpenApi } from '../interfaces/OpenApi';
 import type { OpenApiResponse } from '../interfaces/OpenApiResponse';
 import type { OpenApiResponses } from '../interfaces/OpenApiResponses';
-import { getOperationResponse } from './getOperationResponse';
+import { getOperationResponseContent, getOperationResponseHeaders } from './getOperationResponse';
 import { getOperationResponseCode } from './getOperationResponseCode';
 import { getRef } from './getRef';
 
@@ -18,8 +18,12 @@ export const getOperationResponses = (openApi: OpenApi, responses: OpenApiRespon
             const responseCode = getOperationResponseCode(code);
 
             if (responseCode) {
-                const operationResponse = getOperationResponse(openApi, response, responseCode);
-                operationResponses.push(operationResponse);
+                const operationResponseContent = getOperationResponseContent(openApi, response, responseCode);
+                operationResponses.push(operationResponseContent);
+                const operationResponseHeaders = getOperationResponseHeaders(openApi, response, responseCode);
+                if (operationResponseHeaders !== null) {
+                    operationResponses.push(operationResponseHeaders);
+                }
             }
         }
     }

--- a/src/openApi/v3/parser/getOperation.ts
+++ b/src/openApi/v3/parser/getOperation.ts
@@ -1,5 +1,6 @@
 import type { Operation } from '../../../client/interfaces/Operation';
 import type { OperationParameters } from '../../../client/interfaces/OperationParameters';
+import type { OperationResponse } from '../../../client/interfaces/OperationResponse';
 import type { OpenApi } from '../interfaces/OpenApi';
 import type { OpenApiOperation } from '../interfaces/OpenApiOperation';
 import type { OpenApiRequestBody } from '../interfaces/OpenApiRequestBody';
@@ -13,6 +14,10 @@ import { getOperationResults } from './getOperationResults';
 import { getRef } from './getRef';
 import { getServiceName } from './getServiceName';
 import { sortByRequired } from './sortByRequired';
+
+const getOperationResultsWithoutHeader = (operationResults: OperationResponse[]) => {
+    return operationResults.filter(operationResult => operationResult.in !== 'header');
+};
 
 export const getOperation = (
     openApi: OpenApi,
@@ -74,8 +79,9 @@ export const getOperation = (
         const operationResults = getOperationResults(operationResponses);
         operation.errors = getOperationErrors(operationResponses);
         operation.responseHeader = getOperationResponseHeader(operationResults);
+        const operationResultsWithoutHeader = getOperationResultsWithoutHeader(operationResults);
 
-        operationResults.forEach(operationResult => {
+        operationResultsWithoutHeader.forEach(operationResult => {
             operation.results.push(operationResult);
             operation.imports.push(...operationResult.imports);
         });

--- a/src/openApi/v3/parser/getOperationResponse.ts
+++ b/src/openApi/v3/parser/getOperationResponse.ts
@@ -34,7 +34,7 @@ export const getOperationResponseContent = (
     openApi: OpenApi,
     response: OpenApiResponse,
     responseCode: number
-): OperationResponse | null => {
+): OperationResponse => {
     const operationResponse = getDefaultOperationResponse(responseCode, response);
 
     if (response.content) {
@@ -83,7 +83,7 @@ export const getOperationResponseContent = (
             }
         }
     }
-    return null;
+    return operationResponse;
 };
 
 export const getOperationResponseHeaders = (

--- a/src/openApi/v3/parser/getOperationResponse.ts
+++ b/src/openApi/v3/parser/getOperationResponse.ts
@@ -8,12 +8,8 @@ import { getModel } from './getModel';
 import { getRef } from './getRef';
 import { getType } from './getType';
 
-export const getOperationResponse = (
-    openApi: OpenApi,
-    response: OpenApiResponse,
-    responseCode: number
-): OperationResponse => {
-    const operationResponse: OperationResponse = {
+const getDefaultOperationResponse = (responseCode: number, response: OpenApiResponse): OperationResponse => {
+    return {
         in: 'response',
         name: '',
         code: responseCode,
@@ -32,6 +28,14 @@ export const getOperationResponse = (
         enums: [],
         properties: [],
     };
+};
+
+export const getOperationResponseContent = (
+    openApi: OpenApi,
+    response: OpenApiResponse,
+    responseCode: number
+): OperationResponse | null => {
+    const operationResponse = getDefaultOperationResponse(responseCode, response);
 
     if (response.content) {
         const content = getContent(openApi, response.content);
@@ -79,6 +83,15 @@ export const getOperationResponse = (
             }
         }
     }
+    return null;
+};
+
+export const getOperationResponseHeaders = (
+    openApi: OpenApi,
+    response: OpenApiResponse,
+    responseCode: number
+): OperationResponse | null => {
+    const operationResponse = getDefaultOperationResponse(responseCode, response);
 
     // We support basic properties from response headers, since both
     // fetch and XHR client just support string types.
@@ -93,6 +106,5 @@ export const getOperationResponse = (
             }
         }
     }
-
-    return operationResponse;
+    return null;
 };

--- a/src/openApi/v3/parser/getOperationResponses.ts
+++ b/src/openApi/v3/parser/getOperationResponses.ts
@@ -19,9 +19,7 @@ export const getOperationResponses = (openApi: OpenApi, responses: OpenApiRespon
 
             if (responseCode) {
                 const operationResponseContent = getOperationResponseContent(openApi, response, responseCode);
-                if (operationResponseContent !== null) {
-                    operationResponses.push(operationResponseContent);
-                }
+                operationResponses.push(operationResponseContent);
                 const operationResponseHeaders = getOperationResponseHeaders(openApi, response, responseCode);
                 if (operationResponseHeaders !== null) {
                     operationResponses.push(operationResponseHeaders);

--- a/src/openApi/v3/parser/getOperationResponses.ts
+++ b/src/openApi/v3/parser/getOperationResponses.ts
@@ -2,7 +2,7 @@ import type { OperationResponse } from '../../../client/interfaces/OperationResp
 import type { OpenApi } from '../interfaces/OpenApi';
 import type { OpenApiResponse } from '../interfaces/OpenApiResponse';
 import type { OpenApiResponses } from '../interfaces/OpenApiResponses';
-import { getOperationResponse } from './getOperationResponse';
+import { getOperationResponseContent, getOperationResponseHeaders } from './getOperationResponse';
 import { getOperationResponseCode } from './getOperationResponseCode';
 import { getRef } from './getRef';
 
@@ -18,8 +18,14 @@ export const getOperationResponses = (openApi: OpenApi, responses: OpenApiRespon
             const responseCode = getOperationResponseCode(code);
 
             if (responseCode) {
-                const operationResponse = getOperationResponse(openApi, response, responseCode);
-                operationResponses.push(operationResponse);
+                const operationResponseContent = getOperationResponseContent(openApi, response, responseCode);
+                if (operationResponseContent !== null) {
+                    operationResponses.push(operationResponseContent);
+                }
+                const operationResponseHeaders = getOperationResponseHeaders(openApi, response, responseCode);
+                if (operationResponseHeaders !== null) {
+                    operationResponses.push(operationResponseHeaders);
+                }
             }
         }
     }

--- a/src/templates/core/ApiError.hbs
+++ b/src/templates/core/ApiError.hbs
@@ -8,7 +8,7 @@ export class ApiError extends Error {
 	public readonly statusText: string;
 	public readonly body: any;
 
-	constructor(response: ApiResult, message: string) {
+	constructor(response: ApiResult<any>, message: string) {
 		super(message);
 
 		this.name = 'ApiError';

--- a/src/templates/core/ApiRequestOptions.hbs
+++ b/src/templates/core/ApiRequestOptions.hbs
@@ -10,6 +10,7 @@ export type ApiRequestOptions = {
 	readonly formData?: Record<string, any>;
 	readonly body?: any;
 	readonly mediaType?: string;
+	readonly responseType?: 'blob';
 	readonly responseHeader?: string;
 	readonly errors?: Record<number, string>;
 };

--- a/src/templates/core/ApiResult.hbs
+++ b/src/templates/core/ApiResult.hbs
@@ -1,10 +1,10 @@
 {{>header}}
 
-export type ApiResult = {
+export type ApiResult<T> = {
 	readonly url: string;
 	readonly ok: boolean;
 	readonly status: number;
 	readonly statusText: string;
-	readonly body: any;
+	readonly body: T;
 	readonly header: string | undefined;
 };

--- a/src/templates/core/ApiResult.hbs
+++ b/src/templates/core/ApiResult.hbs
@@ -6,4 +6,5 @@ export type ApiResult = {
 	readonly status: number;
 	readonly statusText: string;
 	readonly body: any;
+	readonly header: string | undefined;
 };

--- a/src/templates/core/BaseHttpRequest.hbs
+++ b/src/templates/core/BaseHttpRequest.hbs
@@ -27,9 +27,9 @@ export abstract class BaseHttpRequest {
 
 	{{#equals @root.httpClient 'angular'}}
 	public abstract request<T>(options: ApiRequestOptions): Observable<T>;
-	public abstract requestWithResponseHeader<T>(options: ApiRequestOptions): Observable<ApiResult>;
+	public abstract requestApiResult<T>(options: ApiRequestOptions): Observable<ApiResult<T>>;
 	{{else}}
 	public abstract request<T>(options: ApiRequestOptions): CancelablePromise<T>;
-	public abstract requestWithResponseHeader<T>(options: ApiRequestOptions): CancelablePromise<ApiResult>;
+	public abstract requestApiResult<T>(options: ApiRequestOptions): CancelablePromise<ApiResult<T>>;
 	{{/equals}}
 }

--- a/src/templates/core/BaseHttpRequest.hbs
+++ b/src/templates/core/BaseHttpRequest.hbs
@@ -5,9 +5,11 @@ import type { HttpClient } from '@angular/common/http';
 import type { Observable } from 'rxjs';
 
 import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
 import type { OpenAPIConfig } from './OpenAPI';
 {{else}}
 import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
 import type { CancelablePromise } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
 {{/equals}}
@@ -25,7 +27,9 @@ export abstract class BaseHttpRequest {
 
 	{{#equals @root.httpClient 'angular'}}
 	public abstract request<T>(options: ApiRequestOptions): Observable<T>;
+	public abstract requestWithResponseHeader<T>(options: ApiRequestOptions): Observable<ApiResult>;
 	{{else}}
 	public abstract request<T>(options: ApiRequestOptions): CancelablePromise<T>;
+	public abstract requestWithResponseHeader<T>(options: ApiRequestOptions): CancelablePromise<ApiResult>;
 	{{/equals}}
 }

--- a/src/templates/core/HttpRequest.hbs
+++ b/src/templates/core/HttpRequest.hbs
@@ -10,14 +10,14 @@ import type { ApiResult } from './ApiResult';
 import { BaseHttpRequest } from './BaseHttpRequest';
 import type { OpenAPIConfig } from './OpenAPI';
 import { OpenAPI } from './OpenAPI';
-import { request as __request } from './request';
+import { request as __request, requestApiResult as __requestApiResult } from './request';
 {{else}}
 import type { ApiRequestOptions } from './ApiRequestOptions';
 import type { ApiResult } from './ApiResult';
 import { BaseHttpRequest } from './BaseHttpRequest';
 import type { CancelablePromise } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
-import { request as __request, requestWithResponseHeader as __requestWithResponseHeader } from './request';
+import { request as __request, requestApiResult as __requestApiResult } from './request';
 {{/equals}}
 
 {{#equals @root.httpClient 'angular'}}
@@ -52,11 +52,11 @@ export class {{httpRequest}} extends BaseHttpRequest {
 	/**
 	 * Request method with ResponseHeader
 	 * @param options The request options from the service
-	 * @returns Observable<ApiResult>
+	 * @returns Observable<ApiResult<T>>
 	 * @throws ApiError
 	 */
-	public override requestWithResponseHeader<T>(options: ApiRequestOptions): Observable<ApiResult> {
-		return __requestWithResponseHeader(this.config, this.http, options);
+	public override requestApiResult<T>(options: ApiRequestOptions): Observable<ApiResult<T>> {
+		return __requestApiResult(this.config, this.http, options);
 	}
 	{{else}}
 	/**
@@ -71,11 +71,11 @@ export class {{httpRequest}} extends BaseHttpRequest {
 	/**
 	 * Request method with ResponseHeader
 	 * @param options The request options from the service
-	 * @returns CancelablePromise<ApiResult>
+	 * @returns CancelablePromise<ApiResult<T>>
 	 * @throws ApiError
 	 */
-	public override requestWithResponseHeader<T>(options: ApiRequestOptions): CancelablePromise<ApiResult> {
-		return __requestWithResponseHeader(this.config, options);
+	public override requestApiResult<T>(options: ApiRequestOptions): CancelablePromise<ApiResult<T>> {
+		return __requestApiResult(this.config, options);
 	}
 	{{/equals}}
 }

--- a/src/templates/core/HttpRequest.hbs
+++ b/src/templates/core/HttpRequest.hbs
@@ -6,16 +6,18 @@ import { HttpClient } from '@angular/common/http';
 import type { Observable } from 'rxjs';
 
 import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
 import { BaseHttpRequest } from './BaseHttpRequest';
 import type { OpenAPIConfig } from './OpenAPI';
 import { OpenAPI } from './OpenAPI';
 import { request as __request } from './request';
 {{else}}
 import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
 import { BaseHttpRequest } from './BaseHttpRequest';
 import type { CancelablePromise } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
-import { request as __request } from './request';
+import { request as __request, requestWithResponseHeader as __requestWithResponseHeader } from './request';
 {{/equals}}
 
 {{#equals @root.httpClient 'angular'}}
@@ -47,6 +49,15 @@ export class {{httpRequest}} extends BaseHttpRequest {
 	public override request<T>(options: ApiRequestOptions): Observable<T> {
 		return __request(this.config, this.http, options);
 	}
+	/**
+	 * Request method with ResponseHeader
+	 * @param options The request options from the service
+	 * @returns Observable<ApiResult>
+	 * @throws ApiError
+	 */
+	public override requestWithResponseHeader<T>(options: ApiRequestOptions): Observable<ApiResult> {
+		return __requestWithResponseHeader(this.config, this.http, options);
+	}
 	{{else}}
 	/**
 	 * Request method
@@ -56,6 +67,15 @@ export class {{httpRequest}} extends BaseHttpRequest {
 	 */
 	public override request<T>(options: ApiRequestOptions): CancelablePromise<T> {
 		return __request(this.config, options);
+	}
+	/**
+	 * Request method with ResponseHeader
+	 * @param options The request options from the service
+	 * @returns CancelablePromise<ApiResult>
+	 * @throws ApiError
+	 */
+	public override requestWithResponseHeader<T>(options: ApiRequestOptions): CancelablePromise<ApiResult> {
+		return __requestWithResponseHeader(this.config, options);
 	}
 	{{/equals}}
 }

--- a/src/templates/core/angular/request.hbs
+++ b/src/templates/core/angular/request.hbs
@@ -60,6 +60,57 @@ import type { OpenAPIConfig } from './OpenAPI';
 
 
 /**
+ * Request method with header
+ * @param config The OpenAPI configuration object
+ * @param http The Angular HTTP client
+ * @param options The request options from the service
+ * @returns Observable<ApiResult<T>>
+ * @throws ApiError
+ */
+export const requestApiResult = <T>(config: OpenAPIConfig, http: HttpClient, options: ApiRequestOptions): Observable<ApiResult<T>> => {
+	const url = getUrl(config, options);
+	const formData = getFormData(options);
+	const body = getRequestBody(options);
+
+	return getHeaders(config, options).pipe(
+		switchMap(headers => {
+			return sendRequest<T>(config, options, http, url, formData, body, headers);
+		}),
+		map(response => {
+			const responseBody = getResponseBody(response);
+			const responseHeader = getResponseHeader(response, options.responseHeader);
+			return {
+				url,
+				ok: response.ok,
+				status: response.status,
+				statusText: response.statusText,
+				body: responseBody,
+				header: responseHeader,
+			} as ApiResult<T>;
+		}),
+		catchError((error: HttpErrorResponse) => {
+			if (!error.status) {
+				return throwError(error);
+			}
+			return of({
+				url,
+				ok: error.ok,
+				status: error.status,
+				statusText: error.statusText,
+				body: error.error ?? error.statusText,
+			} as ApiResult<T>);
+		}),
+		map(result => {
+			catchErrorCodes(options, result);
+			return result as ApiResult<T>;
+		}),
+		catchError((error: ApiError) => {
+			return throwError(error);
+		}),
+	);
+};
+
+/**
  * Request method
  * @param config The OpenAPI configuration object
  * @param http The Angular HTTP client
@@ -84,8 +135,9 @@ export const request = <T>(config: OpenAPIConfig, http: HttpClient, options: Api
 				ok: response.ok,
 				status: response.status,
 				statusText: response.statusText,
-				body: responseHeader ?? responseBody,
-			} as ApiResult;
+				body: responseBody,
+				header: responseHeader,
+			} as ApiResult<T>;
 		}),
 		catchError((error: HttpErrorResponse) => {
 			if (!error.status) {
@@ -97,7 +149,7 @@ export const request = <T>(config: OpenAPIConfig, http: HttpClient, options: Api
 				status: error.status,
 				statusText: error.statusText,
 				body: error.error ?? error.statusText,
-			} as ApiResult);
+			} as ApiResult<T>);
 		}),
 		map(result => {
 			catchErrorCodes(options, result);

--- a/src/templates/core/angular/sendRequest.hbs
+++ b/src/templates/core/angular/sendRequest.hbs
@@ -7,10 +7,11 @@ export const sendRequest = <T>(
 	formData: FormData | undefined,
 	headers: HttpHeaders
 ): Observable<HttpResponse<T>> => {
-	return http.request<T>(options.method, url, {
+	return http.request(options.method, url, {
 		headers,
 		body: body ?? formData,
 		withCredentials: config.WITH_CREDENTIALS,
 		observe: 'response',
+		responseType: options.responseType,
 	});
 };

--- a/src/templates/core/axios/request.hbs
+++ b/src/templates/core/axios/request.hbs
@@ -1,6 +1,6 @@
 {{>header}}
 
-import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios, { AxiosError, type AxiosRequestConfig, type AxiosResponse } from 'axios';
 import FormData from 'form-data';
 
 import { ApiError } from './ApiError';

--- a/src/templates/core/axios/request.hbs
+++ b/src/templates/core/axios/request.hbs
@@ -106,14 +106,14 @@ export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: Api
  * @throws ApiError
  */
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
-    return new CancelablePromise(async (resolve, reject, onCancel) => {
-        try {
-            if (!onCancel.isCancelled) {
-                const result = await requestWithResponseHeader(config, options)
-                resolve(result.body)
-            }
-        } catch (error) {
-            reject(error);
-        }
-    });
+	return new CancelablePromise(async (resolve, reject, onCancel) => {
+		try {
+			if (!onCancel.isCancelled) {
+				const result = await requestWithResponseHeader(config, options)
+				resolve(result.body)
+			}
+		} catch (error) {
+			reject(error);
+		}
+	});
 };

--- a/src/templates/core/axios/request.hbs
+++ b/src/templates/core/axios/request.hbs
@@ -59,13 +59,13 @@ import type { OpenAPIConfig } from './OpenAPI';
 
 
 /**
- * Request method
+ * Request method with header
  * @param config The OpenAPI configuration object
  * @param options The request options from the service
- * @returns CancelablePromise<T>
+ * @returns CancelablePromise<ApiResult>
  * @throws ApiError
  */
-export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult> => {
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
 			const url = getUrl(config, options);
@@ -83,15 +83,37 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
 					ok: isSuccess(response.status),
 					status: response.status,
 					statusText: response.statusText,
-					body: responseHeader ?? responseBody,
+					body: responseBody,
+					header: responseHeader,
 				};
 
 				catchErrorCodes(options, result);
 
-				resolve(result.body);
+				resolve(result);
 			}
 		} catch (error) {
 			reject(error);
 		}
 	});
+};
+
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+    return new CancelablePromise(async (resolve, reject, onCancel) => {
+        try {
+            if (!onCancel.isCancelled) {
+                const result = await requestWithResponseHeader(config, options)
+                resolve(result.body)
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
 };

--- a/src/templates/core/axios/request.hbs
+++ b/src/templates/core/axios/request.hbs
@@ -59,13 +59,13 @@ import type { OpenAPIConfig } from './OpenAPI';
 
 
 /**
- * Request method with header
+ * Request method to get ApiResult
  * @param config The OpenAPI configuration object
  * @param options The request options from the service
- * @returns CancelablePromise<ApiResult>
+ * @returns CancelablePromise<ApiResult<T>>
  * @throws ApiError
  */
-export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult> => {
+export const requestApiResult = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult<T>> => {
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
 			const url = getUrl(config, options);
@@ -78,7 +78,7 @@ export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: Api
 				const responseBody = getResponseBody(response);
 				const responseHeader = getResponseHeader(response, options.responseHeader);
 
-				const result: ApiResult = {
+				const result: ApiResult<T> = {
 					url,
 					ok: isSuccess(response.status),
 					status: response.status,
@@ -109,7 +109,7 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
 			if (!onCancel.isCancelled) {
-				const result = await requestWithResponseHeader(config, options)
+				const result = await requestApiResult<T>(config, options)
 				resolve(result.body)
 			}
 		} catch (error) {

--- a/src/templates/core/axios/sendRequest.hbs
+++ b/src/templates/core/axios/sendRequest.hbs
@@ -15,6 +15,7 @@ const sendRequest = async <T>(
 		data: body ?? formData,
 		method: options.method,
 		withCredentials: config.WITH_CREDENTIALS,
+		responseType: options.responseType,
 		cancelToken: source.token,
 	};
 

--- a/src/templates/core/fetch/getResponseBody.hbs
+++ b/src/templates/core/fetch/getResponseBody.hbs
@@ -1,4 +1,4 @@
-const getResponseBody = async (response: Response): Promise<any> => {
+const getResponseBody = async (response: Response, options: ApiRequestOptions): Promise<any> => {
 	if (response.status !== 204) {
 		try {
 			const contentType = response.headers.get('Content-Type');
@@ -6,6 +6,8 @@ const getResponseBody = async (response: Response): Promise<any> => {
 				const isJSON = contentType.toLowerCase().startsWith('application/json');
 				if (isJSON) {
 					return await response.json();
+				} else if (options.responseType === 'blob') {
+					return await response.blob();
 				} else {
 					return await response.text();
 				}

--- a/src/templates/core/fetch/request.hbs
+++ b/src/templates/core/fetch/request.hbs
@@ -72,7 +72,7 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
 
 			if (!onCancel.isCancelled) {
 				const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
-				const responseBody = await getResponseBody(response);
+				const responseBody = await getResponseBody(response, options);
 				const responseHeader = getResponseHeader(response, options.responseHeader);
 
 				const result: ApiResult = {

--- a/src/templates/core/fetch/request.hbs
+++ b/src/templates/core/fetch/request.hbs
@@ -102,14 +102,14 @@ export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: Api
  * @throws ApiError
  */
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
-    return new CancelablePromise(async (resolve, reject, onCancel) => {
-        try {
-            if (!onCancel.isCancelled) {
-                const result = await requestWithResponseHeader(config, options)
-                resolve(result.body)
-            }
-        } catch (error) {
-            reject(error);
-        }
-    });
+	return new CancelablePromise(async (resolve, reject, onCancel) => {
+		try {
+			if (!onCancel.isCancelled) {
+				const result = await requestWithResponseHeader(config, options)
+				resolve(result.body)
+			}
+		} catch (error) {
+			reject(error);
+		}
+	});
 };

--- a/src/templates/core/fetch/request.hbs
+++ b/src/templates/core/fetch/request.hbs
@@ -56,13 +56,13 @@ import type { OpenAPIConfig } from './OpenAPI';
 
 
 /**
- * Request method with header
+ * Request method to get ApiResult
  * @param config The OpenAPI configuration object
  * @param options The request options from the service
- * @returns CancelablePromise<ApiResult>
+ * @returns CancelablePromise<ApiResult<T>>
  * @throws ApiError
  */
-export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult> => {
+export const requestApiResult = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult<T>> => {
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
 			const url = getUrl(config, options);
@@ -75,7 +75,7 @@ export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: Api
 				const responseBody = await getResponseBody(response, options);
 				const responseHeader = getResponseHeader(response, options.responseHeader);
 
-				const result: ApiResult = {
+				const result: ApiResult<T> = {
 					url,
 					ok: response.ok,
 					status: response.status,
@@ -105,7 +105,7 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
 			if (!onCancel.isCancelled) {
-				const result = await requestWithResponseHeader(config, options)
+				const result = await requestApiResult<T>(config, options)
 				resolve(result.body)
 			}
 		} catch (error) {

--- a/src/templates/core/fetch/request.hbs
+++ b/src/templates/core/fetch/request.hbs
@@ -56,13 +56,13 @@ import type { OpenAPIConfig } from './OpenAPI';
 
 
 /**
- * Request method
+ * Request method with header
  * @param config The OpenAPI configuration object
  * @param options The request options from the service
- * @returns CancelablePromise<T>
+ * @returns CancelablePromise<ApiResult>
  * @throws ApiError
  */
-export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult> => {
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
 			const url = getUrl(config, options);
@@ -80,15 +80,36 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
 					ok: response.ok,
 					status: response.status,
 					statusText: response.statusText,
-					body: responseHeader ?? responseBody,
+					body: responseBody,
+					header: responseHeader,
 				};
 
 				catchErrorCodes(options, result);
 
-				resolve(result.body);
+				resolve(result);
 			}
 		} catch (error) {
 			reject(error);
 		}
 	});
+};
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+    return new CancelablePromise(async (resolve, reject, onCancel) => {
+        try {
+            if (!onCancel.isCancelled) {
+                const result = await requestWithResponseHeader(config, options)
+                resolve(result.body)
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
 };

--- a/src/templates/core/functions/catchErrorCodes.hbs
+++ b/src/templates/core/functions/catchErrorCodes.hbs
@@ -1,4 +1,4 @@
-const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
+const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult<any>): void => {
 	const errors: Record<number, string> = {
 		400: 'Bad Request',
 		401: 'Unauthorized',

--- a/src/templates/core/node/getResponseBody.hbs
+++ b/src/templates/core/node/getResponseBody.hbs
@@ -1,4 +1,4 @@
-const getResponseBody = async (response: Response): Promise<any> => {
+const getResponseBody = async (response: Response, options: ApiRequestOptions): Promise<any> => {
 	if (response.status !== 204) {
 		try {
 			const contentType = response.headers.get('Content-Type');
@@ -6,6 +6,8 @@ const getResponseBody = async (response: Response): Promise<any> => {
 				const isJSON = contentType.toLowerCase().startsWith('application/json');
 				if (isJSON) {
 					return await response.json();
+				} else if (options.responseType === 'blob') {
+					return await response.blob();
 				} else {
 					return await response.text();
 				}

--- a/src/templates/core/node/request.hbs
+++ b/src/templates/core/node/request.hbs
@@ -59,13 +59,13 @@ import type { OpenAPIConfig } from './OpenAPI';
 
 
 /**
- * Request method with header
+ * Request method to get ApiResult
  * @param config The OpenAPI configuration object
  * @param options The request options from the service
- * @returns CancelablePromise<ApiResult>
+ * @returns CancelablePromise<ApiResult<T>>
  * @throws ApiError
  */
-export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult> => {
+export const requestApiResult = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult<T>> => {
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
 			const url = getUrl(config, options);
@@ -78,7 +78,7 @@ export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: Api
 				const responseBody = await getResponseBody(response, options);
 				const responseHeader = getResponseHeader(response, options.responseHeader);
 
-				const result: ApiResult = {
+				const result: ApiResult<T> = {
 					url,
 					ok: response.ok,
 					status: response.status,
@@ -108,7 +108,7 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
 			if (!onCancel.isCancelled) {
-				const result = await requestWithResponseHeader(config, options)
+				const result = await requestApiResult<T>(config, options)
 				resolve(result.body)
 			}
 		} catch (error) {

--- a/src/templates/core/node/request.hbs
+++ b/src/templates/core/node/request.hbs
@@ -105,15 +105,15 @@ export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: Api
  * @throws ApiError
  */
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
-    return new CancelablePromise(async (resolve, reject, onCancel) => {
-        try {
-            if (!onCancel.isCancelled) {
-                const result = await requestWithResponseHeader(config, options)
-                resolve(result.body)
-            }
-        } catch (error) {
-            reject(error);
-        }
-    });
+	return new CancelablePromise(async (resolve, reject, onCancel) => {
+		try {
+			if (!onCancel.isCancelled) {
+				const result = await requestWithResponseHeader(config, options)
+				resolve(result.body)
+			}
+		} catch (error) {
+			reject(error);
+		}
+	});
 };
 

--- a/src/templates/core/node/request.hbs
+++ b/src/templates/core/node/request.hbs
@@ -75,7 +75,7 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
 
 			if (!onCancel.isCancelled) {
 				const response = await sendRequest(options, url, body, formData, headers, onCancel);
-				const responseBody = await getResponseBody(response);
+				const responseBody = await getResponseBody(response, options);
 				const responseHeader = getResponseHeader(response, options.responseHeader);
 
 				const result: ApiResult = {

--- a/src/templates/core/node/request.hbs
+++ b/src/templates/core/node/request.hbs
@@ -59,13 +59,13 @@ import type { OpenAPIConfig } from './OpenAPI';
 
 
 /**
- * Request method
+ * Request method with header
  * @param config The OpenAPI configuration object
  * @param options The request options from the service
- * @returns CancelablePromise<T>
+ * @returns CancelablePromise<ApiResult>
  * @throws ApiError
  */
-export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult> => {
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
 			const url = getUrl(config, options);
@@ -83,15 +83,37 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
 					ok: response.ok,
 					status: response.status,
 					statusText: response.statusText,
-					body: responseHeader ?? responseBody,
+					body: responseBody,
+					header: responseHeader,
 				};
 
 				catchErrorCodes(options, result);
 
-				resolve(result.body);
+				resolve(result);
 			}
 		} catch (error) {
 			reject(error);
 		}
 	});
 };
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+    return new CancelablePromise(async (resolve, reject, onCancel) => {
+        try {
+            if (!onCancel.isCancelled) {
+                const result = await requestWithResponseHeader(config, options)
+                resolve(result.body)
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+};
+

--- a/src/templates/core/xhr/getResponseBody.hbs
+++ b/src/templates/core/xhr/getResponseBody.hbs
@@ -1,4 +1,4 @@
-const getResponseBody = (xhr: XMLHttpRequest): any => {
+const getResponseBody = (xhr: XMLHttpRequest, options: ApiRequestOptions): any => {
 	if (xhr.status !== 204) {
 		try {
 			const contentType = xhr.getResponseHeader('Content-Type');
@@ -6,6 +6,8 @@ const getResponseBody = (xhr: XMLHttpRequest): any => {
 				const isJSON = contentType.toLowerCase().startsWith('application/json');
 				if (isJSON) {
 					return JSON.parse(xhr.responseText);
+				} else if (options.responseType === 'blob') {
+					return xhr.response;
 				} else {
 					return xhr.responseText;
 				}

--- a/src/templates/core/xhr/request.hbs
+++ b/src/templates/core/xhr/request.hbs
@@ -75,7 +75,7 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
 
 			if (!onCancel.isCancelled) {
 				const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
-				const responseBody = getResponseBody(response);
+				const responseBody = getResponseBody(response, options);
 				const responseHeader = getResponseHeader(response, options.responseHeader);
 
 				const result: ApiResult = {

--- a/src/templates/core/xhr/request.hbs
+++ b/src/templates/core/xhr/request.hbs
@@ -105,14 +105,14 @@ export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: Api
  * @throws ApiError
  */
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
-    return new CancelablePromise(async (resolve, reject, onCancel) => {
-        try {
-            if (!onCancel.isCancelled) {
-                const result = await requestWithResponseHeader(config, options)
-                resolve(result.body)
-            }
-        } catch (error) {
-            reject(error);
-        }
-    });
+	return new CancelablePromise(async (resolve, reject, onCancel) => {
+		try {
+			if (!onCancel.isCancelled) {
+				const result = await requestWithResponseHeader(config, options)
+				resolve(result.body)
+			}
+		} catch (error) {
+			reject(error);
+		}
+	});
 };

--- a/src/templates/core/xhr/request.hbs
+++ b/src/templates/core/xhr/request.hbs
@@ -59,13 +59,13 @@ import type { OpenAPIConfig } from './OpenAPI';
 
 
 /**
- * Request method with header
+ * Request method to get ApiResult
  * @param config The OpenAPI configuration object
  * @param options The request options from the service
- * @returns CancelablePromise<ApiResult>
+ * @returns CancelablePromise<ApiResult<T>>
  * @throws ApiError
  */
-export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult> => {
+export const requestApiResult = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult<T>> => {
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
 			const url = getUrl(config, options);
@@ -78,7 +78,7 @@ export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: Api
 				const responseBody = getResponseBody(response, options);
 				const responseHeader = getResponseHeader(response, options.responseHeader);
 
-				const result: ApiResult = {
+				const result: ApiResult<T> = {
 					url,
 					ok: isSuccess(response.status),
 					status: response.status,
@@ -108,7 +108,7 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
 			if (!onCancel.isCancelled) {
-				const result = await requestWithResponseHeader(config, options)
+				const result = await requestApiResult<T>(config, options)
 				resolve(result.body)
 			}
 		} catch (error) {

--- a/src/templates/core/xhr/request.hbs
+++ b/src/templates/core/xhr/request.hbs
@@ -59,13 +59,13 @@ import type { OpenAPIConfig } from './OpenAPI';
 
 
 /**
- * Request method
+ * Request method with header
  * @param config The OpenAPI configuration object
  * @param options The request options from the service
- * @returns CancelablePromise<T>
+ * @returns CancelablePromise<ApiResult>
  * @throws ApiError
  */
-export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult> => {
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
 			const url = getUrl(config, options);
@@ -83,15 +83,36 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
 					ok: isSuccess(response.status),
 					status: response.status,
 					statusText: response.statusText,
-					body: responseHeader ?? responseBody,
+					body: responseBody,
+					header: responseHeader,
 				};
 
 				catchErrorCodes(options, result);
 
-				resolve(result.body);
+				resolve(result);
 			}
 		} catch (error) {
 			reject(error);
 		}
 	});
+};
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+    return new CancelablePromise(async (resolve, reject, onCancel) => {
+        try {
+            if (!onCancel.isCancelled) {
+                const result = await requestWithResponseHeader(config, options)
+                resolve(result.body)
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
 };

--- a/src/templates/core/xhr/sendRequest.hbs
+++ b/src/templates/core/xhr/sendRequest.hbs
@@ -10,6 +10,7 @@ export const sendRequest = async (
 	const xhr = new XMLHttpRequest();
 	xhr.open(options.method, url, true);
 	xhr.withCredentials = config.WITH_CREDENTIALS;
+	xhr.responseType = options.responseType;
 
 	headers.forEach((value, key) => {
 		xhr.setRequestHeader(key, value);

--- a/src/templates/core/xhr/sendRequest.hbs
+++ b/src/templates/core/xhr/sendRequest.hbs
@@ -10,7 +10,7 @@ export const sendRequest = async (
 	const xhr = new XMLHttpRequest();
 	xhr.open(options.method, url, true);
 	xhr.withCredentials = config.WITH_CREDENTIALS;
-	xhr.responseType = options.responseType;
+	xhr.responseType = options.responseType ?? "";
 
 	headers.forEach((value, key) => {
 		xhr.setRequestHeader(key, value);

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -133,6 +133,9 @@ export class {{{name}}}{{{@root.postfix}}} {
 			mediaType: '{{{parametersBody.mediaType}}}',
 			{{/if}}
 			{{/if}}
+			{{#if results}}
+				{{>responseType}}
+			{{/if}}
 			{{#if responseHeader}}
 			responseHeader: '{{{responseHeader}}}',
 			{{/if}}

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -23,12 +23,16 @@ import type { CancelablePromise } from '../core/CancelablePromise';
 {{#if @root.exportClient}}
 {{#equals @root.httpClient 'angular'}}
 import { BaseHttpRequest } from '../core/BaseHttpRequest';
+import type { ApiResult } from '../core/ApiResult';
 {{else}}
 import type { BaseHttpRequest } from '../core/BaseHttpRequest';
+import type { ApiResult } from '../core/ApiResult';
 {{/equals}}
 {{else}}
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestWithResponseHeader as __requestWithResponseHeader } from '../core/request';
 {{/if}}
 
 {{#equals @root.httpClient 'angular'}}
@@ -73,16 +77,26 @@ export class {{{name}}}{{{@root.postfix}}} {
 	public {{{name}}}({{>parameters}}): Observable<{{>result}}> {
 		return this.httpRequest.request({
 	{{else}}
+		{{#if responseHeader}}
+	public {{{name}}}({{>parameters}}): CancelablePromise<ApiResult> {
+		return this.httpRequest.requestWithResponseHeader({
+		{{else}}
 	public {{{name}}}({{>parameters}}): CancelablePromise<{{>result}}> {
 		return this.httpRequest.request({
+		{{/if}}
 	{{/equals}}
 	{{else}}
 	{{#equals @root.httpClient 'angular'}}
 	public {{{name}}}({{>parameters}}): Observable<{{>result}}> {
 		return __request(OpenAPI, this.http, {
 	{{else}}
+		{{#if responseHeader}}
+	public {{{name}}}({{>parameters}}): CancelablePromise<ApiResult> {
+		return __requestWithResponseHeader(OpenAPI, {
+		{{else}}
 	public static {{{name}}}({{>parameters}}): CancelablePromise<{{>result}}> {
 		return __request(OpenAPI, {
+		{{/if}}
 	{{/equals}}
 	{{/if}}
 			method: '{{{method}}}',

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -32,7 +32,7 @@ import type { ApiResult } from '../core/ApiResult';
 import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
-import { requestWithResponseHeader as __requestWithResponseHeader } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 {{/if}}
 
 {{#equals @root.httpClient 'angular'}}
@@ -67,9 +67,15 @@ export class {{{name}}}{{{@root.postfix}}} {
 	{{/each}}
 	{{/if}}
 	{{/unless}}
-	{{#each results}}
+	{{#if responseHeader}}
+		{{#each results}}
+	 * @returns ApiResult<{{{type}}}> {{#if description}}{{{escapeComment description}}}{{/if}}
+		{{/each}}
+	{{else}}
+		{{#each results}}
 	 * @returns {{{type}}} {{#if description}}{{{escapeComment description}}}{{/if}}
-	{{/each}}
+		{{/each}}
+	{{/if}}
 	 * @throws ApiError
 	 */
 	{{#if @root.exportClient}}
@@ -78,8 +84,8 @@ export class {{{name}}}{{{@root.postfix}}} {
 		return this.httpRequest.request({
 	{{else}}
 		{{#if responseHeader}}
-	public {{{name}}}({{>parameters}}): CancelablePromise<ApiResult> {
-		return this.httpRequest.requestWithResponseHeader({
+	public {{{name}}}({{>parameters}}): CancelablePromise<ApiResult<{{>result}}>> {
+		return this.httpRequest.requestApiResult({
 		{{else}}
 	public {{{name}}}({{>parameters}}): CancelablePromise<{{>result}}> {
 		return this.httpRequest.request({
@@ -91,8 +97,8 @@ export class {{{name}}}{{{@root.postfix}}} {
 		return __request(OpenAPI, this.http, {
 	{{else}}
 		{{#if responseHeader}}
-	public {{{name}}}({{>parameters}}): CancelablePromise<ApiResult> {
-		return __requestWithResponseHeader(OpenAPI, {
+	public {{{name}}}({{>parameters}}): CancelablePromise<ApiResult<{{>result}}>> {
+		return __requestApiResult(OpenAPI, {
 		{{else}}
 	public static {{{name}}}({{>parameters}}): CancelablePromise<{{>result}}> {
 		return __request(OpenAPI, {

--- a/src/templates/partials/responseType.hbs
+++ b/src/templates/partials/responseType.hbs
@@ -1,0 +1,5 @@
+{{~#equals results.length 1~}}
+  {{~#equals results.0.base 'binary'~}}
+    responseType: 'blob',
+  {{/equals}}
+{{~/equals~}}

--- a/src/templates/partials/responseType.hbs
+++ b/src/templates/partials/responseType.hbs
@@ -1,5 +1,3 @@
-{{~#equals results.length 1~}}
-  {{~#equals results.0.base 'binary'~}}
-    responseType: 'blob',
-  {{/equals}}
-{{~/equals~}}
+{{~#equals results.0.base 'binary'~}}
+	responseType: 'blob',
+{{/equals}}

--- a/src/utils/registerHandlebarTemplates.ts
+++ b/src/utils/registerHandlebarTemplates.ts
@@ -66,6 +66,7 @@ import partialIsNullable from '../templates/partials/isNullable.hbs';
 import partialIsReadOnly from '../templates/partials/isReadOnly.hbs';
 import partialIsRequired from '../templates/partials/isRequired.hbs';
 import partialParameters from '../templates/partials/parameters.hbs';
+import partialResponseType from '../templates/partials/responseType.hbs';
 import partialResult from '../templates/partials/result.hbs';
 import partialSchema from '../templates/partials/schema.hbs';
 import partialSchemaArray from '../templates/partials/schemaArray.hbs';
@@ -147,6 +148,7 @@ export const registerHandlebarTemplates = (root: {
     Handlebars.registerPartial('isReadOnly', Handlebars.template(partialIsReadOnly));
     Handlebars.registerPartial('isRequired', Handlebars.template(partialIsRequired));
     Handlebars.registerPartial('parameters', Handlebars.template(partialParameters));
+    Handlebars.registerPartial('responseType', Handlebars.template(partialResponseType));
     Handlebars.registerPartial('result', Handlebars.template(partialResult));
     Handlebars.registerPartial('schema', Handlebars.template(partialSchema));
     Handlebars.registerPartial('schemaArray', Handlebars.template(partialSchemaArray));

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -12,7 +12,7 @@ export class ApiError extends Error {
     public readonly statusText: string;
     public readonly body: any;
 
-    constructor(response: ApiResult, message: string) {
+    constructor(response: ApiResult<any>, message: string) {
         super(message);
 
         this.name = 'ApiError';
@@ -48,12 +48,12 @@ exports[`v2 should generate: ./test/generated/v2/core/ApiResult.ts 1`] = `
 "/* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type ApiResult = {
+export type ApiResult<T> = {
     readonly url: string;
     readonly ok: boolean;
     readonly status: number;
     readonly statusText: string;
-    readonly body: any;
+    readonly body: T;
     readonly header: string | undefined;
 };"
 `;
@@ -473,7 +473,7 @@ const getResponseBody = async (response: Response, options: ApiRequestOptions): 
     return undefined;
 };
 
-const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
+const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult<any>): void => {
     const errors: Record<number, string> = {
         400: 'Bad Request',
         401: 'Unauthorized',
@@ -496,13 +496,13 @@ const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void =>
 };
 
 /**
- * Request method with header
+ * Request method to get ApiResult
  * @param config The OpenAPI configuration object
  * @param options The request options from the service
- * @returns CancelablePromise<ApiResult>
+ * @returns CancelablePromise<ApiResult<T>>
  * @throws ApiError
  */
-export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult> => {
+export const requestApiResult = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult<T>> => {
     return new CancelablePromise(async (resolve, reject, onCancel) => {
         try {
             const url = getUrl(config, options);
@@ -515,7 +515,7 @@ export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: Api
                 const responseBody = await getResponseBody(response, options);
                 const responseHeader = getResponseHeader(response, options.responseHeader);
 
-                const result: ApiResult = {
+                const result: ApiResult<T> = {
                     url,
                     ok: response.ok,
                     status: response.status,
@@ -545,7 +545,7 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
     return new CancelablePromise(async (resolve, reject, onCancel) => {
         try {
             if (!onCancel.isCancelled) {
-                const result = await requestWithResponseHeader(config, options)
+                const result = await requestApiResult<T>(config, options)
                 resolve(result.body)
             }
         } catch (error) {
@@ -2170,8 +2170,10 @@ exports[`v2 should generate: ./test/generated/v2/services/CollectionFormatServic
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class CollectionFormatService {
 
@@ -2213,8 +2215,10 @@ exports[`v2 should generate: ./test/generated/v2/services/ComplexService.ts 1`] 
 import type { ModelWithString } from '../models/ModelWithString';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class ComplexService {
 
@@ -2256,8 +2260,10 @@ exports[`v2 should generate: ./test/generated/v2/services/DefaultService.ts 1`] 
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class DefaultService {
 
@@ -2281,8 +2287,10 @@ exports[`v2 should generate: ./test/generated/v2/services/DefaultsService.ts 1`]
 import type { ModelWithString } from '../models/ModelWithString';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class DefaultsService {
 
@@ -2391,8 +2399,10 @@ exports[`v2 should generate: ./test/generated/v2/services/DescriptionsService.ts
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class DescriptionsService {
 
@@ -2438,8 +2448,10 @@ exports[`v2 should generate: ./test/generated/v2/services/DuplicateService.ts 1`
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class DuplicateService {
 
@@ -2491,8 +2503,10 @@ exports[`v2 should generate: ./test/generated/v2/services/ErrorService.ts 1`] = 
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class ErrorService {
 
@@ -2527,20 +2541,39 @@ exports[`v2 should generate: ./test/generated/v2/services/HeaderService.ts 1`] =
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class HeaderService {
 
     /**
-     * @returns string Successful response
+     * @returns ApiResult<any> Successful response
      * @throws ApiError
      */
-    public static callWithResultFromHeader(): CancelablePromise<string> {
-        return __request(OpenAPI, {
+    public callWithResultFromHeader(): CancelablePromise<ApiResult<any>> {
+        return __requestApiResult(OpenAPI, {
             method: 'POST',
             url: '/api/v{api-version}/header',
             responseHeader: 'operation-location',
+            errors: {
+                400: \`400 server error\`,
+                500: \`500 server error\`,
+            },
+        });
+    }
+
+    /**
+     * @returns ApiResult<binary> Successful response
+     * @throws ApiError
+     */
+    public callWithResultFromContentAndHeader(): CancelablePromise<ApiResult<Blob>> {
+        return __requestApiResult(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/content/header',
+            responseType: 'blob',
+            responseHeader: 'content-disposition',
             errors: {
                 400: \`400 server error\`,
                 500: \`500 server error\`,
@@ -2556,8 +2589,10 @@ exports[`v2 should generate: ./test/generated/v2/services/MultipleTags1Service.t
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class MultipleTags1Service {
 
@@ -2591,8 +2626,10 @@ exports[`v2 should generate: ./test/generated/v2/services/MultipleTags2Service.t
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class MultipleTags2Service {
 
@@ -2626,8 +2663,10 @@ exports[`v2 should generate: ./test/generated/v2/services/MultipleTags3Service.t
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class MultipleTags3Service {
 
@@ -2650,8 +2689,10 @@ exports[`v2 should generate: ./test/generated/v2/services/NoContentService.ts 1`
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class NoContentService {
 
@@ -2674,8 +2715,10 @@ exports[`v2 should generate: ./test/generated/v2/services/ParametersService.ts 1
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class ParametersService {
 
@@ -2768,8 +2811,10 @@ import type { ModelThatExtendsExtends } from '../models/ModelThatExtendsExtends'
 import type { ModelWithString } from '../models/ModelWithString';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class ResponseService {
 
@@ -2831,8 +2876,10 @@ exports[`v2 should generate: ./test/generated/v2/services/SimpleService.ts 1`] =
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class SimpleService {
 
@@ -2914,8 +2961,10 @@ exports[`v2 should generate: ./test/generated/v2/services/TypesService.ts 1`] = 
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class TypesService {
 
@@ -2977,7 +3026,7 @@ export class ApiError extends Error {
     public readonly statusText: string;
     public readonly body: any;
 
-    constructor(response: ApiResult, message: string) {
+    constructor(response: ApiResult<any>, message: string) {
         super(message);
 
         this.name = 'ApiError';
@@ -3013,12 +3062,12 @@ exports[`v3 should generate: ./test/generated/v3/core/ApiResult.ts 1`] = `
 "/* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type ApiResult = {
+export type ApiResult<T> = {
     readonly url: string;
     readonly ok: boolean;
     readonly status: number;
     readonly statusText: string;
-    readonly body: any;
+    readonly body: T;
     readonly header: string | undefined;
 };"
 `;
@@ -3438,7 +3487,7 @@ const getResponseBody = async (response: Response, options: ApiRequestOptions): 
     return undefined;
 };
 
-const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
+const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult<any>): void => {
     const errors: Record<number, string> = {
         400: 'Bad Request',
         401: 'Unauthorized',
@@ -3461,13 +3510,13 @@ const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void =>
 };
 
 /**
- * Request method with header
+ * Request method to get ApiResult
  * @param config The OpenAPI configuration object
  * @param options The request options from the service
- * @returns CancelablePromise<ApiResult>
+ * @returns CancelablePromise<ApiResult<T>>
  * @throws ApiError
  */
-export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult> => {
+export const requestApiResult = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult<T>> => {
     return new CancelablePromise(async (resolve, reject, onCancel) => {
         try {
             const url = getUrl(config, options);
@@ -3480,7 +3529,7 @@ export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: Api
                 const responseBody = await getResponseBody(response, options);
                 const responseHeader = getResponseHeader(response, options.responseHeader);
 
-                const result: ApiResult = {
+                const result: ApiResult<T> = {
                     url,
                     ok: response.ok,
                     status: response.status,
@@ -3510,7 +3559,7 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
     return new CancelablePromise(async (resolve, reject, onCancel) => {
         try {
             if (!onCancel.isCancelled) {
-                const result = await requestWithResponseHeader(config, options)
+                const result = await requestApiResult<T>(config, options)
                 resolve(result.body)
             }
         } catch (error) {
@@ -5877,8 +5926,10 @@ exports[`v3 should generate: ./test/generated/v3/services/CollectionFormatServic
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class CollectionFormatService {
 
@@ -5923,8 +5974,10 @@ import type { ModelWithEnum } from '../models/ModelWithEnum';
 import type { ModelWithString } from '../models/ModelWithString';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class ComplexService {
 
@@ -5999,8 +6052,10 @@ exports[`v3 should generate: ./test/generated/v3/services/DefaultService.ts 1`] 
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class DefaultService {
 
@@ -6024,8 +6079,10 @@ exports[`v3 should generate: ./test/generated/v3/services/DefaultsService.ts 1`]
 import type { ModelWithString } from '../models/ModelWithString';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class DefaultsService {
 
@@ -6134,8 +6191,10 @@ exports[`v3 should generate: ./test/generated/v3/services/DescriptionsService.ts
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class DescriptionsService {
 
@@ -6181,8 +6240,10 @@ exports[`v3 should generate: ./test/generated/v3/services/DuplicateService.ts 1`
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class DuplicateService {
 
@@ -6234,8 +6295,10 @@ exports[`v3 should generate: ./test/generated/v3/services/ErrorService.ts 1`] = 
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class ErrorService {
 
@@ -6272,8 +6335,10 @@ exports[`v3 should generate: ./test/generated/v3/services/FormDataService.ts 1`]
 import type { ModelWithString } from '../models/ModelWithString';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class FormDataService {
 
@@ -6305,20 +6370,39 @@ exports[`v3 should generate: ./test/generated/v3/services/HeaderService.ts 1`] =
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class HeaderService {
 
     /**
-     * @returns string Successful response
+     * @returns ApiResult<any> Successful response
      * @throws ApiError
      */
-    public static callWithResultFromHeader(): CancelablePromise<string> {
-        return __request(OpenAPI, {
+    public callWithResultFromHeader(): CancelablePromise<ApiResult<any>> {
+        return __requestApiResult(OpenAPI, {
             method: 'POST',
             url: '/api/v{api-version}/header',
             responseHeader: 'operation-location',
+            errors: {
+                400: \`400 server error\`,
+                500: \`500 server error\`,
+            },
+        });
+    }
+
+    /**
+     * @returns ApiResult<binary> Successful response
+     * @throws ApiError
+     */
+    public callWithResultFromContentAndHeader(): CancelablePromise<ApiResult<Blob>> {
+        return __requestApiResult(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/content/header',
+            responseType: 'blob',
+            responseHeader: 'content-disposition',
             errors: {
                 400: \`400 server error\`,
                 500: \`500 server error\`,
@@ -6336,8 +6420,10 @@ exports[`v3 should generate: ./test/generated/v3/services/MultipartService.ts 1`
 import type { ModelWithString } from '../models/ModelWithString';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class MultipartService {
 
@@ -6384,8 +6470,10 @@ exports[`v3 should generate: ./test/generated/v3/services/MultipleTags1Service.t
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class MultipleTags1Service {
 
@@ -6419,8 +6507,10 @@ exports[`v3 should generate: ./test/generated/v3/services/MultipleTags2Service.t
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class MultipleTags2Service {
 
@@ -6454,8 +6544,10 @@ exports[`v3 should generate: ./test/generated/v3/services/MultipleTags3Service.t
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class MultipleTags3Service {
 
@@ -6478,8 +6570,10 @@ exports[`v3 should generate: ./test/generated/v3/services/NoContentService.ts 1`
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class NoContentService {
 
@@ -6505,8 +6599,10 @@ import type { ModelWithString } from '../models/ModelWithString';
 import type { Pageable } from '../models/Pageable';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class ParametersService {
 
@@ -6649,8 +6745,10 @@ exports[`v3 should generate: ./test/generated/v3/services/RequestBodyService.ts 
 import type { ModelWithString } from '../models/ModelWithString';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class RequestBodyService {
 
@@ -6686,8 +6784,10 @@ import type { ModelThatExtendsExtends } from '../models/ModelThatExtendsExtends'
 import type { ModelWithString } from '../models/ModelWithString';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class ResponseService {
 
@@ -6749,8 +6849,10 @@ exports[`v3 should generate: ./test/generated/v3/services/SimpleService.ts 1`] =
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class SimpleService {
 
@@ -6832,8 +6934,10 @@ exports[`v3 should generate: ./test/generated/v3/services/TypesService.ts 1`] = 
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class TypesService {
 
@@ -6888,8 +6992,10 @@ exports[`v3 should generate: ./test/generated/v3/services/UploadService.ts 1`] =
 /* tslint:disable */
 /* eslint-disable */
 import type { CancelablePromise } from '../core/CancelablePromise';
+import type { ApiResult } from '../core/ApiResult';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { requestApiResult as __requestApiResult } from '../core/request';
 
 export class UploadService {
 

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -54,6 +54,7 @@ export type ApiResult = {
     readonly status: number;
     readonly statusText: string;
     readonly body: any;
+    readonly header: string | undefined;
 };"
 `;
 
@@ -495,13 +496,13 @@ const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void =>
 };
 
 /**
- * Request method
+ * Request method with header
  * @param config The OpenAPI configuration object
  * @param options The request options from the service
- * @returns CancelablePromise<T>
+ * @returns CancelablePromise<ApiResult>
  * @throws ApiError
  */
-export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult> => {
     return new CancelablePromise(async (resolve, reject, onCancel) => {
         try {
             const url = getUrl(config, options);
@@ -519,12 +520,33 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
                     ok: response.ok,
                     status: response.status,
                     statusText: response.statusText,
-                    body: responseHeader ?? responseBody,
+                    body: responseBody,
+                    header: responseHeader,
                 };
 
                 catchErrorCodes(options, result);
 
-                resolve(result.body);
+                resolve(result);
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+};
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+    return new CancelablePromise(async (resolve, reject, onCancel) => {
+        try {
+            if (!onCancel.isCancelled) {
+                const result = await requestWithResponseHeader(config, options)
+                resolve(result.body)
             }
         } catch (error) {
             reject(error);
@@ -2997,6 +3019,7 @@ export type ApiResult = {
     readonly status: number;
     readonly statusText: string;
     readonly body: any;
+    readonly header: string | undefined;
 };"
 `;
 
@@ -3438,13 +3461,13 @@ const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void =>
 };
 
 /**
- * Request method
+ * Request method with header
  * @param config The OpenAPI configuration object
  * @param options The request options from the service
- * @returns CancelablePromise<T>
+ * @returns CancelablePromise<ApiResult>
  * @throws ApiError
  */
-export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+export const requestWithResponseHeader = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<ApiResult> => {
     return new CancelablePromise(async (resolve, reject, onCancel) => {
         try {
             const url = getUrl(config, options);
@@ -3462,12 +3485,33 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
                     ok: response.ok,
                     status: response.status,
                     statusText: response.statusText,
-                    body: responseHeader ?? responseBody,
+                    body: responseBody,
+                    header: responseHeader,
                 };
 
                 catchErrorCodes(options, result);
 
-                resolve(result.body);
+                resolve(result);
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+};
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+    return new CancelablePromise(async (resolve, reject, onCancel) => {
+        try {
+            if (!onCancel.isCancelled) {
+                const result = await requestWithResponseHeader(config, options)
+                resolve(result.body)
             }
         } catch (error) {
             reject(error);

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -38,6 +38,7 @@ export type ApiRequestOptions = {
     readonly formData?: Record<string, any>;
     readonly body?: any;
     readonly mediaType?: string;
+    readonly responseType?: 'blob';
     readonly responseHeader?: string;
     readonly errors?: Record<number, string>;
 };"
@@ -450,7 +451,7 @@ const getResponseHeader = (response: Response, responseHeader?: string): string 
     return undefined;
 };
 
-const getResponseBody = async (response: Response): Promise<any> => {
+const getResponseBody = async (response: Response, options: ApiRequestOptions): Promise<any> => {
     if (response.status !== 204) {
         try {
             const contentType = response.headers.get('Content-Type');
@@ -458,6 +459,8 @@ const getResponseBody = async (response: Response): Promise<any> => {
                 const isJSON = contentType.toLowerCase().startsWith('application/json');
                 if (isJSON) {
                     return await response.json();
+                } else if (options.responseType === 'blob') {
+                    return await response.blob();
                 } else {
                     return await response.text();
                 }
@@ -508,7 +511,7 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
 
             if (!onCancel.isCancelled) {
                 const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
-                const responseBody = await getResponseBody(response);
+                const responseBody = await getResponseBody(response, options);
                 const responseHeader = getResponseHeader(response, options.responseHeader);
 
                 const result: ApiResult = {
@@ -2978,6 +2981,7 @@ export type ApiRequestOptions = {
     readonly formData?: Record<string, any>;
     readonly body?: any;
     readonly mediaType?: string;
+    readonly responseType?: 'blob';
     readonly responseHeader?: string;
     readonly errors?: Record<number, string>;
 };"
@@ -3390,7 +3394,7 @@ const getResponseHeader = (response: Response, responseHeader?: string): string 
     return undefined;
 };
 
-const getResponseBody = async (response: Response): Promise<any> => {
+const getResponseBody = async (response: Response, options: ApiRequestOptions): Promise<any> => {
     if (response.status !== 204) {
         try {
             const contentType = response.headers.get('Content-Type');
@@ -3398,6 +3402,8 @@ const getResponseBody = async (response: Response): Promise<any> => {
                 const isJSON = contentType.toLowerCase().startsWith('application/json');
                 if (isJSON) {
                     return await response.json();
+                } else if (options.responseType === 'blob') {
+                    return await response.blob();
                 } else {
                     return await response.text();
                 }
@@ -3448,7 +3454,7 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
 
             if (!onCancel.isCancelled) {
                 const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
-                const responseBody = await getResponseBody(response);
+                const responseBody = await getResponseBody(response, options);
                 const responseHeader = getResponseHeader(response, options.responseHeader);
 
                 const result: ApiResult = {

--- a/test/spec/v2.json
+++ b/test/spec/v2.json
@@ -872,6 +872,36 @@
                 }
             }
         },
+        "/api/v{api-version}/content/header": {
+            "post": {
+                "tags": [
+                    "Header"
+                ],
+                "operationId": "CallWithResultFromContentAndHeader",
+                "produces": [
+                    "application/pdf"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "schema": {
+                            "type": "file"
+                        },
+                        "headers": {
+                            "content-disposition": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "400 server error"
+                    },
+                    "500": {
+                        "description": "500 server error"
+                    }
+                }
+            }
+        },
         "/api/v{api-version}/error": {
             "post": {
                 "tags": [

--- a/test/spec/v3.json
+++ b/test/spec/v3.json
@@ -1407,6 +1407,35 @@
                 }
             }
         },
+        "/api/v{api-version}/content/header": {
+            "post": {
+                "tags": [
+                    "Header"
+                ],
+                "operationId": "CallWithResultFromContentAndHeader",
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application/pdf": {"schema": {"type": "string", "format": "binary"}}
+                        },
+                        "headers": {
+                            "content-disposition": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "400 server error"
+                    },
+                    "500": {
+                        "description": "500 server error"
+                    }
+                }
+            }
+        },
         "/api/v{api-version}/error": {
             "post": {
                 "tags": [


### PR DESCRIPTION
We have a similar problems like #829 and #981, when trying to access an endpoint with a pdf file and the filename in the header.

Therefore I started working on this branch and fixed it (at least for our problem). Please be aware that this pull request at the moment would introduce breaking change and I doubt it is in the sense of the original design. So in effect I don't expect this to be merged but I still hope it might be useful for someone.

- ApiResult is now a Generic with body and header. 
- During `getOperation` both the header and the content from the responses are pushed to the list, handled to create the necessary entries and finally the header is dropped, in order to not polluting the types.
- A new request function is added, which is chosen, when a responseHeader is included in the options. With that it only includes still only one header

Known short comings:
 - Still only handles one header
 - It is always expected that the first entry is the entry with the binary type, which is not guaranteed to best of my knowledge
 - If a responseHeader is set, the return type is now always a ApiResult and no longer a string. 
 - It's missing additional test cases to verify the added behavior

This branch includes other than stated in the contribution guideline merge commits from the two open pull requests (#1037 and #986 )

Would be happy about any feedback. 

Best regards and thank you very much for this neat code generator
