### PR TITLE
Add support for const validation

### DIFF
--- a/src/openApi/v3/interfaces/OpenApiSchema.d.ts
+++ b/src/openApi/v3/interfaces/OpenApiSchema.d.ts
@@ -25,6 +25,7 @@ export interface OpenApiSchema extends OpenApiReference, WithEnumExtension {
     minProperties?: number;
     required?: string[];
     enum?: (string | number)[];
+    const?: any;
     type?: string | string[];
     allOf?: OpenApiSchema[];
     oneOf?: OpenApiSchema[];

--- a/src/openApi/v3/parser/getModel.ts
+++ b/src/openApi/v3/parser/getModel.ts
@@ -59,6 +59,12 @@ export const getModel = (
         return model;
     }
 
+    // Rewrite const to be single-value enums for the sake of processing
+    if (definition.const) {
+        definition.enum = [definition.const];
+        definition.const = undefined;
+    }
+
     if (definition.enum && definition.type !== 'boolean') {
         const enumerators = getEnum(definition.enum);
         const extendedEnumerators = extendEnum(enumerators, definition);


### PR DESCRIPTION
See also https://github.com/IntrinsicLabsAI/intrinsic-model-server/pull/99/files#r1254572079

This adds support for parsing of values with JSON Schema [`const` validation](https://json-schema.org/draft/2020-12/json-schema-validation.html#name-const), which is allowed as part of OpenAPI 3.1.0 absorbing JSON Schema validation language.

**Usecase**

This is something that will affect clients who use this tool to integrate with a Python FastAPI backend once 0.100.0 releases **and** are using single-valued enums.

When using the FastAPI + Pydantic v2 stack (just bumped earlier this week), they've started emitting OpenAPI v3.1.0 schemas, including a change in how single-value enums are encoded.

Take the following Python enum definition:

```python
from enum import Enum

class ModelType(str, Enum):
  completion = "completion"
```

In FastAPI before 0.100.0/Pydantic pre-v2, the following enum definition would be serialized as the following OpenAPI 3.0 schema:

```json
"ModelType": {
    "title": "ModelType",
    "enum": [
      "completion"
    ],
    "type": "string"
}
```

This tool then generates a TypeScript definition that looks like

```typescript
/* generated using openapi-typescript-codegen -- do no edit */
/* istanbul ignore file */
/* tslint:disable */
/* eslint-disable */

export enum ModelType {
    COMPLETION = 'completion',
}
```


However, the latest version of FastAPI/Pydantic is targeting OpenAPI 3.1.0 which allows for the `const` validation keyword for types. When using `pydantic==2.0.3` and `fastapi==0.100.0-beta3`, the same schema definition is now emitted as

```json
"ModelType": {
    "type": "string",
    "const": "completion",
    "title": "ModelType"
}
```

This tool before this change discards the `const` information and will generate TypeScript that maps the type to string, losing all type safety:

```typescript
export type ModelType = string;
```

---

This PR is a minimum-viable patch to allow `const` to be treated as a single-value `enum` type for the codegen process, i.e. preserving the pre-existing behavior.

An alternative is to use TypeScript's literal types to implement this instead so that for a `const` we generate code that looks like

```typescript
export type ModelType = "completion";
```

I'm happy to change the PR to target this format, just wanted to push something up to make sure you're interested in accepting this change at all. Thanks for the great tool!