### PR TITLE
Indicate auto-generation in file headers.

### DIFF
--- a/src/templates/partials/header.hbs
+++ b/src/templates/partials/header.hbs
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */


### PR DESCRIPTION
Thanks for this great code generator.

I wonder if you would consider this addition, it adds a line to the file header indicating that the file is auto-generated. Feedback I got from my collaborators is that it was not obvious that files created by openapi-typescript-codegen were automatically generated.