### PR TITLE
Fix TanStack Query compatability by adding support for returning null instead of undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $ openapi --help
     --name <value>            Custom client class name
     --useOptions              Use options instead of arguments
     --useUnionTypes           Use union types instead of enums
+    --useNullForNoContent     Use null for returning instead of undefined if a response returns 204 no content
     --exportCore <value>      Write core files to disk (default: true)
     --exportServices <value>  Write services to disk (default: true)
     --exportModels <value>    Write models to disk (default: true)

--- a/bin/index.js
+++ b/bin/index.js
@@ -16,6 +16,7 @@ const params = program
     .option('--name <value>', 'Custom client class name')
     .option('--useOptions', 'Use options instead of arguments')
     .option('--useUnionTypes', 'Use union types instead of enums')
+    .option('--useNullForNoContent', 'Use null for returning instead of undefined if a response returns 204 no content')
     .option('--exportCore <value>', 'Write core files to disk', true)
     .option('--exportServices <value>', 'Write services to disk', true)
     .option('--exportModels <value>', 'Write models to disk', true)
@@ -38,6 +39,7 @@ if (OpenAPI) {
         clientName: params.name,
         useOptions: params.useOptions,
         useUnionTypes: params.useUnionTypes,
+        useNullForNoContent: params.useNullForNoContent,
         exportCore: JSON.parse(params.exportCore) === true,
         exportServices: JSON.parse(params.exportServices) === true,
         exportModels: JSON.parse(params.exportModels) === true,

--- a/bin/index.spec.js
+++ b/bin/index.spec.js
@@ -24,6 +24,7 @@ describe('bin', () => {
             'fetch',
             '--useOptions',
             '--useUnionTypes',
+            '--useNullForNoContent',
             '--exportCore',
             'true',
             '--exportServices',

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -13,6 +13,7 @@ $ openapi --help
     --name <value>            Custom client class name
     --useOptions              Use options instead of arguments
     --useUnionTypes           Use union types instead of enums
+    --useNullForNoContent     Use null for returning instead of undefined if a response returns 204 no content
     --exportCore <value>      Write core files to disk (default: true)
     --exportServices <value>  Write services to disk (default: true)
     --exportModels <value>    Write models to disk (default: true)

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export type Options = {
     clientName?: string;
     useOptions?: boolean;
     useUnionTypes?: boolean;
+    useNullForNoContent?: boolean;
     exportCore?: boolean;
     exportServices?: boolean;
     exportModels?: boolean;
@@ -40,6 +41,7 @@ export type Options = {
  * @param clientName Custom client class name
  * @param useOptions Use options or arguments functions
  * @param useUnionTypes Use union types instead of enums
+ * @param useNullForNoContent Use null for no content responses
  * @param exportCore Generate core client classes
  * @param exportServices Generate services
  * @param exportModels Generate models
@@ -57,6 +59,7 @@ export const generate = async ({
     clientName,
     useOptions = false,
     useUnionTypes = false,
+    useNullForNoContent = false,
     exportCore = true,
     exportServices = true,
     exportModels = true,
@@ -72,6 +75,7 @@ export const generate = async ({
     const templates = registerHandlebarTemplates({
         httpClient,
         useUnionTypes,
+        useNullForNoContent,
         useOptions,
     });
 
@@ -87,6 +91,7 @@ export const generate = async ({
                 httpClient,
                 useOptions,
                 useUnionTypes,
+                useNullForNoContent,
                 exportCore,
                 exportServices,
                 exportModels,
@@ -111,6 +116,7 @@ export const generate = async ({
                 httpClient,
                 useOptions,
                 useUnionTypes,
+                useNullForNoContent,
                 exportCore,
                 exportServices,
                 exportModels,

--- a/src/templates/core/angular/getResponseBody.hbs
+++ b/src/templates/core/angular/getResponseBody.hbs
@@ -2,5 +2,9 @@ const getResponseBody = <T>(response: HttpResponse<T>): T | undefined => {
 	if (response.status !== 204 && response.body !== null) {
 		return response.body;
 	}
+	{{#if @root.useNullForNoContent}}
+	return null;
+	{{else}}
 	return undefined;
+	{{/if}}
 };

--- a/src/templates/core/angular/getResponseBody.hbs
+++ b/src/templates/core/angular/getResponseBody.hbs
@@ -1,4 +1,4 @@
-const getResponseBody = <T>(response: HttpResponse<T>): T | undefined => {
+const getResponseBody = <T>(response: HttpResponse<T>): T | {{#if @root.useNullForNoContent}}null{{else}}undefined{{/if}} => {
 	if (response.status !== 204 && response.body !== null) {
 		return response.body;
 	}

--- a/src/templates/core/axios/getResponseBody.hbs
+++ b/src/templates/core/axios/getResponseBody.hbs
@@ -2,5 +2,9 @@ const getResponseBody = (response: AxiosResponse<any>): any => {
 	if (response.status !== 204) {
 		return response.data;
 	}
+	{{#if @root.useNullForNoContent}}
+	return null;
+	{{else}}
 	return undefined;
+	{{/if}}
 };

--- a/src/templates/core/fetch/getResponseBody.hbs
+++ b/src/templates/core/fetch/getResponseBody.hbs
@@ -15,5 +15,9 @@ const getResponseBody = async (response: Response): Promise<any> => {
 			console.error(error);
 		}
 	}
+	{{#if @root.useNullForNoContent}}
+	return null;
+	{{else}}
 	return undefined;
+	{{/if}}
 };

--- a/src/templates/core/node/getResponseBody.hbs
+++ b/src/templates/core/node/getResponseBody.hbs
@@ -15,5 +15,9 @@ const getResponseBody = async (response: Response): Promise<any> => {
 			console.error(error);
 		}
 	}
+	{{#if @root.useNullForNoContent}}
+	return null;
+	{{else}}
 	return undefined;
+	{{/if}}
 };

--- a/src/templates/core/xhr/getResponseBody.hbs
+++ b/src/templates/core/xhr/getResponseBody.hbs
@@ -15,5 +15,9 @@ const getResponseBody = (xhr: XMLHttpRequest): any => {
 			console.error(error);
 		}
 	}
+	{{#if @root.useNullForNoContent}}
+	return null;
+	{{else}}
 	return undefined;
+	{{/if}}
 };

--- a/src/utils/registerHandlebarTemplates.ts
+++ b/src/utils/registerHandlebarTemplates.ts
@@ -113,6 +113,7 @@ export const registerHandlebarTemplates = (root: {
     httpClient: HttpClient;
     useOptions: boolean;
     useUnionTypes: boolean;
+    useNullForNoContent: boolean;
 }): Templates => {
     registerHandlebarHelpers(root);
 

--- a/src/utils/writeClient.ts
+++ b/src/utils/writeClient.ts
@@ -40,6 +40,7 @@ export const writeClient = async (
     httpClient: HttpClient,
     useOptions: boolean,
     useUnionTypes: boolean,
+    useNullForNoContent: boolean,
     exportCore: boolean,
     exportServices: boolean,
     exportModels: boolean,
@@ -63,7 +64,7 @@ export const writeClient = async (
     if (exportCore) {
         await rmdir(outputPathCore);
         await mkdir(outputPathCore);
-        await writeClientCore(client, templates, outputPathCore, httpClient, indent, clientName, request);
+        await writeClientCore(client, templates, outputPathCore, httpClient, indent, clientName, request, useNullForNoContent);
     }
 
     if (exportServices) {

--- a/src/utils/writeClientCore.ts
+++ b/src/utils/writeClientCore.ts
@@ -26,7 +26,8 @@ export const writeClientCore = async (
     httpClient: HttpClient,
     indent: Indent,
     clientName?: string,
-    request?: string
+    request?: string,
+    useNullForNoContent: boolean,
 ): Promise<void> => {
     const httpRequest = getHttpRequestName(httpClient);
     const context = {
@@ -35,6 +36,7 @@ export const writeClientCore = async (
         httpRequest,
         server: client.server,
         version: client.version,
+        useNullForNoContent,
     };
 
     await writeFile(resolve(outputPath, 'OpenAPI.ts'), i(templates.core.settings(context), indent));


### PR DESCRIPTION
### Issue
This pull request aims to address an issue that arises when an endpoint returns a `204 No Content` status. Currently, the TanStack query generates an error stating that the Query data cannot be undefined, as demonstrated in the following screenshot:
![afbeelding](https://user-images.githubusercontent.com/18684874/230741982-d2a5ada2-d20b-433a-a669-b0f822111d20.png)

### Solution
To resolve this issue, the proposed solution involves allowing the return of null values instead of undefined by introducing an optional parameter. This change will enable the library to handle `204 No Content` responses more gracefully and prevent errors in such scenarios.

### Changes

This pull request includes the following changes to the codebase:

- Added --useNullForNoContent flag in the README, documentation, and command-line options

- Added useNullForNoContent to the Options type, the generate function, and related utility functions
- Updated test cases to include the --useNullForNoContent flag
- Modified the getResponseBody template for one of the core clients (applies to all) to conditionally return null or undefined based on the useNullForNoContent flag

These changes allow the library to support "204 No Content" responses by returning null instead of undefined when the --useNullForNoContent flag is set.