### PR TITLE
support nested any-of to use with openapi v3.1 type null

### DIFF
--- a/src/openApi/v3/parser/getModelComposition.ts
+++ b/src/openApi/v3/parser/getModelComposition.ts
@@ -30,9 +30,10 @@ export const getModelComposition = (
         .filter(model => {
             const hasProperties = model.properties.length;
             const hasEnums = model.enums.length;
+            const hasLink = typeof model.link !== 'undefined' && model.link !== null;
             const isObject = model.type === 'any';
             const isDictionary = model.export === 'dictionary';
-            const isEmpty = isObject && !hasProperties && !hasEnums;
+            const isEmpty = isObject && !hasProperties && !hasEnums && !hasLink;
             return !isEmpty || isDictionary;
         })
         .forEach(model => {

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -3682,6 +3682,7 @@ export type { CompositionWithAllOfAndNullable } from './models/CompositionWithAl
 export type { CompositionWithAnyOf } from './models/CompositionWithAnyOf';
 export type { CompositionWithAnyOfAndNullable } from './models/CompositionWithAnyOfAndNullable';
 export type { CompositionWithAnyOfAnonymous } from './models/CompositionWithAnyOfAnonymous';
+export type { CompositionWithNestedAnyAndTypeNull } from './models/CompositionWithNestedAnyAndTypeNull';
 export type { CompositionWithOneOf } from './models/CompositionWithOneOf';
 export type { CompositionWithOneOfAndComplexArrayDictionary } from './models/CompositionWithOneOfAndComplexArrayDictionary';
 export type { CompositionWithOneOfAndNullable } from './models/CompositionWithOneOfAndNullable';
@@ -3752,6 +3753,7 @@ export { $CompositionWithAllOfAndNullable } from './schemas/$CompositionWithAllO
 export { $CompositionWithAnyOf } from './schemas/$CompositionWithAnyOf';
 export { $CompositionWithAnyOfAndNullable } from './schemas/$CompositionWithAnyOfAndNullable';
 export { $CompositionWithAnyOfAnonymous } from './schemas/$CompositionWithAnyOfAnonymous';
+export { $CompositionWithNestedAnyAndTypeNull } from './schemas/$CompositionWithNestedAnyAndTypeNull';
 export { $CompositionWithOneOf } from './schemas/$CompositionWithOneOf';
 export { $CompositionWithOneOfAndComplexArrayDictionary } from './schemas/$CompositionWithOneOfAndComplexArrayDictionary';
 export { $CompositionWithOneOfAndNullable } from './schemas/$CompositionWithOneOfAndNullable';
@@ -4096,6 +4098,23 @@ export type CompositionWithAnyOfAnonymous = {
     propA?: ({
         propA?: string;
     } | string | number);
+};
+
+"
+`;
+
+exports[`v3 should generate: test/generated/v3/models/CompositionWithNestedAnyAndTypeNull.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithArray } from './ModelWithArray';
+import type { ModelWithDictionary } from './ModelWithDictionary';
+/**
+ * This is a model with nested 'any of' property with a type null
+ */
+export type CompositionWithNestedAnyAndTypeNull = {
+    propA?: (Array<(ModelWithDictionary | null)> | Array<(ModelWithArray | null)>);
 };
 
 "
@@ -5292,6 +5311,43 @@ export const $CompositionWithAnyOfAnonymous = {
             }, {
                 type: 'number',
                 description: \`Anonymous integer type\`,
+            }],
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate: test/generated/v3/schemas/$CompositionWithNestedAnyAndTypeNull.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithNestedAnyAndTypeNull = {
+    description: \`This is a model with nested 'any of' property with a type null\`,
+    properties: {
+        propA: {
+            type: 'any-of',
+            contains: [{
+                type: 'array',
+                contains: {
+                    type: 'any-of',
+                    contains: [{
+                        type: 'ModelWithDictionary',
+                    }, {
+                        type: 'null',
+                    }],
+                },
+            }, {
+                type: 'array',
+                contains: {
+                    type: 'any-of',
+                    contains: [{
+                        type: 'ModelWithArray',
+                    }, {
+                        type: 'null',
+                    }],
+                },
             }],
         },
     },

--- a/test/spec/v3.json
+++ b/test/spec/v3.json
@@ -2553,6 +2553,43 @@
                 "description": "This is a free-form object with additionalProperties: {}.",
                 "type": "object",
                 "additionalProperties": {}
+            },
+            "CompositionWithNestedAnyAndTypeNull": {
+                "description": "This is a model with nested 'any of' property with a type null",
+                "type": "object",
+                "properties": {
+                    "propA": {
+                        "type": "object",
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ModelWithDictionary"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ModelWithArray"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            }
+                        ]
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Hi there 👋🏻 

Thanks @ferdikoomen for your amazing job on this library 🙏🏻 

I've tried my best to implement support for nested anyOf in order to use the[ type null rework on open api specification v3.1](https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0).

It seems related to https://github.com/ferdikoomen/openapi-typescript-codegen/issues/1643.

I remain at your disposal for any feedback on the implementation.

I wish you a great day ☀️ 

Best regards ☮️ 
