### PR TITLE
fix: adjust promise resolve for next issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "openapi-typescript-codegen",
-    "version": "0.24.0",
+    "version": "0.25.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "openapi-typescript-codegen",
-            "version": "0.24.0",
+            "version": "0.25.0",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "^6.3.0",

--- a/src/templates/core/CancelablePromise.hbs
+++ b/src/templates/core/CancelablePromise.hbs
@@ -49,7 +49,7 @@ export class CancelablePromise<T> implements Promise<T> {
 					return;
 				}
 				this.#isResolved = true;
-				this.#resolve?.(value);
+				if (this.#resolve) this.#resolve(value);
 			};
 
 			const onReject = (reason?: any): void => {
@@ -57,7 +57,7 @@ export class CancelablePromise<T> implements Promise<T> {
 					return;
 				}
 				this.#isRejected = true;
-				this.#reject?.(reason);
+				if (this.#reject) this.#reject(reason);
 			};
 
 			const onCancel = (cancelHandler: () => void): void => {

--- a/src/templates/core/CancelablePromise.hbs
+++ b/src/templates/core/CancelablePromise.hbs
@@ -120,7 +120,7 @@ export class CancelablePromise<T> implements Promise<T> {
 			}
 		}
 		this.#cancelHandlers.length = 0;
-		this.#reject?.(new CancelError('Request aborted'));
+		if (this.#reject) this.#reject(new CancelError('Request aborted'));
 	}
 
 	public get isCancelled(): boolean {

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -119,7 +119,7 @@ export class CancelablePromise<T> implements Promise<T> {
                     return;
                 }
                 this.#isResolved = true;
-                this.#resolve?.(value);
+                if (this.#resolve) this.#resolve(value);
             };
 
             const onReject = (reason?: any): void => {
@@ -127,7 +127,7 @@ export class CancelablePromise<T> implements Promise<T> {
                     return;
                 }
                 this.#isRejected = true;
-                this.#reject?.(reason);
+                if (this.#reject) this.#reject(reason);
             };
 
             const onCancel = (cancelHandler: () => void): void => {
@@ -3345,7 +3345,7 @@ export class CancelablePromise<T> implements Promise<T> {
                     return;
                 }
                 this.#isResolved = true;
-                this.#resolve?.(value);
+                if (this.#resolve) this.#resolve(value);
             };
 
             const onReject = (reason?: any): void => {
@@ -3353,7 +3353,7 @@ export class CancelablePromise<T> implements Promise<T> {
                     return;
                 }
                 this.#isRejected = true;
-                this.#reject?.(reason);
+                if (this.#reject) this.#reject(reason);
             };
 
             const onCancel = (cancelHandler: () => void): void => {


### PR DESCRIPTION
Adressing issue #1626.

Proposal for a slight adjustment of the resolving process for the `CancelablePromise`.

As said, I have no clue why this issue occurs when updating Next.js for me, but something in the background must've changed that I'm not aware of. The exact same generated code works for me with Next.js 12.
It seems to try to call the `resolve()` function before the instance is initiated and not resolving the valid syntax of `this.#resolve?.(value)` correctly.

Doing the `undefined` check without an intermediate value, seems to resolve this issue for me, so I would propose this in a PR and would be interested in your opinions on this.
Imo, this shouldn't affect other users in a negative way and only increase the code size very slightly.

So instead of `this.#resolve?.(value);`, I propose:
```typescript
if (this.#resolve) this.#resolve(value);
```