### PR TITLE
Fix undefined request body when body is a valid JSON falsy value: false or 0, "".

### DIFF
--- a/src/templates/core/fetch/getRequestBody.hbs
+++ b/src/templates/core/fetch/getRequestBody.hbs
@@ -1,5 +1,5 @@
 const getRequestBody = (options: ApiRequestOptions): any => {
-	if (options.body) {
+	if (options.body !== undefined) {
 		if (options.mediaType?.includes('/json')) {
 			return JSON.stringify(options.body)
 		} else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {


### PR DESCRIPTION
The same can be done for other client types.