### PR TITLE
Support exactOptionalPropertyTypes

### DIFF
--- a/src/templates/core/OpenAPI.hbs
+++ b/src/templates/core/OpenAPI.hbs
@@ -10,11 +10,11 @@ export type OpenAPIConfig = {
 	VERSION: string;
 	WITH_CREDENTIALS: boolean;
 	CREDENTIALS: 'include' | 'omit' | 'same-origin';
-	TOKEN?: string | Resolver<string>;
-	USERNAME?: string | Resolver<string>;
-	PASSWORD?: string | Resolver<string>;
-	HEADERS?: Headers | Resolver<Headers>;
-	ENCODE_PATH?: (path: string) => string;
+	TOKEN?: string | Resolver<string> | undefined;
+	USERNAME?: string | Resolver<string> | undefined;
+	PASSWORD?: string | Resolver<string> | undefined;
+	HEADERS?: Headers | Resolver<Headers> | undefined;
+	ENCODE_PATH?: ((path: string) => string) | undefined;
 };
 
 export const OpenAPI: OpenAPIConfig = {


### PR DESCRIPTION
A key being optional is different than the value being optional. Former indicates missing keys, while latter indicate, required key but missing value.

When defining a type like this, we're explicitly stating that the key must exists, but its value could be undefined. 
```ts
export type OpenAPIConfig = {
	myKey: string | undefined;
};
```
**`Valid`**
`const invalid: OpenAPIConfig = {myKey: undefined}`

*`Invalid`*
`const invalid: OpenAPIConfig = {}`

Which is different from following that says, key could be missing - which translates into the value being missing as well. Which is why with `exactOptionalPropertyTypes` all optional keys need to explicitly state `undefined` as value type. 

```ts
export type OpenAPIConfig = {
	myKey?: string | undefined;
};
```

**`Valid`**
`const invalid: OpenAPIConfig = {myKey: undefined}`

**`Valid`**
`const invalid: OpenAPIConfig = {}`

Now, you might actually want the user to be explicit with the keys, in which case can change it, but I'm inferring from context that it's not important. 

In any case, in that scenario, dropping the optional keyword on the key would change that. But that might break for users who are currently not passing explicit keys. This maintains backwards compatibility. 
