### PR TITLE
Add support for Parameter Serialization

### DIFF
--- a/src/client/interfaces/OperationParameter.d.ts
+++ b/src/client/interfaces/OperationParameter.d.ts
@@ -4,4 +4,6 @@ export interface OperationParameter extends Model {
     in: 'path' | 'query' | 'header' | 'formData' | 'body' | 'cookie';
     prop: string;
     mediaType: string | null;
+    style: 'simple' | 'label' | 'matrix' | 'form' | 'spaceDelimited' | 'pipeDelimited' | 'deepObject' | null;
+    explode: boolean | null;
 }

--- a/src/openApi/v2/parser/getOperationParameter.ts
+++ b/src/openApi/v2/parser/getOperationParameter.ts
@@ -43,6 +43,8 @@ export const getOperationParameter = (openApi: OpenApi, parameter: OpenApiParame
         enums: [],
         properties: [],
         mediaType: null,
+        explode: null,
+        style: null,
     };
 
     if (parameter.$ref) {

--- a/src/openApi/v3/parser/getOperationParameter.ts
+++ b/src/openApi/v3/parser/getOperationParameter.ts
@@ -30,6 +30,8 @@ export const getOperationParameter = (openApi: OpenApi, parameter: OpenApiParame
         enums: [],
         properties: [],
         mediaType: null,
+        explode: parameter.explode || null,
+        style: (parameter.style as OperationParameter['style']) || null,
     };
 
     if (parameter.$ref) {

--- a/src/openApi/v3/parser/getOperationRequestBody.ts
+++ b/src/openApi/v3/parser/getOperationRequestBody.ts
@@ -27,6 +27,8 @@ export const getOperationRequestBody = (openApi: OpenApi, body: OpenApiRequestBo
         enums: [],
         properties: [],
         mediaType: null,
+        explode: null,
+        style: null,
     };
 
     if (body.content) {

--- a/src/templates/core/SerializableParameter.hbs
+++ b/src/templates/core/SerializableParameter.hbs
@@ -1,0 +1,15 @@
+{{>header}}
+
+export class SerializableParameter {
+	public readonly parameterName: string;
+	public readonly style: string | null;
+	public readonly explode: boolean | null;
+	public readonly parameterValue: any;
+
+	constructor(parameterName: string, style: string | null, explode: boolean | null, parameterValue: any) {
+		this.parameterName = parameterName;
+		this.style = style;
+		this.explode = explode;
+		this.parameterValue = parameterValue;
+	}
+}

--- a/src/templates/core/angular/getHeaders.hbs
+++ b/src/templates/core/angular/getHeaders.hbs
@@ -1,4 +1,6 @@
 const getHeaders = (config: OpenAPIConfig, options: ApiRequestOptions): Observable<HttpHeaders> => {
+	{{>functions/serializeHeaders}}
+
 	return forkJoin({
 		token: resolve(options, config.TOKEN),
 		username: resolve(options, config.USERNAME),
@@ -9,7 +11,7 @@ const getHeaders = (config: OpenAPIConfig, options: ApiRequestOptions): Observab
 			const headers = Object.entries({
 				Accept: 'application/json',
 				...additionalHeaders,
-				...options.headers,
+				...serializeHeaders(options.headers),
 			})
 				.filter(([_, value]) => isDefined(value))
 				.reduce((headers, [key, value]) => ({

--- a/src/templates/core/angular/request.hbs
+++ b/src/templates/core/angular/request.hbs
@@ -10,6 +10,7 @@ import { ApiError } from './ApiError';
 import type { ApiRequestOptions } from './ApiRequestOptions';
 import type { ApiResult } from './ApiResult';
 import type { OpenAPIConfig } from './OpenAPI';
+import { SerializableParameter } from './SerializableParameter';
 
 {{>functions/isDefined}}
 

--- a/src/templates/core/axios/getHeaders.hbs
+++ b/src/templates/core/axios/getHeaders.hbs
@@ -5,10 +5,12 @@ const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions, for
 	const additionalHeaders = await resolve(options, config.HEADERS);
 	const formHeaders = typeof formData?.getHeaders === 'function' && formData?.getHeaders() || {}
 
+	{{>functions/serializeHeaders}}
+
 	const headers = Object.entries({
 		Accept: 'application/json',
 		...additionalHeaders,
-		...options.headers,
+		...serializeHeaders(options.headers),
 		...formHeaders,
 	})
 	.filter(([_, value]) => isDefined(value))

--- a/src/templates/core/axios/request.hbs
+++ b/src/templates/core/axios/request.hbs
@@ -10,6 +10,7 @@ import type { ApiResult } from './ApiResult';
 import { CancelablePromise } from './CancelablePromise';
 import type { OnCancel } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
+import { SerializableParameter } from './SerializableParameter';
 
 {{>functions/isDefined}}
 

--- a/src/templates/core/fetch/getHeaders.hbs
+++ b/src/templates/core/fetch/getHeaders.hbs
@@ -4,10 +4,12 @@ const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Pr
 	const password = await resolve(options, config.PASSWORD);
 	const additionalHeaders = await resolve(options, config.HEADERS);
 
+	{{>functions/serializeHeaders}}
+
 	const headers = Object.entries({
 		Accept: 'application/json',
 		...additionalHeaders,
-		...options.headers,
+		...serializeHeaders(options.headers),
 	})
 		.filter(([_, value]) => isDefined(value))
 		.reduce((headers, [key, value]) => ({

--- a/src/templates/core/fetch/request.hbs
+++ b/src/templates/core/fetch/request.hbs
@@ -6,6 +6,7 @@ import type { ApiResult } from './ApiResult';
 import { CancelablePromise } from './CancelablePromise';
 import type { OnCancel } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
+import { SerializableParameter } from './SerializableParameter';
 
 {{>functions/isDefined}}
 

--- a/src/templates/core/functions/getQueryString.hbs
+++ b/src/templates/core/functions/getQueryString.hbs
@@ -5,16 +5,44 @@ const getQueryString = (params: Record<string, any>): string => {
 		qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
 	};
 
-	const process = (key: string, value: any) => {
+	const process = (key: string, value: any, style = 'form', explode = true) => {
 		if (isDefined(value)) {
-			if (Array.isArray(value)) {
-				value.forEach(v => {
-					process(key, v);
-				});
+			if (value instanceof SerializableParameter) {
+				process(
+					value.parameterName,
+					value.parameterValue,
+					value.style || style,
+					value.explode !== null ? value.explode : explode,
+				);
+			} else if (Array.isArray(value)) {
+				if (!explode && style === 'form') {
+					append(key, value.join(','));
+				} else if (!explode && style === 'spaceDelimited') {
+					append(key, value.join(' '));
+				} else if (!explode && style === 'pipeDelimited') {
+					append(key, value.join('|'));
+				} else {
+					value.forEach(v => {
+						process(key, v);
+					});
+				}
 			} else if (typeof value === 'object') {
-				Object.entries(value).forEach(([k, v]) => {
-					process(`${key}[${k}]`, v);
-				});
+				if (style === 'form') {
+					if (explode) {
+						Object.entries(value).forEach(([k, v]) => {
+							append(k, v);
+						});
+					} else {
+						append(
+							key,
+							Object.entries(value).map(([k, v]) => `${k},${v}`).join(',')
+						);
+					}
+				} else {
+					Object.entries(value).forEach(([k, v]) => {
+						process(`${key}[${k}]`, v);
+					});
+				}
 			} else {
 				append(key, value);
 			}

--- a/src/templates/core/functions/getUrl.hbs
+++ b/src/templates/core/functions/getUrl.hbs
@@ -5,7 +5,53 @@ const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
 		.replace('{api-version}', config.VERSION)
 		.replace(/{(.*?)}/g, (substring: string, group: string) => {
 			if (options.path?.hasOwnProperty(group)) {
-				return encoder(String(options.path[group]));
+				const item = options.path[group];
+				if (!(item instanceof SerializableParameter)) {
+					return encoder(String(item));
+				}
+
+				const style = item.style || 'simple';
+				const explode = item.explode || false;
+				const name = item.parameterName;
+				const value = item.parameterValue;
+
+				if (Array.isArray(value)) {
+					if (style === 'label') {
+						return encoder(`.${value.join(explode ? '.' : ',')}`);
+					} else if (style === 'matrix') {
+						if (!explode) {
+							return encoder(`;${name}=${value.join(',')}`);
+						}
+
+						return encoder(`;${value.map((v) => `${name}=${v}`).join(';')}`);
+					} else {
+						return encoder(value.join(','));
+					}
+				} else if (typeof value === 'object') {
+					const entries = Object.entries(value);
+					if (style === 'simple' && explode) {
+						return encoder(entries.map(([k, v]) => `${k}=${v}`).join(','));
+					} else if (style === 'label') {
+						return encoder(`.${entries.map(([k, v]) => `${k},${v}`).join(explode ? '.' : ',')}`);
+					} else if (style === 'matrix') {
+						if (!explode) {
+							return encoder(`;${name}=${entries.map(([k, v]) => `${k},${v}`).join(',')}`);
+						}
+
+						return encoder(`;${entries.map(([k, v]) => `${k}=${v}`).join(';')}`);
+					}
+
+					return encoder(entries.map(([k, v]) => `${k},${v}`).join(','));
+				} else {
+					const stringVal = String(value);
+					if (style === 'label') {
+						return encoder(`.${stringVal}`);
+					} else if (style === 'matrix') {
+						return encoder(`;${name}=${stringVal}`);
+					} else {
+						return encoder(stringVal);
+					}
+				}
 			}
 			return substring;
 		});

--- a/src/templates/core/functions/serializeHeaders.hbs
+++ b/src/templates/core/functions/serializeHeaders.hbs
@@ -1,0 +1,32 @@
+const serializeHeaders = (headers?: Record<string, any>): Record<string, string> | undefined => {
+	if (!headers) {
+		return headers;
+	}
+
+	const out = {};
+
+	Object.entries(headers).forEach(([hKey, hValue]) => {
+		if (!(hValue instanceof SerializableParameter)) {
+			out[hKey] = hValue;
+			return;
+		}
+
+		const explode = hValue.explode || false;
+		const value = hValue.parameterValue;
+
+		if (Array.isArray(value)) {
+			out[hKey] = value.join(',');
+		} else if (typeof value === 'object') {
+			if (explode) {
+				out[hKey] = Object.entries(value).map(([k, v]) => `${k},${v}`).join(',');
+				return;
+			}
+
+			out[hKey] = Object.entries(value).map(([k, v]) => `${k}=${v}`).join(',');
+		} else {
+			out[hKey] = value;
+		}
+	});
+
+	return out;
+};

--- a/src/templates/core/node/getHeaders.hbs
+++ b/src/templates/core/node/getHeaders.hbs
@@ -4,10 +4,12 @@ const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Pr
 	const password = await resolve(options, config.PASSWORD);
 	const additionalHeaders = await resolve(options, config.HEADERS);
 
+	{{>functions/serializeHeaders}}
+
 	const headers = Object.entries({
 		Accept: 'application/json',
 		...additionalHeaders,
-		...options.headers,
+		...serializeHeaders(options.headers),
 	})
 		.filter(([_, value]) => isDefined(value))
 		.reduce((headers, [key, value]) => ({

--- a/src/templates/core/node/request.hbs
+++ b/src/templates/core/node/request.hbs
@@ -11,6 +11,7 @@ import type { ApiResult } from './ApiResult';
 import { CancelablePromise } from './CancelablePromise';
 import type { OnCancel } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
+import { SerializableParameter } from './SerializableParameter';
 
 {{>functions/isDefined}}
 

--- a/src/templates/core/xhr/getHeaders.hbs
+++ b/src/templates/core/xhr/getHeaders.hbs
@@ -4,10 +4,12 @@ const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Pr
 	const password = await resolve(options, config.PASSWORD);
 	const additionalHeaders = await resolve(options, config.HEADERS);
 
+	{{>functions/serializeHeaders}}
+
 	const headers = Object.entries({
 		Accept: 'application/json',
 		...additionalHeaders,
-		...options.headers,
+		...serializeHeaders(options.headers),
 	})
 		.filter(([_, value]) => isDefined(value))
 		.reduce((headers, [key, value]) => ({

--- a/src/templates/core/xhr/request.hbs
+++ b/src/templates/core/xhr/request.hbs
@@ -6,6 +6,7 @@ import type { ApiResult } from './ApiResult';
 import { CancelablePromise } from './CancelablePromise';
 import type { OnCancel } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
+import { SerializableParameter } from './SerializableParameter';
 
 {{>functions/isDefined}}
 

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -30,6 +30,7 @@ import type { BaseHttpRequest } from '../core/BaseHttpRequest';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
 {{/if}}
+import { SerializableParameter } from '../core/SerializableParameter';
 
 {{#equals @root.httpClient 'angular'}}
 @Injectable({
@@ -92,7 +93,7 @@ export class {{{name}}}{{{@root.postfix}}} {
 			{{#if parametersPath}}
 			path: {
 				{{#each parametersPath}}
-				'{{{prop}}}': {{{name}}},
+				'{{{prop}}}': new SerializableParameter('{{{prop}}}', '{{{style}}}', {{#if explode}}true{{else}}false{{/if}}, {{{name}}}),
 				{{/each}}
 			},
 			{{/if}}
@@ -106,14 +107,14 @@ export class {{{name}}}{{{@root.postfix}}} {
 			{{#if parametersHeader}}
 			headers: {
 				{{#each parametersHeader}}
-				'{{{prop}}}': {{{name}}},
+				'{{{prop}}}': new SerializableParameter('{{{prop}}}', '{{{style}}}', {{#if explode}}true{{else}}false{{/if}}, {{{name}}}),
 				{{/each}}
 			},
 			{{/if}}
 			{{#if parametersQuery}}
 			query: {
 				{{#each parametersQuery}}
-				'{{{prop}}}': {{{name}}},
+				'{{{prop}}}': new SerializableParameter('{{{prop}}}', '{{{style}}}', {{#if explode}}true{{else}}false{{/if}}, {{{name}}}),
 				{{/each}}
 			},
 			{{/if}}

--- a/src/utils/registerHandlebarTemplates.ts
+++ b/src/utils/registerHandlebarTemplates.ts
@@ -37,6 +37,7 @@ import functionIsString from '../templates/core/functions/isString.hbs';
 import functionIsStringWithValue from '../templates/core/functions/isStringWithValue.hbs';
 import functionIsSuccess from '../templates/core/functions/isSuccess.hbs';
 import functionResolve from '../templates/core/functions/resolve.hbs';
+import functionSerializeHeaders from '../templates/core/functions/serializeHeaders.hbs';
 import templateCoreHttpRequest from '../templates/core/HttpRequest.hbs';
 import nodeGetHeaders from '../templates/core/node/getHeaders.hbs';
 import nodeGetRequestBody from '../templates/core/node/getRequestBody.hbs';
@@ -46,6 +47,7 @@ import nodeRequest from '../templates/core/node/request.hbs';
 import nodeSendRequest from '../templates/core/node/sendRequest.hbs';
 import templateCoreSettings from '../templates/core/OpenAPI.hbs';
 import templateCoreRequest from '../templates/core/request.hbs';
+import templateSerializableParameter from '../templates/core/SerializableParameter.hbs';
 import xhrGetHeaders from '../templates/core/xhr/getHeaders.hbs';
 import xhrGetRequestBody from '../templates/core/xhr/getRequestBody.hbs';
 import xhrGetResponseBody from '../templates/core/xhr/getResponseBody.hbs';
@@ -102,6 +104,7 @@ export interface Templates {
         request: Handlebars.TemplateDelegate;
         baseHttpRequest: Handlebars.TemplateDelegate;
         httpRequest: Handlebars.TemplateDelegate;
+        serializableParameter: Handlebars.TemplateDelegate;
     };
 }
 
@@ -134,6 +137,7 @@ export const registerHandlebarTemplates = (root: {
             request: Handlebars.template(templateCoreRequest),
             baseHttpRequest: Handlebars.template(templateCoreBaseHttpRequest),
             httpRequest: Handlebars.template(templateCoreHttpRequest),
+            serializableParameter: Handlebars.template(templateSerializableParameter),
         },
     };
 
@@ -179,6 +183,9 @@ export const registerHandlebarTemplates = (root: {
     Handlebars.registerPartial('functions/isSuccess', Handlebars.template(functionIsSuccess));
     Handlebars.registerPartial('functions/base64', Handlebars.template(functionBase64));
     Handlebars.registerPartial('functions/resolve', Handlebars.template(functionResolve));
+
+    // Generic functions used in client implementations
+    Handlebars.registerPartial('functions/serializeHeaders', Handlebars.template(functionSerializeHeaders));
 
     // Specific files for the fetch client implementation
     Handlebars.registerPartial('fetch/getHeaders', Handlebars.template(fetchGetHeaders));

--- a/src/utils/writeClient.spec.ts
+++ b/src/utils/writeClient.spec.ts
@@ -33,6 +33,7 @@ describe('writeClient', () => {
                 request: () => 'request',
                 baseHttpRequest: () => 'baseHttpRequest',
                 httpRequest: () => 'httpRequest',
+                serializableParameter: () => 'serializableParameter',
             },
         };
 

--- a/src/utils/writeClientClass.spec.ts
+++ b/src/utils/writeClientClass.spec.ts
@@ -33,6 +33,7 @@ describe('writeClientClass', () => {
                 request: () => 'request',
                 baseHttpRequest: () => 'baseHttpRequest',
                 httpRequest: () => 'httpRequest',
+                serializableParameter: () => 'serializableParameter',
             },
         };
 

--- a/src/utils/writeClientCore.spec.ts
+++ b/src/utils/writeClientCore.spec.ts
@@ -35,6 +35,7 @@ describe('writeClientCore', () => {
                 request: () => 'request',
                 baseHttpRequest: () => 'baseHttpRequest',
                 httpRequest: () => 'httpRequest',
+                serializableParameter: () => 'serializableParameter',
             },
         };
 

--- a/src/utils/writeClientCore.ts
+++ b/src/utils/writeClientCore.ts
@@ -43,6 +43,10 @@ export const writeClientCore = async (
     await writeFile(resolve(outputPath, 'ApiResult.ts'), i(templates.core.apiResult(context), indent));
     await writeFile(resolve(outputPath, 'CancelablePromise.ts'), i(templates.core.cancelablePromise(context), indent));
     await writeFile(resolve(outputPath, 'request.ts'), i(templates.core.request(context), indent));
+    await writeFile(
+        resolve(outputPath, 'SerializableParameter.ts'),
+        i(templates.core.serializableParameter(context), indent)
+    );
 
     if (isDefined(clientName)) {
         await writeFile(resolve(outputPath, 'BaseHttpRequest.ts'), i(templates.core.baseHttpRequest(context), indent));

--- a/src/utils/writeClientIndex.spec.ts
+++ b/src/utils/writeClientIndex.spec.ts
@@ -31,6 +31,7 @@ describe('writeClientIndex', () => {
                 request: () => 'request',
                 baseHttpRequest: () => 'baseHttpRequest',
                 httpRequest: () => 'httpRequest',
+                serializableParameter: () => 'serializableParameter',
             },
         };
 

--- a/src/utils/writeClientModels.spec.ts
+++ b/src/utils/writeClientModels.spec.ts
@@ -48,6 +48,7 @@ describe('writeClientModels', () => {
                 request: () => 'request',
                 baseHttpRequest: () => 'baseHttpRequest',
                 httpRequest: () => 'httpRequest',
+                serializableParameter: () => 'serializableParameter',
             },
         };
 

--- a/src/utils/writeClientSchemas.spec.ts
+++ b/src/utils/writeClientSchemas.spec.ts
@@ -48,6 +48,7 @@ describe('writeClientSchemas', () => {
                 request: () => 'request',
                 baseHttpRequest: () => 'baseHttpRequest',
                 httpRequest: () => 'httpRequest',
+                serializableParameter: () => 'serializableParameter',
             },
         };
 

--- a/src/utils/writeClientServices.spec.ts
+++ b/src/utils/writeClientServices.spec.ts
@@ -36,6 +36,7 @@ describe('writeClientServices', () => {
                 request: () => 'request',
                 baseHttpRequest: () => 'baseHttpRequest',
                 httpRequest: () => 'httpRequest',
+                serializableParameter: () => 'serializableParameter',
             },
         };
 

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -229,6 +229,26 @@ export const OpenAPI: OpenAPIConfig = {
 "
 `;
 
+exports[`v2 should generate: ./test/generated/v2/core/SerializableParameter.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export class SerializableParameter {
+    public readonly parameterName: string;
+    public readonly style: string | null;
+    public readonly explode: boolean | null;
+    public readonly parameterValue: any;
+
+    constructor(parameterName: string, style: string | null, explode: boolean | null, parameterValue: any) {
+        this.parameterName = parameterName;
+        this.style = style;
+        this.explode = explode;
+        this.parameterValue = parameterValue;
+    }
+}
+"
+`;
+
 exports[`v2 should generate: ./test/generated/v2/core/request.ts 1`] = `
 "/* istanbul ignore file */
 /* tslint:disable */
@@ -239,6 +259,7 @@ import type { ApiResult } from './ApiResult';
 import { CancelablePromise } from './CancelablePromise';
 import type { OnCancel } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
+import { SerializableParameter } from './SerializableParameter';
 
 const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
     return value !== undefined && value !== null;
@@ -285,16 +306,44 @@ const getQueryString = (params: Record<string, any>): string => {
         qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
     };
 
-    const process = (key: string, value: any) => {
+    const process = (key: string, value: any, style = 'form', explode = true) => {
         if (isDefined(value)) {
-            if (Array.isArray(value)) {
-                value.forEach(v => {
-                    process(key, v);
-                });
+            if (value instanceof SerializableParameter) {
+                process(
+                    value.parameterName,
+                    value.parameterValue,
+                    value.style || style,
+                    value.explode !== null ? value.explode : explode,
+                );
+            } else if (Array.isArray(value)) {
+                if (!explode && style === 'form') {
+                    append(key, value.join(','));
+                } else if (!explode && style === 'spaceDelimited') {
+                    append(key, value.join(' '));
+                } else if (!explode && style === 'pipeDelimited') {
+                    append(key, value.join('|'));
+                } else {
+                    value.forEach(v => {
+                        process(key, v);
+                    });
+                }
             } else if (typeof value === 'object') {
-                Object.entries(value).forEach(([k, v]) => {
-                    process(\`\${key}[\${k}]\`, v);
-                });
+                if (style === 'form') {
+                    if (explode) {
+                        Object.entries(value).forEach(([k, v]) => {
+                            append(k, v);
+                        });
+                    } else {
+                        append(
+                            key,
+                            Object.entries(value).map(([k, v]) => \`\${k},\${v}\`).join(',')
+                        );
+                    }
+                } else {
+                    Object.entries(value).forEach(([k, v]) => {
+                        process(\`\${key}[\${k}]\`, v);
+                    });
+                }
             } else {
                 append(key, value);
             }
@@ -319,7 +368,53 @@ const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
         .replace('{api-version}', config.VERSION)
         .replace(/{(.*?)}/g, (substring: string, group: string) => {
             if (options.path?.hasOwnProperty(group)) {
-                return encoder(String(options.path[group]));
+                const item = options.path[group];
+                if (!(item instanceof SerializableParameter)) {
+                    return encoder(String(item));
+                }
+
+                const style = item.style || 'simple';
+                const explode = item.explode || false;
+                const name = item.parameterName;
+                const value = item.parameterValue;
+
+                if (Array.isArray(value)) {
+                    if (style === 'label') {
+                        return encoder(\`.\${value.join(explode ? '.' : ',')}\`);
+                    } else if (style === 'matrix') {
+                        if (!explode) {
+                            return encoder(\`;\${name}=\${value.join(',')}\`);
+                        }
+
+                        return encoder(\`;\${value.map((v) => \`\${name}=\${v}\`).join(';')}\`);
+                    } else {
+                        return encoder(value.join(','));
+                    }
+                } else if (typeof value === 'object') {
+                    const entries = Object.entries(value);
+                    if (style === 'simple' && explode) {
+                        return encoder(entries.map(([k, v]) => \`\${k}=\${v}\`).join(','));
+                    } else if (style === 'label') {
+                        return encoder(\`.\${entries.map(([k, v]) => \`\${k},\${v}\`).join(explode ? '.' : ',')}\`);
+                    } else if (style === 'matrix') {
+                        if (!explode) {
+                            return encoder(\`;\${name}=\${entries.map(([k, v]) => \`\${k},\${v}\`).join(',')}\`);
+                        }
+
+                        return encoder(\`;\${entries.map(([k, v]) => \`\${k}=\${v}\`).join(';')}\`);
+                    }
+
+                    return encoder(entries.map(([k, v]) => \`\${k},\${v}\`).join(','));
+                } else {
+                    const stringVal = String(value);
+                    if (style === 'label') {
+                        return encoder(\`.\${stringVal}\`);
+                    } else if (style === 'matrix') {
+                        return encoder(\`;\${name}=\${stringVal}\`);
+                    } else {
+                        return encoder(stringVal);
+                    }
+                }
             }
             return substring;
         });
@@ -373,10 +468,42 @@ const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Pr
     const password = await resolve(options, config.PASSWORD);
     const additionalHeaders = await resolve(options, config.HEADERS);
 
+    const serializeHeaders = (headers?: Record<string, any>): Record<string, string> | undefined => {
+    if (!headers) {
+        return headers;
+    }
+
+    const out = {};
+
+    Object.entries(headers).forEach(([hKey, hValue]) => {
+        if (!(hValue instanceof SerializableParameter)) {
+            out[hKey] = hValue;
+            return;
+        }
+
+        const explode = hValue.explode || false;
+        const value = hValue.parameterValue;
+
+        if (Array.isArray(value)) {
+            out[hKey] = value.join(',');
+        } else if (typeof value === 'object') {
+            if (explode) {
+                out[hKey] = Object.entries(value).map(([k, v]) => \`\${k},\${v}\`).join(',');
+                return;
+            }
+
+            out[hKey] = Object.entries(value).map(([k, v]) => \`\${k}=\${v}\`).join(',');
+        } else {
+            out[hKey] = value;
+        }
+    });
+
+    return out;
+};
     const headers = Object.entries({
         Accept: 'application/json',
         ...additionalHeaders,
-        ...options.headers,
+        ...serializeHeaders(options.headers),
     })
         .filter(([_, value]) => isDefined(value))
         .reduce((headers, [key, value]) => ({
@@ -2284,6 +2411,7 @@ exports[`v2 should generate: ./test/generated/v2/services/CollectionFormatServic
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class CollectionFormatService {
 
@@ -2306,11 +2434,11 @@ export class CollectionFormatService {
             method: 'GET',
             url: '/api/v{api-version}/collectionFormat',
             query: {
-                'parameterArrayCSV': parameterArrayCsv,
-                'parameterArraySSV': parameterArraySsv,
-                'parameterArrayTSV': parameterArrayTsv,
-                'parameterArrayPipes': parameterArrayPipes,
-                'parameterArrayMulti': parameterArrayMulti,
+                'parameterArrayCSV': new SerializableParameter('parameterArrayCSV', '', false, parameterArrayCsv),
+                'parameterArraySSV': new SerializableParameter('parameterArraySSV', '', false, parameterArraySsv),
+                'parameterArrayTSV': new SerializableParameter('parameterArrayTSV', '', false, parameterArrayTsv),
+                'parameterArrayPipes': new SerializableParameter('parameterArrayPipes', '', false, parameterArrayPipes),
+                'parameterArrayMulti': new SerializableParameter('parameterArrayMulti', '', false, parameterArrayMulti),
             },
         });
     }
@@ -2328,6 +2456,7 @@ import type { ModelWithString } from '../models/ModelWithString';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class ComplexService {
 
@@ -2351,8 +2480,8 @@ export class ComplexService {
             method: 'GET',
             url: '/api/v{api-version}/complex',
             query: {
-                'parameterObject': parameterObject,
-                'parameterReference': parameterReference,
+                'parameterObject': new SerializableParameter('parameterObject', '', false, parameterObject),
+                'parameterReference': new SerializableParameter('parameterReference', '', false, parameterReference),
             },
             errors: {
                 400: \`400 server error\`,
@@ -2372,6 +2501,7 @@ exports[`v2 should generate: ./test/generated/v2/services/DefaultService.ts 1`] 
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class DefaultService {
 
@@ -2398,6 +2528,7 @@ import type { ModelWithString } from '../models/ModelWithString';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class DefaultsService {
 
@@ -2422,11 +2553,11 @@ export class DefaultsService {
             method: 'GET',
             url: '/api/v{api-version}/defaults',
             query: {
-                'parameterString': parameterString,
-                'parameterNumber': parameterNumber,
-                'parameterBoolean': parameterBoolean,
-                'parameterEnum': parameterEnum,
-                'parameterModel': parameterModel,
+                'parameterString': new SerializableParameter('parameterString', '', false, parameterString),
+                'parameterNumber': new SerializableParameter('parameterNumber', '', false, parameterNumber),
+                'parameterBoolean': new SerializableParameter('parameterBoolean', '', false, parameterBoolean),
+                'parameterEnum': new SerializableParameter('parameterEnum', '', false, parameterEnum),
+                'parameterModel': new SerializableParameter('parameterModel', '', false, parameterModel),
             },
         });
     }
@@ -2452,11 +2583,11 @@ export class DefaultsService {
             method: 'POST',
             url: '/api/v{api-version}/defaults',
             query: {
-                'parameterString': parameterString,
-                'parameterNumber': parameterNumber,
-                'parameterBoolean': parameterBoolean,
-                'parameterEnum': parameterEnum,
-                'parameterModel': parameterModel,
+                'parameterString': new SerializableParameter('parameterString', '', false, parameterString),
+                'parameterNumber': new SerializableParameter('parameterNumber', '', false, parameterNumber),
+                'parameterBoolean': new SerializableParameter('parameterBoolean', '', false, parameterBoolean),
+                'parameterEnum': new SerializableParameter('parameterEnum', '', false, parameterEnum),
+                'parameterModel': new SerializableParameter('parameterModel', '', false, parameterModel),
             },
         });
     }
@@ -2486,14 +2617,14 @@ export class DefaultsService {
             method: 'PUT',
             url: '/api/v{api-version}/defaults',
             query: {
-                'parameterOptionalStringWithDefault': parameterOptionalStringWithDefault,
-                'parameterOptionalStringWithEmptyDefault': parameterOptionalStringWithEmptyDefault,
-                'parameterOptionalStringWithNoDefault': parameterOptionalStringWithNoDefault,
-                'parameterStringWithDefault': parameterStringWithDefault,
-                'parameterStringWithEmptyDefault': parameterStringWithEmptyDefault,
-                'parameterStringWithNoDefault': parameterStringWithNoDefault,
-                'parameterStringNullableWithNoDefault': parameterStringNullableWithNoDefault,
-                'parameterStringNullableWithDefault': parameterStringNullableWithDefault,
+                'parameterOptionalStringWithDefault': new SerializableParameter('parameterOptionalStringWithDefault', '', false, parameterOptionalStringWithDefault),
+                'parameterOptionalStringWithEmptyDefault': new SerializableParameter('parameterOptionalStringWithEmptyDefault', '', false, parameterOptionalStringWithEmptyDefault),
+                'parameterOptionalStringWithNoDefault': new SerializableParameter('parameterOptionalStringWithNoDefault', '', false, parameterOptionalStringWithNoDefault),
+                'parameterStringWithDefault': new SerializableParameter('parameterStringWithDefault', '', false, parameterStringWithDefault),
+                'parameterStringWithEmptyDefault': new SerializableParameter('parameterStringWithEmptyDefault', '', false, parameterStringWithEmptyDefault),
+                'parameterStringWithNoDefault': new SerializableParameter('parameterStringWithNoDefault', '', false, parameterStringWithNoDefault),
+                'parameterStringNullableWithNoDefault': new SerializableParameter('parameterStringNullableWithNoDefault', '', false, parameterStringNullableWithNoDefault),
+                'parameterStringNullableWithDefault': new SerializableParameter('parameterStringNullableWithDefault', '', false, parameterStringNullableWithDefault),
             },
         });
     }
@@ -2509,6 +2640,7 @@ exports[`v2 should generate: ./test/generated/v2/services/DescriptionsService.ts
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class DescriptionsService {
 
@@ -2536,12 +2668,12 @@ export class DescriptionsService {
             method: 'POST',
             url: '/api/v{api-version}/descriptions/',
             query: {
-                'parameterWithBreaks': parameterWithBreaks,
-                'parameterWithBackticks': parameterWithBackticks,
-                'parameterWithSlashes': parameterWithSlashes,
-                'parameterWithExpressionPlaceholders': parameterWithExpressionPlaceholders,
-                'parameterWithQuotes': parameterWithQuotes,
-                'parameterWithReservedCharacters': parameterWithReservedCharacters,
+                'parameterWithBreaks': new SerializableParameter('parameterWithBreaks', '', false, parameterWithBreaks),
+                'parameterWithBackticks': new SerializableParameter('parameterWithBackticks', '', false, parameterWithBackticks),
+                'parameterWithSlashes': new SerializableParameter('parameterWithSlashes', '', false, parameterWithSlashes),
+                'parameterWithExpressionPlaceholders': new SerializableParameter('parameterWithExpressionPlaceholders', '', false, parameterWithExpressionPlaceholders),
+                'parameterWithQuotes': new SerializableParameter('parameterWithQuotes', '', false, parameterWithQuotes),
+                'parameterWithReservedCharacters': new SerializableParameter('parameterWithReservedCharacters', '', false, parameterWithReservedCharacters),
             },
         });
     }
@@ -2557,6 +2689,7 @@ exports[`v2 should generate: ./test/generated/v2/services/DuplicateService.ts 1`
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class DuplicateService {
 
@@ -2611,6 +2744,7 @@ exports[`v2 should generate: ./test/generated/v2/services/ErrorService.ts 1`] = 
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class ErrorService {
 
@@ -2626,7 +2760,7 @@ export class ErrorService {
             method: 'POST',
             url: '/api/v{api-version}/error',
             query: {
-                'status': status,
+                'status': new SerializableParameter('status', '', false, status),
             },
             errors: {
                 500: \`Custom message: Internal Server Error\`,
@@ -2648,6 +2782,7 @@ exports[`v2 should generate: ./test/generated/v2/services/HeaderService.ts 1`] =
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class HeaderService {
 
@@ -2678,6 +2813,7 @@ exports[`v2 should generate: ./test/generated/v2/services/MultipleTags1Service.t
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class MultipleTags1Service {
 
@@ -2714,6 +2850,7 @@ exports[`v2 should generate: ./test/generated/v2/services/MultipleTags2Service.t
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class MultipleTags2Service {
 
@@ -2750,6 +2887,7 @@ exports[`v2 should generate: ./test/generated/v2/services/MultipleTags3Service.t
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class MultipleTags3Service {
 
@@ -2775,6 +2913,7 @@ exports[`v2 should generate: ./test/generated/v2/services/NoContentService.ts 1`
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class NoContentService {
 
@@ -2800,6 +2939,7 @@ exports[`v2 should generate: ./test/generated/v2/services/ParametersService.ts 1
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class ParametersService {
 
@@ -2822,13 +2962,13 @@ export class ParametersService {
             method: 'POST',
             url: '/api/v{api-version}/parameters/{parameterPath}',
             path: {
-                'parameterPath': parameterPath,
+                'parameterPath': new SerializableParameter('parameterPath', '', false, parameterPath),
             },
             headers: {
-                'parameterHeader': parameterHeader,
+                'parameterHeader': new SerializableParameter('parameterHeader', '', false, parameterHeader),
             },
             query: {
-                'parameterQuery': parameterQuery,
+                'parameterQuery': new SerializableParameter('parameterQuery', '', false, parameterQuery),
             },
             formData: {
                 'parameterForm': parameterForm,
@@ -2862,16 +3002,16 @@ export class ParametersService {
             method: 'POST',
             url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
             path: {
-                'parameter.path.1': parameterPath1,
-                'parameter-path-2': parameterPath2,
-                'PARAMETER-PATH-3': parameterPath3,
+                'parameter.path.1': new SerializableParameter('parameter.path.1', '', false, parameterPath1),
+                'parameter-path-2': new SerializableParameter('parameter-path-2', '', false, parameterPath2),
+                'PARAMETER-PATH-3': new SerializableParameter('PARAMETER-PATH-3', '', false, parameterPath3),
             },
             headers: {
-                'parameter.header': parameterHeader,
+                'parameter.header': new SerializableParameter('parameter.header', '', false, parameterHeader),
             },
             query: {
-                'default': _default,
-                'parameter-query': parameterQuery,
+                'default': new SerializableParameter('default', '', false, _default),
+                'parameter-query': new SerializableParameter('parameter-query', '', false, parameterQuery),
             },
             formData: {
                 'parameter_form': parameterForm,
@@ -2895,6 +3035,7 @@ import type { ModelWithString } from '../models/ModelWithString';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class ResponseService {
 
@@ -2959,6 +3100,7 @@ exports[`v2 should generate: ./test/generated/v2/services/SimpleService.ts 1`] =
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class SimpleService {
 
@@ -3043,6 +3185,7 @@ exports[`v2 should generate: ./test/generated/v2/services/TypesService.ts 1`] = 
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class TypesService {
 
@@ -3075,16 +3218,16 @@ export class TypesService {
             method: 'GET',
             url: '/api/v{api-version}/types',
             path: {
-                'id': id,
+                'id': new SerializableParameter('id', '', false, id),
             },
             query: {
-                'parameterNumber': parameterNumber,
-                'parameterString': parameterString,
-                'parameterBoolean': parameterBoolean,
-                'parameterObject': parameterObject,
-                'parameterArray': parameterArray,
-                'parameterDictionary': parameterDictionary,
-                'parameterEnum': parameterEnum,
+                'parameterNumber': new SerializableParameter('parameterNumber', '', false, parameterNumber),
+                'parameterString': new SerializableParameter('parameterString', '', false, parameterString),
+                'parameterBoolean': new SerializableParameter('parameterBoolean', '', false, parameterBoolean),
+                'parameterObject': new SerializableParameter('parameterObject', '', false, parameterObject),
+                'parameterArray': new SerializableParameter('parameterArray', '', false, parameterArray),
+                'parameterDictionary': new SerializableParameter('parameterDictionary', '', false, parameterDictionary),
+                'parameterEnum': new SerializableParameter('parameterEnum', '', false, parameterEnum),
             },
         });
     }
@@ -3322,6 +3465,26 @@ export const OpenAPI: OpenAPIConfig = {
 "
 `;
 
+exports[`v3 should generate: ./test/generated/v3/core/SerializableParameter.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export class SerializableParameter {
+    public readonly parameterName: string;
+    public readonly style: string | null;
+    public readonly explode: boolean | null;
+    public readonly parameterValue: any;
+
+    constructor(parameterName: string, style: string | null, explode: boolean | null, parameterValue: any) {
+        this.parameterName = parameterName;
+        this.style = style;
+        this.explode = explode;
+        this.parameterValue = parameterValue;
+    }
+}
+"
+`;
+
 exports[`v3 should generate: ./test/generated/v3/core/request.ts 1`] = `
 "/* istanbul ignore file */
 /* tslint:disable */
@@ -3332,6 +3495,7 @@ import type { ApiResult } from './ApiResult';
 import { CancelablePromise } from './CancelablePromise';
 import type { OnCancel } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
+import { SerializableParameter } from './SerializableParameter';
 
 const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
     return value !== undefined && value !== null;
@@ -3378,16 +3542,44 @@ const getQueryString = (params: Record<string, any>): string => {
         qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
     };
 
-    const process = (key: string, value: any) => {
+    const process = (key: string, value: any, style = 'form', explode = true) => {
         if (isDefined(value)) {
-            if (Array.isArray(value)) {
-                value.forEach(v => {
-                    process(key, v);
-                });
+            if (value instanceof SerializableParameter) {
+                process(
+                    value.parameterName,
+                    value.parameterValue,
+                    value.style || style,
+                    value.explode !== null ? value.explode : explode,
+                );
+            } else if (Array.isArray(value)) {
+                if (!explode && style === 'form') {
+                    append(key, value.join(','));
+                } else if (!explode && style === 'spaceDelimited') {
+                    append(key, value.join(' '));
+                } else if (!explode && style === 'pipeDelimited') {
+                    append(key, value.join('|'));
+                } else {
+                    value.forEach(v => {
+                        process(key, v);
+                    });
+                }
             } else if (typeof value === 'object') {
-                Object.entries(value).forEach(([k, v]) => {
-                    process(\`\${key}[\${k}]\`, v);
-                });
+                if (style === 'form') {
+                    if (explode) {
+                        Object.entries(value).forEach(([k, v]) => {
+                            append(k, v);
+                        });
+                    } else {
+                        append(
+                            key,
+                            Object.entries(value).map(([k, v]) => \`\${k},\${v}\`).join(',')
+                        );
+                    }
+                } else {
+                    Object.entries(value).forEach(([k, v]) => {
+                        process(\`\${key}[\${k}]\`, v);
+                    });
+                }
             } else {
                 append(key, value);
             }
@@ -3412,7 +3604,53 @@ const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
         .replace('{api-version}', config.VERSION)
         .replace(/{(.*?)}/g, (substring: string, group: string) => {
             if (options.path?.hasOwnProperty(group)) {
-                return encoder(String(options.path[group]));
+                const item = options.path[group];
+                if (!(item instanceof SerializableParameter)) {
+                    return encoder(String(item));
+                }
+
+                const style = item.style || 'simple';
+                const explode = item.explode || false;
+                const name = item.parameterName;
+                const value = item.parameterValue;
+
+                if (Array.isArray(value)) {
+                    if (style === 'label') {
+                        return encoder(\`.\${value.join(explode ? '.' : ',')}\`);
+                    } else if (style === 'matrix') {
+                        if (!explode) {
+                            return encoder(\`;\${name}=\${value.join(',')}\`);
+                        }
+
+                        return encoder(\`;\${value.map((v) => \`\${name}=\${v}\`).join(';')}\`);
+                    } else {
+                        return encoder(value.join(','));
+                    }
+                } else if (typeof value === 'object') {
+                    const entries = Object.entries(value);
+                    if (style === 'simple' && explode) {
+                        return encoder(entries.map(([k, v]) => \`\${k}=\${v}\`).join(','));
+                    } else if (style === 'label') {
+                        return encoder(\`.\${entries.map(([k, v]) => \`\${k},\${v}\`).join(explode ? '.' : ',')}\`);
+                    } else if (style === 'matrix') {
+                        if (!explode) {
+                            return encoder(\`;\${name}=\${entries.map(([k, v]) => \`\${k},\${v}\`).join(',')}\`);
+                        }
+
+                        return encoder(\`;\${entries.map(([k, v]) => \`\${k}=\${v}\`).join(';')}\`);
+                    }
+
+                    return encoder(entries.map(([k, v]) => \`\${k},\${v}\`).join(','));
+                } else {
+                    const stringVal = String(value);
+                    if (style === 'label') {
+                        return encoder(\`.\${stringVal}\`);
+                    } else if (style === 'matrix') {
+                        return encoder(\`;\${name}=\${stringVal}\`);
+                    } else {
+                        return encoder(stringVal);
+                    }
+                }
             }
             return substring;
         });
@@ -3466,10 +3704,42 @@ const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Pr
     const password = await resolve(options, config.PASSWORD);
     const additionalHeaders = await resolve(options, config.HEADERS);
 
+    const serializeHeaders = (headers?: Record<string, any>): Record<string, string> | undefined => {
+    if (!headers) {
+        return headers;
+    }
+
+    const out = {};
+
+    Object.entries(headers).forEach(([hKey, hValue]) => {
+        if (!(hValue instanceof SerializableParameter)) {
+            out[hKey] = hValue;
+            return;
+        }
+
+        const explode = hValue.explode || false;
+        const value = hValue.parameterValue;
+
+        if (Array.isArray(value)) {
+            out[hKey] = value.join(',');
+        } else if (typeof value === 'object') {
+            if (explode) {
+                out[hKey] = Object.entries(value).map(([k, v]) => \`\${k},\${v}\`).join(',');
+                return;
+            }
+
+            out[hKey] = Object.entries(value).map(([k, v]) => \`\${k}=\${v}\`).join(',');
+        } else {
+            out[hKey] = value;
+        }
+    });
+
+    return out;
+};
     const headers = Object.entries({
         Accept: 'application/json',
         ...additionalHeaders,
-        ...options.headers,
+        ...serializeHeaders(options.headers),
     })
         .filter(([_, value]) => isDefined(value))
         .reduce((headers, [key, value]) => ({
@@ -6274,6 +6544,7 @@ exports[`v3 should generate: ./test/generated/v3/services/CollectionFormatServic
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class CollectionFormatService {
 
@@ -6296,11 +6567,11 @@ export class CollectionFormatService {
             method: 'GET',
             url: '/api/v{api-version}/collectionFormat',
             query: {
-                'parameterArrayCSV': parameterArrayCsv,
-                'parameterArraySSV': parameterArraySsv,
-                'parameterArrayTSV': parameterArrayTsv,
-                'parameterArrayPipes': parameterArrayPipes,
-                'parameterArrayMulti': parameterArrayMulti,
+                'parameterArrayCSV': new SerializableParameter('parameterArrayCSV', '', false, parameterArrayCsv),
+                'parameterArraySSV': new SerializableParameter('parameterArraySSV', '', false, parameterArraySsv),
+                'parameterArrayTSV': new SerializableParameter('parameterArrayTSV', '', false, parameterArrayTsv),
+                'parameterArrayPipes': new SerializableParameter('parameterArrayPipes', '', false, parameterArrayPipes),
+                'parameterArrayMulti': new SerializableParameter('parameterArrayMulti', '', false, parameterArrayMulti),
             },
         });
     }
@@ -6321,6 +6592,7 @@ import type { ModelWithString } from '../models/ModelWithString';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class ComplexService {
 
@@ -6344,8 +6616,8 @@ export class ComplexService {
             method: 'GET',
             url: '/api/v{api-version}/complex',
             query: {
-                'parameterObject': parameterObject,
-                'parameterReference': parameterReference,
+                'parameterObject': new SerializableParameter('parameterObject', '', false, parameterObject),
+                'parameterReference': new SerializableParameter('parameterReference', '', false, parameterReference),
             },
             errors: {
                 400: \`400 server error\`,
@@ -6380,7 +6652,7 @@ export class ComplexService {
             method: 'PUT',
             url: '/api/v{api-version}/complex/{id}',
             path: {
-                'id': id,
+                'id': new SerializableParameter('id', '', false, id),
             },
             body: requestBody,
             mediaType: 'application/json-patch+json',
@@ -6398,6 +6670,7 @@ exports[`v3 should generate: ./test/generated/v3/services/DefaultService.ts 1`] 
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class DefaultService {
 
@@ -6424,6 +6697,7 @@ import type { ModelWithString } from '../models/ModelWithString';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class DefaultsService {
 
@@ -6448,11 +6722,11 @@ export class DefaultsService {
             method: 'GET',
             url: '/api/v{api-version}/defaults',
             query: {
-                'parameterString': parameterString,
-                'parameterNumber': parameterNumber,
-                'parameterBoolean': parameterBoolean,
-                'parameterEnum': parameterEnum,
-                'parameterModel': parameterModel,
+                'parameterString': new SerializableParameter('parameterString', '', false, parameterString),
+                'parameterNumber': new SerializableParameter('parameterNumber', '', false, parameterNumber),
+                'parameterBoolean': new SerializableParameter('parameterBoolean', '', false, parameterBoolean),
+                'parameterEnum': new SerializableParameter('parameterEnum', '', false, parameterEnum),
+                'parameterModel': new SerializableParameter('parameterModel', '', false, parameterModel),
             },
         });
     }
@@ -6478,11 +6752,11 @@ export class DefaultsService {
             method: 'POST',
             url: '/api/v{api-version}/defaults',
             query: {
-                'parameterString': parameterString,
-                'parameterNumber': parameterNumber,
-                'parameterBoolean': parameterBoolean,
-                'parameterEnum': parameterEnum,
-                'parameterModel': parameterModel,
+                'parameterString': new SerializableParameter('parameterString', '', false, parameterString),
+                'parameterNumber': new SerializableParameter('parameterNumber', '', false, parameterNumber),
+                'parameterBoolean': new SerializableParameter('parameterBoolean', '', false, parameterBoolean),
+                'parameterEnum': new SerializableParameter('parameterEnum', '', false, parameterEnum),
+                'parameterModel': new SerializableParameter('parameterModel', '', false, parameterModel),
             },
         });
     }
@@ -6512,14 +6786,14 @@ export class DefaultsService {
             method: 'PUT',
             url: '/api/v{api-version}/defaults',
             query: {
-                'parameterOptionalStringWithDefault': parameterOptionalStringWithDefault,
-                'parameterOptionalStringWithEmptyDefault': parameterOptionalStringWithEmptyDefault,
-                'parameterOptionalStringWithNoDefault': parameterOptionalStringWithNoDefault,
-                'parameterStringWithDefault': parameterStringWithDefault,
-                'parameterStringWithEmptyDefault': parameterStringWithEmptyDefault,
-                'parameterStringWithNoDefault': parameterStringWithNoDefault,
-                'parameterStringNullableWithNoDefault': parameterStringNullableWithNoDefault,
-                'parameterStringNullableWithDefault': parameterStringNullableWithDefault,
+                'parameterOptionalStringWithDefault': new SerializableParameter('parameterOptionalStringWithDefault', '', false, parameterOptionalStringWithDefault),
+                'parameterOptionalStringWithEmptyDefault': new SerializableParameter('parameterOptionalStringWithEmptyDefault', '', false, parameterOptionalStringWithEmptyDefault),
+                'parameterOptionalStringWithNoDefault': new SerializableParameter('parameterOptionalStringWithNoDefault', '', false, parameterOptionalStringWithNoDefault),
+                'parameterStringWithDefault': new SerializableParameter('parameterStringWithDefault', '', false, parameterStringWithDefault),
+                'parameterStringWithEmptyDefault': new SerializableParameter('parameterStringWithEmptyDefault', '', false, parameterStringWithEmptyDefault),
+                'parameterStringWithNoDefault': new SerializableParameter('parameterStringWithNoDefault', '', false, parameterStringWithNoDefault),
+                'parameterStringNullableWithNoDefault': new SerializableParameter('parameterStringNullableWithNoDefault', '', false, parameterStringNullableWithNoDefault),
+                'parameterStringNullableWithDefault': new SerializableParameter('parameterStringNullableWithDefault', '', false, parameterStringNullableWithDefault),
             },
         });
     }
@@ -6537,6 +6811,7 @@ import type { DeprecatedModel } from '../models/DeprecatedModel';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class DeprecatedService {
 
@@ -6552,7 +6827,7 @@ export class DeprecatedService {
             method: 'POST',
             url: '/api/v{api-version}/parameters/deprecated',
             headers: {
-                'parameter': parameter,
+                'parameter': new SerializableParameter('parameter', '', false, parameter),
             },
         });
     }
@@ -6568,6 +6843,7 @@ exports[`v3 should generate: ./test/generated/v3/services/DescriptionsService.ts
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class DescriptionsService {
 
@@ -6595,12 +6871,12 @@ export class DescriptionsService {
             method: 'POST',
             url: '/api/v{api-version}/descriptions/',
             query: {
-                'parameterWithBreaks': parameterWithBreaks,
-                'parameterWithBackticks': parameterWithBackticks,
-                'parameterWithSlashes': parameterWithSlashes,
-                'parameterWithExpressionPlaceholders': parameterWithExpressionPlaceholders,
-                'parameterWithQuotes': parameterWithQuotes,
-                'parameterWithReservedCharacters': parameterWithReservedCharacters,
+                'parameterWithBreaks': new SerializableParameter('parameterWithBreaks', '', false, parameterWithBreaks),
+                'parameterWithBackticks': new SerializableParameter('parameterWithBackticks', '', false, parameterWithBackticks),
+                'parameterWithSlashes': new SerializableParameter('parameterWithSlashes', '', false, parameterWithSlashes),
+                'parameterWithExpressionPlaceholders': new SerializableParameter('parameterWithExpressionPlaceholders', '', false, parameterWithExpressionPlaceholders),
+                'parameterWithQuotes': new SerializableParameter('parameterWithQuotes', '', false, parameterWithQuotes),
+                'parameterWithReservedCharacters': new SerializableParameter('parameterWithReservedCharacters', '', false, parameterWithReservedCharacters),
             },
         });
     }
@@ -6616,6 +6892,7 @@ exports[`v3 should generate: ./test/generated/v3/services/DuplicateService.ts 1`
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class DuplicateService {
 
@@ -6670,6 +6947,7 @@ exports[`v3 should generate: ./test/generated/v3/services/ErrorService.ts 1`] = 
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class ErrorService {
 
@@ -6685,7 +6963,7 @@ export class ErrorService {
             method: 'POST',
             url: '/api/v{api-version}/error',
             query: {
-                'status': status,
+                'status': new SerializableParameter('status', '', false, status),
             },
             errors: {
                 500: \`Custom message: Internal Server Error\`,
@@ -6709,6 +6987,7 @@ import type { ModelWithString } from '../models/ModelWithString';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class FormDataService {
 
@@ -6725,7 +7004,7 @@ export class FormDataService {
             method: 'POST',
             url: '/api/v{api-version}/formData/',
             query: {
-                'parameter': parameter,
+                'parameter': new SerializableParameter('parameter', '', false, parameter),
             },
             formData: formData,
             mediaType: 'multipart/form-data',
@@ -6743,6 +7022,7 @@ exports[`v3 should generate: ./test/generated/v3/services/HeaderService.ts 1`] =
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class HeaderService {
 
@@ -6775,6 +7055,7 @@ import type { ModelWithString } from '../models/ModelWithString';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class MultipartService {
 
@@ -6824,6 +7105,7 @@ exports[`v3 should generate: ./test/generated/v3/services/MultipleTags1Service.t
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class MultipleTags1Service {
 
@@ -6860,6 +7142,7 @@ exports[`v3 should generate: ./test/generated/v3/services/MultipleTags2Service.t
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class MultipleTags2Service {
 
@@ -6896,6 +7179,7 @@ exports[`v3 should generate: ./test/generated/v3/services/MultipleTags3Service.t
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class MultipleTags3Service {
 
@@ -6921,6 +7205,7 @@ exports[`v3 should generate: ./test/generated/v3/services/NoContentService.ts 1`
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class NoContentService {
 
@@ -6949,6 +7234,7 @@ import type { Pageable } from '../models/Pageable';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class ParametersService {
 
@@ -6973,16 +7259,16 @@ export class ParametersService {
             method: 'POST',
             url: '/api/v{api-version}/parameters/{parameterPath}',
             path: {
-                'parameterPath': parameterPath,
+                'parameterPath': new SerializableParameter('parameterPath', '', false, parameterPath),
             },
             cookies: {
                 'parameterCookie': parameterCookie,
             },
             headers: {
-                'parameterHeader': parameterHeader,
+                'parameterHeader': new SerializableParameter('parameterHeader', '', false, parameterHeader),
             },
             query: {
-                'parameterQuery': parameterQuery,
+                'parameterQuery': new SerializableParameter('parameterQuery', '', false, parameterQuery),
             },
             formData: {
                 'parameterForm': parameterForm,
@@ -7019,19 +7305,19 @@ export class ParametersService {
             method: 'POST',
             url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
             path: {
-                'parameter.path.1': parameterPath1,
-                'parameter-path-2': parameterPath2,
-                'PARAMETER-PATH-3': parameterPath3,
+                'parameter.path.1': new SerializableParameter('parameter.path.1', '', false, parameterPath1),
+                'parameter-path-2': new SerializableParameter('parameter-path-2', '', false, parameterPath2),
+                'PARAMETER-PATH-3': new SerializableParameter('PARAMETER-PATH-3', '', false, parameterPath3),
             },
             cookies: {
                 'PARAMETER-COOKIE': parameterCookie,
             },
             headers: {
-                'parameter.header': parameterHeader,
+                'parameter.header': new SerializableParameter('parameter.header', '', false, parameterHeader),
             },
             query: {
-                'default': _default,
-                'parameter-query': parameterQuery,
+                'default': new SerializableParameter('default', '', false, _default),
+                'parameter-query': new SerializableParameter('parameter-query', '', false, parameterQuery),
             },
             formData: {
                 'parameter_form': parameterForm,
@@ -7054,7 +7340,7 @@ export class ParametersService {
             method: 'GET',
             url: '/api/v{api-version}/parameters/',
             query: {
-                'parameter': parameter,
+                'parameter': new SerializableParameter('parameter', '', false, parameter),
             },
             body: requestBody,
             mediaType: 'application/json',
@@ -7074,7 +7360,7 @@ export class ParametersService {
             method: 'POST',
             url: '/api/v{api-version}/parameters/',
             query: {
-                'parameter': parameter,
+                'parameter': new SerializableParameter('parameter', '', false, parameter),
             },
             body: requestBody,
             mediaType: 'application/json',
@@ -7094,6 +7380,7 @@ import type { ModelWithString } from '../models/ModelWithString';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class RequestBodyService {
 
@@ -7110,7 +7397,7 @@ export class RequestBodyService {
             method: 'POST',
             url: '/api/v{api-version}/requestBody/',
             query: {
-                'parameter': parameter,
+                'parameter': new SerializableParameter('parameter', '', false, parameter),
             },
             body: requestBody,
             mediaType: 'application/json',
@@ -7132,6 +7419,7 @@ import type { ModelWithString } from '../models/ModelWithString';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class ResponseService {
 
@@ -7196,6 +7484,7 @@ exports[`v3 should generate: ./test/generated/v3/services/SimpleService.ts 1`] =
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class SimpleService {
 
@@ -7280,6 +7569,7 @@ exports[`v3 should generate: ./test/generated/v3/services/TypesService.ts 1`] = 
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class TypesService {
 
@@ -7312,16 +7602,16 @@ export class TypesService {
             method: 'GET',
             url: '/api/v{api-version}/types',
             path: {
-                'id': id,
+                'id': new SerializableParameter('id', '', false, id),
             },
             query: {
-                'parameterNumber': parameterNumber,
-                'parameterString': parameterString,
-                'parameterBoolean': parameterBoolean,
-                'parameterObject': parameterObject,
-                'parameterArray': parameterArray,
-                'parameterDictionary': parameterDictionary,
-                'parameterEnum': parameterEnum,
+                'parameterNumber': new SerializableParameter('parameterNumber', '', false, parameterNumber),
+                'parameterString': new SerializableParameter('parameterString', '', false, parameterString),
+                'parameterBoolean': new SerializableParameter('parameterBoolean', '', false, parameterBoolean),
+                'parameterObject': new SerializableParameter('parameterObject', '', false, parameterObject),
+                'parameterArray': new SerializableParameter('parameterArray', '', false, parameterArray),
+                'parameterDictionary': new SerializableParameter('parameterDictionary', '', false, parameterDictionary),
+                'parameterEnum': new SerializableParameter('parameterEnum', '', false, parameterEnum),
             },
         });
     }
@@ -7337,6 +7627,7 @@ exports[`v3 should generate: ./test/generated/v3/services/UploadService.ts 1`] =
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { SerializableParameter } from '../core/SerializableParameter';
 
 export class UploadService {
 


### PR DESCRIPTION
### Summary

This PR addresses #654 (and probably #917). It adds support for parameter serialization for path-parameters, query-parameters and headers as per https://swagger.io/docs/specification/serialization/.

### Details

I've implemented this feature by adding a small data class that gets instantiated for each parameter. The class holds the `style` and `explode` values as well as the parameter name and value. I did this to allow backwards compatibility in case someone directly uses the `ApiRequestOptions`. Same applies to all functions handling the affected parameter types. If the value provided is not an instance of the data class the known behavior will occur.

I also didn't want to be too strict on the rules in regards of discarding parameters or throwing errors. So currently if invalid `style`/`explode` values are provided, the parameters will at best be serialized with the default `style`/`explode` settings for that parameter type or at worst the data will end up malformed (IMO this is fine as we can't really do anything about an invalid spec file or we would have to perform a validation when parsing the spec file).

As a side effect of adding the parameter serialization for headers, header values can now also be arrays or objects (just as url and query parameters).

### Breaking Changes

Current serialization serializes parameter values to specs default settings. So if no `style`/`explode` is defined, then there should not be any breaking changes. However, due to the fact that after this PR the `style`/`explode` settings will be taken into account so in case they are defined the generated parameters will change in layout which could break something.

### ToDO

* [ ] Unit tests for parameter serialization