### PR TITLE
Add json support for application/problem+json content type

### DIFF
--- a/src/templates/core/fetch/getResponseBody.hbs
+++ b/src/templates/core/fetch/getResponseBody.hbs
@@ -3,7 +3,8 @@ const getResponseBody = async (response: Response): Promise<any> => {
 		try {
 			const contentType = response.headers.get('Content-Type');
 			if (contentType) {
-				const isJSON = contentType.toLowerCase().startsWith('application/json');
+				const jsonTypes = ['application/json', 'application/problem+json']
+				const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
 				if (isJSON) {
 					return await response.json();
 				} else {

--- a/src/templates/core/node/getResponseBody.hbs
+++ b/src/templates/core/node/getResponseBody.hbs
@@ -3,7 +3,8 @@ const getResponseBody = async (response: Response): Promise<any> => {
 		try {
 			const contentType = response.headers.get('Content-Type');
 			if (contentType) {
-				const isJSON = contentType.toLowerCase().startsWith('application/json');
+				const jsonTypes = ['application/json', 'application/problem+json']
+				const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
 				if (isJSON) {
 					return await response.json();
 				} else {

--- a/src/templates/core/xhr/getResponseBody.hbs
+++ b/src/templates/core/xhr/getResponseBody.hbs
@@ -3,7 +3,8 @@ const getResponseBody = (xhr: XMLHttpRequest): any => {
 		try {
 			const contentType = xhr.getResponseHeader('Content-Type');
 			if (contentType) {
-				const isJSON = contentType.toLowerCase().startsWith('application/json');
+				const jsonTypes = ['application/json', 'application/problem+json']
+				const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
 				if (isJSON) {
 					return JSON.parse(xhr.responseText);
 				} else {

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -463,7 +463,8 @@ const getResponseBody = async (response: Response): Promise<any> => {
         try {
             const contentType = response.headers.get('Content-Type');
             if (contentType) {
-                const isJSON = contentType.toLowerCase().startsWith('application/json');
+                const jsonTypes = ['application/json', 'application/problem+json']
+                const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
                 if (isJSON) {
                     return await response.json();
                 } else {
@@ -3522,7 +3523,8 @@ const getResponseBody = async (response: Response): Promise<any> => {
         try {
             const contentType = response.headers.get('Content-Type');
             if (contentType) {
-                const isJSON = contentType.toLowerCase().startsWith('application/json');
+                const jsonTypes = ['application/json', 'application/problem+json']
+                const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
                 if (isJSON) {
                     return await response.json();
                 } else {


### PR DESCRIPTION
I have several projects that return a `application/problem+json` content type. As seen in [this RFC](https://datatracker.ietf.org/doc/html/rfc7807), it should always be possible to parse it with `response.json()`.

The [symfony](https://symfony.com/) framework uses this as default, so when my back-end is build with symfony I cannot select items in the body of the error at this moment since it is parsed as text.

This PR adds support for the `application/problem+json` content type so that the errors in json format are parsed as json instead of text.