### PR TITLE
add support for onDownloadProgress for axios

### DIFF
--- a/src/templates/core/ApiRequestOptions.hbs
+++ b/src/templates/core/ApiRequestOptions.hbs
@@ -12,4 +12,5 @@ export type ApiRequestOptions = {
 	readonly mediaType?: string;
 	readonly responseHeader?: string;
 	readonly errors?: Record<number, string>;
+	readonly onDownloadProgress?: (progressEvent: ProgressEvent) => void;
 };

--- a/src/templates/core/axios/sendRequest.hbs
+++ b/src/templates/core/axios/sendRequest.hbs
@@ -16,6 +16,7 @@ const sendRequest = async <T>(
 		method: options.method,
 		withCredentials: config.WITH_CREDENTIALS,
 		cancelToken: source.token,
+		onDownloadProgress: options.onDownloadProgress,
 	};
 
 	onCancel(() => source.cancel('The user aborted a request.'));


### PR DESCRIPTION
This PR closes https://github.com/ferdikoomen/openapi-typescript-codegen/issues/1428

It basically adds `onDownloadProgress` to the `ApiRequestOptions` and further unwraps those later in the `requestConfig` of the `sendRequest` method.

Related: is there an automatic way of regenerating snapshots?