### PR TITLE
fix: eslint ignore before tslint

### DIFF
--- a/src/templates/partials/header.hbs
+++ b/src/templates/partials/header.hbs
@@ -1,4 +1,4 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
-/* tslint:disable */
 /* eslint-disable */
+/* tslint:disable */


### PR DESCRIPTION
In my dev environment, I get ESlint errors of [`tslint comment detected: "/* tslint:disable */"  @typescript-eslint/ban-tslint-comment`](https://typescript-eslint.io/rules/ban-tslint-comment/).

I can ignore it in my configuration, but I think it will be helpful to change the order on the template to save this.
