### PR TITLE
Set Content-Type in axios

### DIFF
--- a/src/templates/core/axios/getHeaders.hbs
+++ b/src/templates/core/axios/getHeaders.hbs
@@ -26,5 +26,17 @@ const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions, for
 		headers['Authorization'] = `Basic ${credentials}`;
 	}
 
+	if (options.body) {
+		if (options.mediaType) {
+			headers['Content-Type'] = options.mediaType;
+		} else if (isBlob(options.body)) {
+			headers['Content-Type'] = options.body.type || 'application/octet-stream';
+		} else if (isString(options.body)) {
+			headers['Content-Type'] = 'text/plain';
+		} else if (!isFormData(options.body)) {
+			headers['Content-Type'] = 'application/json';
+		}
+	}
+
 	return headers;
 };

--- a/src/templates/core/axios/request.hbs
+++ b/src/templates/core/axios/request.hbs
@@ -22,6 +22,9 @@ import type { OpenAPIConfig } from './OpenAPI';
 {{>functions/isBlob}}
 
 
+{{>functions/isFormData}}
+
+
 {{>functions/isSuccess}}
 
 


### PR DESCRIPTION
Rel: #1022 

The `Content-Type` header wasn't getting set in the axios client like it was in all the other clients.

I think axios is not affected by the issue described in #1022, though, because it sets the header itself for form data (or, more accurately, defers to the browser or the `form-data` lib).