### PR TITLE
build: use npm prepare instead of prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "test:e2e": "jest --selectProjects E2E --runInBand --verbose",
         "eslint": "eslint .",
         "eslint:fix": "eslint . --fix",
-        "prepublishOnly": "npm run clean && npm run release",
+        "prepare": "npm run clean && npm run release",
         "codecov": "codecov --token=66c30c23-8954-4892-bef9-fbaed0a2e42b",
         "docker": "docker build -t eeelenbaas/openapi-typescript-codegen ."
     },


### PR DESCRIPTION
In NPM, the `prepublishOnly` script is run only before running `npm publish`. However, this means that people trying to use the git version of of this project (i.e. with `npm install github:ferdikoomen/openapi-typescript-codegen`) won't get a working version of this project, since there will be nothing in the `dist/` folder.

[NPM (since v4.0.0)][1] supports a `prepack` script, that is called:

> * Runs BEFORE the package is packed
> * Runs BEFORE the package is published
> * Runs on local `npm install` without any arguments
> * Run AFTER `prepublish`, but BEFORE `prepublishOnly`
> * NOTE: If a package being installed through git contains a `prepare`
>   script, its `dependencies` and `devDependencies` will be installed,
>   and the prepare script will be run, before the package is packaged
>   and installed.

According to the NPM docs, this is the recommended place to put scripts that do things like "Compiling CoffeeScript source code into JavaScript.".

[1]: https://docs.npmjs.com/cli/v6/using-npm/scripts#life-cycle-scripts

Fixes https://github.com/ferdikoomen/openapi-typescript-codegen/issues/1457, resolves https://github.com/ferdikoomen/openapi-typescript-codegen/pull/1458 (this PR is cleaner than that PR)

### Benefits

Installing directly from `git` can be pretty useful, as it allows `openapi-typescript-codegen` users to use a specific git commit/branch, e.g. so that they don't need to wait for an NPM release (or people can use a commit from a PR that hasn't yet been merged).

### Tests

Testing:
  - Running directly from GitHub:
    - `npx github:ferdikoomen/openapi-typescript-codegen --help` (fails)
    - `npx github:aloisklink/openapi-typescript-codegen#build/use-npm-prepare-instead-of-prepublishOnly --help` (works)
  - Built automatically when running `npm publish`:
    ```console
    user@pc:~/openapi-typescript-codegen (build/use-npm-prepare-instead-of-prepublishOnly)$ rm -r dist/
    user@pc:~/openapi-typescript-codegen (build/use-npm-prepare-instead-of-prepublishOnly)$         
    npm publish --dry-run
    npm notice 
    npm notice 📦  openapi-typescript-codegen@0.24.0
    npm notice === Tarball Contents === 
    npm notice 1.1kB   LICENSE         
    npm notice 4.3kB   README.md       
    npm notice 2.2kB   bin/index.js    
    npm notice 217.3kB dist/index.js   
    npm notice 4.4kB   package.json    
    npm notice 928B    types/index.d.ts
    npm notice === Tarball Details === 
    npm notice name:          openapi-typescript-codegen              
    npm notice version:       0.24.0                                  
    npm notice filename:      openapi-typescript-codegen-0.24.0.tgz   
    npm notice package size:  33.9 kB                                 
    npm notice unpacked size: 230.3 kB                                
    npm notice shasum:        8b23209515a5e36e1bf9581234f9a8c164e19d3b
    npm notice integrity:     sha512-N7gF1E68WEmrd[...]spGffk8E7DHiQ==
    npm notice total files:   6                                       
    npm notice 
    npm WARN This command requires you to be logged in to https://registry.npmjs.org/ (dry-run)
    npm notice Publishing to https://registry.npmjs.org/ (dry-run)
    + openapi-typescript-codegen@0.24.0
    ```