### PR TITLE
add more detail to Generic Error message for easier troubleshooting

### DIFF
--- a/src/templates/core/functions/catchErrorCodes.hbs
+++ b/src/templates/core/functions/catchErrorCodes.hbs
@@ -16,6 +16,16 @@ const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void =>
 	}
 
 	if (!result.ok) {
-		throw new ApiError(options, result, 'Generic Error');
+		const resultBody = (() => {
+      try {
+        return JSON.stringify(result.body, null, 2);
+      } catch (err) {
+        return undefined;
+      }
+    })();
+    throw new ApiError(
+      result,
+      `Generic Error: status: ${result.status ?? 'unknown'}; status text: ${result.statusText}; body: ${resultBody}`
+    );
 	}
 };


### PR DESCRIPTION
'Generic Error' gives no insight into the nature of the issue, whereas having at least the http status conveys a great deal for troubleshooting