### PR TITLE
Fixes #1252. Adds --transformModelCase flag.

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -24,6 +24,7 @@ const params = program
     .option('--postfix <value>', 'Deprecated: Use --postfixServices instead. Service name postfix', 'Service')
     .option('--postfixServices <value>', 'Service name postfix', 'Service')
     .option('--postfixModels <value>', 'Model name postfix')
+    .option('--transformModelCase <value>', 'Transform model case [camel, snake]', 'none')
     .option('--request <value>', 'Path to custom request file')
     .parse(process.argv)
     .opts();
@@ -45,6 +46,7 @@ if (OpenAPI) {
         indent: params.indent,
         postfixServices: params.postfixServices ?? params.postfix,
         postfixModels: params.postfixModels,
+        transformModelCase: params.transformModelCase,
         request: params.request,
     })
         .then(() => {

--- a/src/Case.ts
+++ b/src/Case.ts
@@ -1,0 +1,38 @@
+import { Model } from './client/interfaces/Model';
+
+export enum Case {
+    NONE = 'none',
+    CAMEL = 'camel',
+    SNAKE = 'snake',
+}
+// Convert a string from snake case or pascal case to camel case.
+const toCamelCase = (str: string): string => {
+    return str.replace(/_([a-z])/g, match => match[1].toUpperCase());
+};
+
+// Convert a string from camel case or pascal case to snake case.
+const toSnakeCase = (str: string): string => {
+    return str.replace(/([A-Z])/g, match => `_${match.toLowerCase()}`);
+};
+
+const transforms = {
+    [Case.CAMEL]: toCamelCase,
+    [Case.SNAKE]: toSnakeCase,
+};
+
+// A recursive function that looks at the models and their properties and
+// converts each property name using the provided transform function.
+export const convertModelNames = (model: Model, type: Exclude<Case, Case.NONE>): Model => {
+    if (!model.properties.length) {
+        return {
+            ...model,
+            name: transforms[type](model.name),
+        };
+    }
+    return {
+        ...model,
+        properties: model.properties.map(property => {
+            return convertModelNames(property, type);
+        }),
+    };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { Case } from './Case';
 import { HttpClient } from './HttpClient';
 import { Indent } from './Indent';
 import { parse as parseV2 } from './openApi/v2';
@@ -26,6 +27,7 @@ export type Options = {
     indent?: Indent;
     postfixServices?: string;
     postfixModels?: string;
+    transformModelCase?: Case;
     request?: string;
     write?: boolean;
 };
@@ -47,6 +49,7 @@ export type Options = {
  * @param indent Indentation options (4, 2 or tab)
  * @param postfixServices Service name postfix
  * @param postfixModels Model name postfix
+ * @param transformModelCase Transform model case (camel, snake)
  * @param request Path to custom request file
  * @param write Write the files to disk (true or false)
  */
@@ -64,6 +67,7 @@ export const generate = async ({
     indent = Indent.SPACE_4,
     postfixServices = 'Service',
     postfixModels = '',
+    transformModelCase = Case.NONE,
     request,
     write = true,
 }: Options): Promise<void> => {
@@ -94,6 +98,7 @@ export const generate = async ({
                 indent,
                 postfixServices,
                 postfixModels,
+                transformModelCase,
                 clientName,
                 request
             );
@@ -118,6 +123,7 @@ export const generate = async ({
                 indent,
                 postfixServices,
                 postfixModels,
+                transformModelCase,
                 clientName,
                 request
             );

--- a/src/utils/writeClient.spec.ts
+++ b/src/utils/writeClient.spec.ts
@@ -1,3 +1,4 @@
+import { Case } from '../Case';
 import type { Client } from '../client/interfaces/Client';
 import { HttpClient } from '../HttpClient';
 import { Indent } from '../Indent';
@@ -49,7 +50,8 @@ describe('writeClient', () => {
             true,
             Indent.SPACE_4,
             'Service',
-            'AppClient'
+            'AppClient',
+            Case.NONE
         );
 
         expect(rmdir).toBeCalled();

--- a/src/utils/writeClient.ts
+++ b/src/utils/writeClient.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'path';
 
 import type { Client } from '../client/interfaces/Client';
+import { Case } from '../Case';
 import type { HttpClient } from '../HttpClient';
 import type { Indent } from '../Indent';
 import { mkdir, rmdir } from './fileSystem';
@@ -30,6 +31,7 @@ import { writeClientServices } from './writeClientServices';
  * @param indent Indentation options (4, 2 or tab)
  * @param postfixServices Service name postfix
  * @param postfixModels Model name postfix
+ * @param transformModelCase Transform model case (camel, snake)
  * @param clientName Custom client class name
  * @param request Path to custom request file
  */
@@ -47,6 +49,7 @@ export const writeClient = async (
     indent: Indent,
     postfixServices: string,
     postfixModels: string,
+    transformModelCase: Case,
     clientName?: string,
     request?: string
 ): Promise<void> => {
@@ -91,7 +94,15 @@ export const writeClient = async (
     if (exportModels) {
         await rmdir(outputPathModels);
         await mkdir(outputPathModels);
-        await writeClientModels(client.models, templates, outputPathModels, httpClient, useUnionTypes, indent);
+        await writeClientModels(
+            client.models,
+            templates,
+            outputPathModels,
+            httpClient,
+            useUnionTypes,
+            indent,
+            transformModelCase
+        );
     }
 
     if (isDefined(clientName)) {

--- a/src/utils/writeClientModels.spec.ts
+++ b/src/utils/writeClientModels.spec.ts
@@ -1,4 +1,5 @@
 import { EOL } from 'os';
+import { Case } from '../Case';
 
 import type { Model } from '../client/interfaces/Model';
 import { HttpClient } from '../HttpClient';
@@ -51,7 +52,7 @@ describe('writeClientModels', () => {
             },
         };
 
-        await writeClientModels(models, templates, '/', HttpClient.FETCH, false, Indent.SPACE_4);
+        await writeClientModels(models, templates, '/', HttpClient.FETCH, false, Indent.SPACE_4, Case.NONE);
 
         expect(writeFile).toBeCalledWith('/User.ts', `model${EOL}`);
     });

--- a/src/utils/writeClientModels.ts
+++ b/src/utils/writeClientModels.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'path';
 
 import type { Model } from '../client/interfaces/Model';
+import { Case, convertModelNames } from '../Case';
 import type { HttpClient } from '../HttpClient';
 import type { Indent } from '../Indent';
 import { writeFile } from './fileSystem';
@@ -16,6 +17,7 @@ import type { Templates } from './registerHandlebarTemplates';
  * @param httpClient The selected httpClient (fetch, xhr, node or axios)
  * @param useUnionTypes Use union types instead of enums
  * @param indent Indentation options (4, 2 or tab)
+ * @param transformModelCase Transform model case (camel, snake)
  */
 export const writeClientModels = async (
     models: Model[],
@@ -23,12 +25,14 @@ export const writeClientModels = async (
     outputPath: string,
     httpClient: HttpClient,
     useUnionTypes: boolean,
-    indent: Indent
+    indent: Indent,
+    transformModelCase: Case
 ): Promise<void> => {
     for (const model of models) {
+        const newModel = transformModelCase === Case.NONE ? model : convertModelNames(model, transformModelCase);
         const file = resolve(outputPath, `${model.name}.ts`);
         const templateResult = templates.exports.model({
-            ...model,
+            ...newModel,
             httpClient,
             useUnionTypes,
         });


### PR DESCRIPTION
**What changed**

Adds a `--transformModelCase` flag that accepts either `snake` or `camel` (defaults to `none`). Will convert model names from snake, camel, or pascal case to whichever option was passed in.

For example, if the original file was in pascal case:

```ts
type MyModel {
  FooBar: string;  
}
```

`--transformModelCase camel`

```ts
type MyModel {
  fooBar: string;  
}
```

`--transformModelCase snake`

```ts
type MyModel {
  foo_bar: string;  
}
```

**Why the change was made**

Much like the original requester in #1252, our company has a large API that returns keys in snake case, but we convert them to camel case on the frontend using a bit of middleware in our fetch functions. The types generated from our OpenAPI specs are in snake case, which means we can't use them.

@ferdikoomen Is this feature something you'd consider incorporating? If so I'd be happy to add additional tests and make any changes you think are needed.
