### PR TITLE
Fix error TS2564

### DIFF
--- a/src/templates/core/CancelablePromise.hbs
+++ b/src/templates/core/CancelablePromise.hbs
@@ -21,7 +21,7 @@ export interface OnCancel {
 }
 
 export class CancelablePromise<T> implements Promise<T> {
-	readonly [Symbol.toStringTag]: string;
+	readonly [Symbol.toStringTag]!: string;
 
 	private _isResolved: boolean;
 	private _isRejected: boolean;


### PR DESCRIPTION
Error on `tsc`:

```
openapi-client/core/CancelablePromise.ts:25:14 - error TS2564: Property '[Symbol.toStringTag]' has no initializer and is not definitely assigned in the constructor.

25     readonly [Symbol.toStringTag]: string;
```