### PR TITLE
[request] export used functions for reusability

### DIFF
--- a/src/templates/core/angular/getHeaders.hbs
+++ b/src/templates/core/angular/getHeaders.hbs
@@ -1,4 +1,4 @@
-const getHeaders = (config: OpenAPIConfig, options: ApiRequestOptions): Observable<HttpHeaders> => {
+export const getHeaders = (config: OpenAPIConfig, options: ApiRequestOptions): Observable<HttpHeaders> => {
 	return forkJoin({
 		token: resolve(options, config.TOKEN),
 		username: resolve(options, config.USERNAME),

--- a/src/templates/core/angular/getRequestBody.hbs
+++ b/src/templates/core/angular/getRequestBody.hbs
@@ -1,4 +1,4 @@
-const getRequestBody = (options: ApiRequestOptions): any => {
+export const getRequestBody = (options: ApiRequestOptions): any => {
 	if (options.body) {
 		if (options.mediaType?.includes('/json')) {
 			return JSON.stringify(options.body)

--- a/src/templates/core/angular/getResponseBody.hbs
+++ b/src/templates/core/angular/getResponseBody.hbs
@@ -1,4 +1,4 @@
-const getResponseBody = <T>(response: HttpResponse<T>): T | undefined => {
+export const getResponseBody = <T>(response: HttpResponse<T>): T | undefined => {
 	if (response.status !== 204 && response.body !== null) {
 		return response.body;
 	}

--- a/src/templates/core/angular/getResponseHeader.hbs
+++ b/src/templates/core/angular/getResponseHeader.hbs
@@ -1,4 +1,4 @@
-const getResponseHeader = <T>(response: HttpResponse<T>, responseHeader?: string): string | undefined => {
+export const getResponseHeader = <T>(response: HttpResponse<T>, responseHeader?: string): string | undefined => {
 	if (responseHeader) {
 		const value = response.headers.get(responseHeader);
 		if (isString(value)) {

--- a/src/templates/core/angular/sendRequest.hbs
+++ b/src/templates/core/angular/sendRequest.hbs
@@ -1,4 +1,4 @@
-export const sendRequest = <T>(
+export export const sendRequest = <T>(
 	config: OpenAPIConfig,
 	options: ApiRequestOptions,
 	http: HttpClient,

--- a/src/templates/core/axios/getHeaders.hbs
+++ b/src/templates/core/axios/getHeaders.hbs
@@ -1,4 +1,4 @@
-const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions, formData?: FormData): Promise<Record<string, string>> => {
+export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions, formData?: FormData): Promise<Record<string, string>> => {
 	const token = await resolve(options, config.TOKEN);
 	const username = await resolve(options, config.USERNAME);
 	const password = await resolve(options, config.PASSWORD);

--- a/src/templates/core/axios/getRequestBody.hbs
+++ b/src/templates/core/axios/getRequestBody.hbs
@@ -1,4 +1,4 @@
-const getRequestBody = (options: ApiRequestOptions): any => {
+export const getRequestBody = (options: ApiRequestOptions): any => {
 	if (options.body) {
 		return options.body;
 	}

--- a/src/templates/core/axios/getResponseBody.hbs
+++ b/src/templates/core/axios/getResponseBody.hbs
@@ -1,4 +1,4 @@
-const getResponseBody = (response: AxiosResponse<any>): any => {
+export const getResponseBody = (response: AxiosResponse<any>): any => {
 	if (response.status !== 204) {
 		return response.data;
 	}

--- a/src/templates/core/axios/getResponseHeader.hbs
+++ b/src/templates/core/axios/getResponseHeader.hbs
@@ -1,4 +1,4 @@
-const getResponseHeader = (response: AxiosResponse<any>, responseHeader?: string): string | undefined => {
+export const getResponseHeader = (response: AxiosResponse<any>, responseHeader?: string): string | undefined => {
 	if (responseHeader) {
 		const content = response.headers[responseHeader];
 		if (isString(content)) {

--- a/src/templates/core/axios/sendRequest.hbs
+++ b/src/templates/core/axios/sendRequest.hbs
@@ -1,4 +1,4 @@
-const sendRequest = async <T>(
+export export const sendRequest = async <T>(
 	config: OpenAPIConfig,
 	options: ApiRequestOptions,
 	url: string,

--- a/src/templates/core/fetch/getHeaders.hbs
+++ b/src/templates/core/fetch/getHeaders.hbs
@@ -1,4 +1,4 @@
-const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
 	const token = await resolve(options, config.TOKEN);
 	const username = await resolve(options, config.USERNAME);
 	const password = await resolve(options, config.PASSWORD);

--- a/src/templates/core/fetch/getRequestBody.hbs
+++ b/src/templates/core/fetch/getRequestBody.hbs
@@ -1,4 +1,4 @@
-const getRequestBody = (options: ApiRequestOptions): any => {
+export const getRequestBody = (options: ApiRequestOptions): any => {
 	if (options.body !== undefined) {
 		if (options.mediaType?.includes('/json')) {
 			return JSON.stringify(options.body)

--- a/src/templates/core/fetch/getResponseBody.hbs
+++ b/src/templates/core/fetch/getResponseBody.hbs
@@ -1,4 +1,4 @@
-const getResponseBody = async (response: Response): Promise<any> => {
+export const getResponseBody = async (response: Response): Promise<any> => {
 	if (response.status !== 204) {
 		try {
 			const contentType = response.headers.get('Content-Type');

--- a/src/templates/core/fetch/getResponseHeader.hbs
+++ b/src/templates/core/fetch/getResponseHeader.hbs
@@ -1,4 +1,4 @@
-const getResponseHeader = (response: Response, responseHeader?: string): string | undefined => {
+export const getResponseHeader = (response: Response, responseHeader?: string): string | undefined => {
 	if (responseHeader) {
 		const content = response.headers.get(responseHeader);
 		if (isString(content)) {

--- a/src/templates/core/fetch/sendRequest.hbs
+++ b/src/templates/core/fetch/sendRequest.hbs
@@ -1,4 +1,4 @@
-export const sendRequest = async (
+export export const sendRequest = async (
 	config: OpenAPIConfig,
 	options: ApiRequestOptions,
 	url: string,

--- a/src/templates/core/functions/base64.hbs
+++ b/src/templates/core/functions/base64.hbs
@@ -1,4 +1,4 @@
-const base64 = (str: string): string => {
+export const base64 = (str: string): string => {
 	try {
 		return btoa(str);
 	} catch (err) {

--- a/src/templates/core/functions/catchErrorCodes.hbs
+++ b/src/templates/core/functions/catchErrorCodes.hbs
@@ -1,4 +1,4 @@
-const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
+export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
 	const errors: Record<number, string> = {
 		400: 'Bad Request',
 		401: 'Unauthorized',

--- a/src/templates/core/functions/getFormData.hbs
+++ b/src/templates/core/functions/getFormData.hbs
@@ -1,4 +1,4 @@
-const getFormData = (options: ApiRequestOptions): FormData | undefined => {
+export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
 	if (options.formData) {
 		const formData = new FormData();
 

--- a/src/templates/core/functions/getQueryString.hbs
+++ b/src/templates/core/functions/getQueryString.hbs
@@ -1,4 +1,4 @@
-const getQueryString = (params: Record<string, any>): string => {
+export const getQueryString = (params: Record<string, any>): string => {
 	const qs: string[] = [];
 
 	const append = (key: string, value: any) => {

--- a/src/templates/core/functions/isBlob.hbs
+++ b/src/templates/core/functions/isBlob.hbs
@@ -1,4 +1,4 @@
-const isBlob = (value: any): value is Blob => {
+export const isBlob = (value: any): value is Blob => {
 	return (
 		typeof value === 'object' &&
 		typeof value.type === 'string' &&

--- a/src/templates/core/functions/isDefined.hbs
+++ b/src/templates/core/functions/isDefined.hbs
@@ -1,3 +1,3 @@
-const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
+export const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
 	return value !== undefined && value !== null;
 };

--- a/src/templates/core/functions/isFormData.hbs
+++ b/src/templates/core/functions/isFormData.hbs
@@ -1,3 +1,3 @@
-const isFormData = (value: any): value is FormData => {
+export const isFormData = (value: any): value is FormData => {
 	return value instanceof FormData;
 };

--- a/src/templates/core/functions/isString.hbs
+++ b/src/templates/core/functions/isString.hbs
@@ -1,3 +1,3 @@
-const isString = (value: any): value is string => {
+export const isString = (value: any): value is string => {
 	return typeof value === 'string';
 };

--- a/src/templates/core/functions/isStringWithValue.hbs
+++ b/src/templates/core/functions/isStringWithValue.hbs
@@ -1,3 +1,3 @@
-const isStringWithValue = (value: any): value is string => {
+export const isStringWithValue = (value: any): value is string => {
 	return isString(value) && value !== '';
 };

--- a/src/templates/core/functions/isSuccess.hbs
+++ b/src/templates/core/functions/isSuccess.hbs
@@ -1,3 +1,3 @@
-const isSuccess = (status: number): boolean => {
+export const isSuccess = (status: number): boolean => {
 	return status >= 200 && status < 300;
 };

--- a/src/templates/core/functions/resolve.hbs
+++ b/src/templates/core/functions/resolve.hbs
@@ -1,6 +1,6 @@
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 
-const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
+export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
 	if (typeof resolver === 'function') {
 		return (resolver as Resolver<T>)(options);
 	}

--- a/src/templates/core/node/getHeaders.hbs
+++ b/src/templates/core/node/getHeaders.hbs
@@ -1,4 +1,4 @@
-const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
 	const token = await resolve(options, config.TOKEN);
 	const username = await resolve(options, config.USERNAME);
 	const password = await resolve(options, config.PASSWORD);

--- a/src/templates/core/node/getRequestBody.hbs
+++ b/src/templates/core/node/getRequestBody.hbs
@@ -1,4 +1,4 @@
-const getRequestBody = (options: ApiRequestOptions): any => {
+export const getRequestBody = (options: ApiRequestOptions): any => {
 	if (options.body !== undefined) {
 		if (options.mediaType?.includes('/json')) {
 			return JSON.stringify(options.body)

--- a/src/templates/core/node/getResponseBody.hbs
+++ b/src/templates/core/node/getResponseBody.hbs
@@ -1,4 +1,4 @@
-const getResponseBody = async (response: Response): Promise<any> => {
+export const getResponseBody = async (response: Response): Promise<any> => {
 	if (response.status !== 204) {
 		try {
 			const contentType = response.headers.get('Content-Type');

--- a/src/templates/core/node/getResponseHeader.hbs
+++ b/src/templates/core/node/getResponseHeader.hbs
@@ -1,4 +1,4 @@
-const getResponseHeader = (response: Response, responseHeader?: string): string | undefined => {
+export const getResponseHeader = (response: Response, responseHeader?: string): string | undefined => {
 	if (responseHeader) {
 		const content = response.headers.get(responseHeader);
 		if (isString(content)) {

--- a/src/templates/core/xhr/getHeaders.hbs
+++ b/src/templates/core/xhr/getHeaders.hbs
@@ -1,4 +1,4 @@
-const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
 	const token = await resolve(options, config.TOKEN);
 	const username = await resolve(options, config.USERNAME);
 	const password = await resolve(options, config.PASSWORD);

--- a/src/templates/core/xhr/getRequestBody.hbs
+++ b/src/templates/core/xhr/getRequestBody.hbs
@@ -1,4 +1,4 @@
-const getRequestBody = (options: ApiRequestOptions): any => {
+export const getRequestBody = (options: ApiRequestOptions): any => {
 	if (options.body !== undefined) {
 		if (options.mediaType?.includes('/json')) {
 			return JSON.stringify(options.body)

--- a/src/templates/core/xhr/getResponseBody.hbs
+++ b/src/templates/core/xhr/getResponseBody.hbs
@@ -1,4 +1,4 @@
-const getResponseBody = (xhr: XMLHttpRequest): any => {
+export const getResponseBody = (xhr: XMLHttpRequest): any => {
 	if (xhr.status !== 204) {
 		try {
 			const contentType = xhr.getResponseHeader('Content-Type');

--- a/src/templates/core/xhr/getResponseHeader.hbs
+++ b/src/templates/core/xhr/getResponseHeader.hbs
@@ -1,4 +1,4 @@
-const getResponseHeader = (xhr: XMLHttpRequest, responseHeader?: string): string | undefined => {
+export const getResponseHeader = (xhr: XMLHttpRequest, responseHeader?: string): string | undefined => {
 	if (responseHeader) {
 		const content = xhr.getResponseHeader(responseHeader);
 		if (isString(content)) {


### PR DESCRIPTION
When using a custom request method, you might want to use some or even most of the methods generated with this client.
This PR makes sure it exports all used functions in request.ts so you can import it from a custom request