### PR TITLE
Allow usage of a custom axios instance

### DIFF
--- a/src/templates/core/axios/request.hbs
+++ b/src/templates/core/axios/request.hbs
@@ -1,7 +1,7 @@
 {{>header}}
 
 import axios from 'axios';
-import type { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
+import type { AxiosError, AxiosRequestConfig, AxiosResponse, AxiosInstance } from 'axios';
 import FormData from 'form-data';
 
 import { ApiError } from './ApiError';
@@ -66,10 +66,11 @@ import type { OpenAPIConfig } from './OpenAPI';
  * Request method
  * @param config The OpenAPI configuration object
  * @param options The request options from the service
+ * @param axiosClient The axios client instance to use
  * @returns CancelablePromise<T>
  * @throws ApiError
  */
-export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions, axiosClient: AxiosInstance = axios): CancelablePromise<T> => {
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
 			const url = getUrl(config, options);
@@ -78,7 +79,7 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
 			const headers = await getHeaders(config, options, formData);
 
 			if (!onCancel.isCancelled) {
-				const response = await sendRequest<T>(config, options, url, body, formData, headers, onCancel);
+				const response = await sendRequest<T>(config, options, url, body, formData, headers, onCancel, axiosClient);
 				const responseBody = getResponseBody(response);
 				const responseHeader = getResponseHeader(response, options.responseHeader);
 

--- a/src/templates/core/axios/sendRequest.hbs
+++ b/src/templates/core/axios/sendRequest.hbs
@@ -5,7 +5,8 @@ const sendRequest = async <T>(
 	body: any,
 	formData: FormData | undefined,
 	headers: Record<string, string>,
-	onCancel: OnCancel
+	onCancel: OnCancel,
+	axiosClient: AxiosInstance
 ): Promise<AxiosResponse<T>> => {
 	const source = axios.CancelToken.source();
 
@@ -21,7 +22,7 @@ const sendRequest = async <T>(
 	onCancel(() => source.cancel('The user aborted a request.'));
 
 	try {
-		return await axios.request(requestConfig);
+		return await axiosClient.request(requestConfig);
 	} catch (error) {
 		const axiosError = error as AxiosError<T>;
 		if (axiosError.response) {


### PR DESCRIPTION
This PR solves #942, and any issues requesting specific advanced axios features (e.g. #1428, part of #1084)
 
Currently, it is impossible to add any interceptors to axios without modifying the global axios instance, which can effect other parts of your program in unwanted ways.

Also, hiding away the actual usage of the axios library in the `request` file means this generator will always play catch up with new axios features, or people asking for very specific axios parameters to be externalized.

This PR allows passing in a custom axios instance to the inner request module, providing an escape hatch for advanced users. 