### PR TITLE
Rename bin script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ npm install openapi-typescript-codegen --save-dev
 ## Usage
 
 ```
-$ openapi --help
+$ openapi-typescript-codegen --help
 
-  Usage: openapi [options]
+  Usage: openapi-typescript-codegen [options]
 
   Options:
     -V, --version             output the version number
@@ -54,8 +54,8 @@ $ openapi --help
     -h, --help                display help for command
 
   Examples
-    $ openapi --input ./spec.json --output ./generated
-    $ openapi --input ./spec.json --output ./generated --client xhr
+    $ openapi-typescript-codegen --input ./spec.json --output ./generated
+    $ openapi-typescript-codegen --input ./spec.json --output ./generated --client xhr
 ```
 
 Documentation

--- a/bin/index.js
+++ b/bin/index.js
@@ -7,7 +7,7 @@ const { program } = require('commander');
 const pkg = require('../package.json');
 
 const params = program
-    .name('openapi')
+    .name(pkg.name)
     .usage('[options]')
     .version(pkg.version)
     .requiredOption('-i, --input <value>', 'OpenAPI specification, can be a path, url or string content (required)')

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "json-schema-ref-parser": "^9.0.9"
             },
             "bin": {
-                "openapi": "bin/index.js"
+                "openapi-typescript-codegen": "bin/index.js"
             },
             "devDependencies": {
                 "@angular-devkit/build-angular": "14.2.7",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "main": "dist/index.js",
     "types": "types/index.d.ts",
     "bin": {
-        "openapi": "bin/index.js"
+        "openapi-typescript-codegen": "bin/index.js"
     },
     "files": [
         "bin/index.js",


### PR DESCRIPTION
## Description of Problem

I tried to use this with redocly/redocly-cli and had problems because the bin script is provided under the same name.

cf. https://github.com/Redocly/redocly-cli/blob/main/packages/cli/package.json#L7

## Proposed Solution

In my personal opinion...
I would prefer that the primary name of the bin script be the same as the name of the package.

## Additional Information

related #1412
