### PR TITLE
fix: not all not ok responses are errors

### DIFF
--- a/src/templates/core/functions/catchErrorCodes.hbs
+++ b/src/templates/core/functions/catchErrorCodes.hbs
@@ -14,8 +14,4 @@ const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void =>
 	if (error) {
 		throw new ApiError(options, result, error);
 	}
-
-	if (!result.ok) {
-		throw new ApiError(options, result, 'Generic Error');
-	}
 };


### PR DESCRIPTION
Hello there, 
Not all Successful responses are ok, however all 2xx status codes are considered to be successful responses considering [Mozilla's documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status). With that in mind, this PR makes a small change to the catchErrorCodes template, removing the conditional `if not Ok status code, return error`