### PR TITLE
Prevent duplication of parameter names

### DIFF
--- a/src/openApi/v3/parser/getOperationParameterName.spec.ts
+++ b/src/openApi/v3/parser/getOperationParameterName.spec.ts
@@ -13,5 +13,7 @@ describe('getOperationParameterName', () => {
         expect(getOperationParameterName('123.foo.bar')).toEqual('fooBar');
         expect(getOperationParameterName('Foo-Bar')).toEqual('fooBar');
         expect(getOperationParameterName('FOO-BAR')).toEqual('fooBar');
+        expect(getOperationParameterName('foo[bar]')).toEqual('fooBar');
+        expect(getOperationParameterName('foo.bar[]')).toEqual('fooBarArray');
     });
 });

--- a/src/openApi/v3/parser/getOperationParameterName.ts
+++ b/src/openApi/v3/parser/getOperationParameterName.ts
@@ -10,6 +10,7 @@ const reservedWords =
 export const getOperationParameterName = (value: string): string => {
     const clean = value
         .replace(/^[^a-zA-Z]+/g, '')
+        .replace('[]', 'Array')
         .replace(/[^\w\-]+/g, '-')
         .trim();
     return camelCase(clean).replace(reservedWords, '_$1');


### PR DESCRIPTION
Hi

I am working with an API that has parameters like e.g `product.code` and `product.code[]` The problem is that when generated, these parameters are doubled. I added a simple workaround. I don't know if this is the best solution, but it works for me, so I will leave it here and I hope it helps 😄 