### PR TITLE
export operation's options as type

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ $ openapi --help
     --exportServices <value>  Write services to disk (default: true)
     --exportModels <value>    Write models to disk (default: true)
     --exportSchemas <value>   Write schemas to disk (default: false)
+    --exportOptions <value>   Write function's options to disk (default: false)
     --indent <value>          Indentation options [4, 2, tab] (default: "4")
     --postfixServices         Service name postfix (default: "Service")
     --postfixModels           Model name postfix

--- a/bin/index.js
+++ b/bin/index.js
@@ -20,6 +20,7 @@ const params = program
     .option('--exportServices <value>', 'Write services to disk', true)
     .option('--exportModels <value>', 'Write models to disk', true)
     .option('--exportSchemas <value>', 'Write schemas to disk', false)
+    .option('--exportOptions <value>', `Write function's options to disk`, false)
     .option('--indent <value>', 'Indentation options [4, 2, tabs]', '4')
     .option('--postfixServices <value>', 'Service name postfix', 'Service')
     .option('--postfixModels <value>', 'Model name postfix')
@@ -41,6 +42,7 @@ if (OpenAPI) {
         exportServices: JSON.parse(params.exportServices) === true,
         exportModels: JSON.parse(params.exportModels) === true,
         exportSchemas: JSON.parse(params.exportSchemas) === true,
+        exportOptions: JSON.parse(params.exportOptions) === true,
         indent: params.indent,
         postfixServices: params.postfixServices,
         postfixModels: params.postfixModels,

--- a/bin/index.spec.js
+++ b/bin/index.spec.js
@@ -32,6 +32,8 @@ describe('bin', () => {
             'true',
             '--exportSchemas',
             'true',
+            '--exportOptions',
+            'true',
             '--indent',
             '4',
             '--postfixServices',

--- a/src/client/interfaces/Operation.d.ts
+++ b/src/client/interfaces/Operation.d.ts
@@ -5,6 +5,7 @@ import type { OperationResponse } from './OperationResponse';
 export interface Operation extends OperationParameters {
     service: string;
     name: string;
+    optionsTypeName: string;
     summary: string | null;
     description: string | null;
     deprecated: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export type Options = {
     exportServices?: boolean;
     exportModels?: boolean;
     exportSchemas?: boolean;
+    exportOptions?: boolean;
     indent?: Indent;
     postfixServices?: string;
     postfixModels?: string;
@@ -44,6 +45,7 @@ export type Options = {
  * @param exportServices Generate services
  * @param exportModels Generate models
  * @param exportSchemas Generate schemas
+ * @param exportOptions Generate function's options
  * @param indent Indentation options (4, 2 or tab)
  * @param postfixServices Service name postfix
  * @param postfixModels Model name postfix
@@ -61,6 +63,7 @@ export const generate = async ({
     exportServices = true,
     exportModels = true,
     exportSchemas = false,
+    exportOptions = false,
     indent = Indent.SPACE_4,
     postfixServices = 'Service',
     postfixModels = '',
@@ -91,6 +94,7 @@ export const generate = async ({
                 exportServices,
                 exportModels,
                 exportSchemas,
+                exportOptions,
                 indent,
                 postfixServices,
                 postfixModels,
@@ -115,6 +119,7 @@ export const generate = async ({
                 exportServices,
                 exportModels,
                 exportSchemas,
+                exportOptions,
                 indent,
                 postfixServices,
                 postfixModels,

--- a/src/openApi/v2/parser/getOperation.ts
+++ b/src/openApi/v2/parser/getOperation.ts
@@ -1,3 +1,5 @@
+import camelCase from 'camelcase';
+
 import type { Operation } from '../../../client/interfaces/Operation';
 import type { OperationParameters } from '../../../client/interfaces/OperationParameters';
 import type { OpenApi } from '../interfaces/OpenApi';
@@ -26,6 +28,7 @@ export const getOperation = (
     const operation: Operation = {
         service: serviceName,
         name: operationName,
+        optionsTypeName: camelCase([operationName, 'Options'], { pascalCase: true }),
         summary: op.summary || null,
         description: op.description || null,
         deprecated: op.deprecated === true,

--- a/src/openApi/v3/parser/getOperation.ts
+++ b/src/openApi/v3/parser/getOperation.ts
@@ -1,3 +1,5 @@
+import camelCase from 'camelcase';
+
 import type { Operation } from '../../../client/interfaces/Operation';
 import type { OperationParameters } from '../../../client/interfaces/OperationParameters';
 import type { OpenApi } from '../interfaces/OpenApi';
@@ -29,6 +31,7 @@ export const getOperation = (
     const operation: Operation = {
         service: serviceName,
         name: operationName,
+        optionsTypeName: camelCase([operationName, 'Options'], { pascalCase: true }),
         summary: op.summary || null,
         description: op.description || null,
         deprecated: op.deprecated === true,

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -31,6 +31,30 @@ import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
 {{/if}}
 
+{{#if @root.useOptions }}
+{{#if @root.exportOptions }}
+{{#each operations}}
+{{#if parameters}}
+export type {{{optionsTypeName}}} = {
+{{#each parameters}}
+{{#ifdef description deprecated}}
+  /**
+{{#if description}}
+   * {{{escapeComment description}}}
+{{/if}}
+{{#if deprecated}}
+   * @deprecated
+{{/if}}
+   */
+{{/ifdef}}
+   {{{name}}}{{>isRequired}}: {{>type}},
+{{/each}}
+};
+{{/if}}
+{{/each}}
+{{/if}}
+{{/if}}
+
 {{#equals @root.httpClient 'angular'}}
 @Injectable({
   providedIn: 'root',

--- a/src/templates/index.hbs
+++ b/src/templates/index.hbs
@@ -41,7 +41,7 @@ export { ${{{name}}} } from './schemas/${{{name}}}';
 {{#if services}}
 
 {{#each services}}
-export { {{{name}}}{{{@root.postfixServices}}} } from './services/{{{name}}}{{{@root.postfixServices}}}';
+export { {{{name}}}{{{@root.postfixServices}}}{{#if @root.useOptions}}{{#if @root.exportOptions}}{{#each operations}}{{#if parameters}}, {{{ optionsTypeName }}}{{/if}}{{/each}}{{/if}}{{/if}} } from './services/{{{name}}}{{{@root.postfixServices}}}';
 {{/each}}
 {{/if}}
 {{/if}}

--- a/src/templates/partials/parameters.hbs
+++ b/src/templates/partials/parameters.hbs
@@ -4,7 +4,7 @@
 {{#each parameters}}
 {{{name}}}{{#if default}} = {{{default}}}{{/if}},
 {{/each}}
-}: {
+}: {{#if @root.exportOptions~}}{{{ optionsTypeName }}}{{~else}}{
 {{#each parameters}}
 {{#ifdef description deprecated}}
 /**
@@ -19,6 +19,7 @@
 {{{name}}}{{>isRequired}}: {{>type}},
 {{/each}}
 }
+{{/if}}
 {{~else}}
 
 {{#each parameters}}

--- a/src/utils/writeClient.spec.ts
+++ b/src/utils/writeClient.spec.ts
@@ -47,6 +47,7 @@ describe('writeClient', () => {
             true,
             true,
             true,
+            false,
             Indent.SPACE_4,
             'Service',
             'AppClient'

--- a/src/utils/writeClient.ts
+++ b/src/utils/writeClient.ts
@@ -26,7 +26,7 @@ import { writeClientServices } from './writeClientServices';
  * @param exportServices Generate services
  * @param exportModels Generate models
  * @param exportSchemas Generate schemas
- * @param exportSchemas Generate schemas
+ * @param exportOptions Generate function's options
  * @param indent Indentation options (4, 2 or tab)
  * @param postfixServices Service name postfix
  * @param postfixModels Model name postfix
@@ -44,6 +44,7 @@ export const writeClient = async (
     exportServices: boolean,
     exportModels: boolean,
     exportSchemas: boolean,
+    exportOptions: boolean,
     indent: Indent,
     postfixServices: string,
     postfixModels: string,
@@ -76,6 +77,7 @@ export const writeClient = async (
             httpClient,
             useUnionTypes,
             useOptions,
+            exportOptions,
             indent,
             postfixServices,
             clientName
@@ -106,10 +108,12 @@ export const writeClient = async (
             templates,
             outputPath,
             useUnionTypes,
+            useOptions,
             exportCore,
             exportServices,
             exportModels,
             exportSchemas,
+            exportOptions,
             postfixServices,
             postfixModels,
             clientName

--- a/src/utils/writeClientIndex.spec.ts
+++ b/src/utils/writeClientIndex.spec.ts
@@ -36,7 +36,7 @@ describe('writeClientIndex', () => {
             },
         };
 
-        await writeClientIndex(client, templates, '/', true, true, true, true, true, 'Service', '');
+        await writeClientIndex(client, templates, '/', true, true, true, true, true, true, true, 'Service', '');
 
         expect(writeFile).toBeCalledWith(resolve('/', '/index.ts'), 'index');
     });

--- a/src/utils/writeClientIndex.ts
+++ b/src/utils/writeClientIndex.ts
@@ -15,10 +15,12 @@ import { sortServicesByName } from './sortServicesByName';
  * @param templates The loaded handlebar templates
  * @param outputPath Directory to write the generated files to
  * @param useUnionTypes Use union types instead of enums
+ * @param useOptions Use options or arguments functions
  * @param exportCore Generate core
  * @param exportServices Generate services
  * @param exportModels Generate models
  * @param exportSchemas Generate schemas
+ * @param exportOptions Generate function's options
  * @param postfixServices Service name postfix
  * @param postfixModels Model name postfix
  * @param clientName Custom client class name
@@ -28,10 +30,12 @@ export const writeClientIndex = async (
     templates: Templates,
     outputPath: string,
     useUnionTypes: boolean,
+    useOptions: boolean,
     exportCore: boolean,
     exportServices: boolean,
     exportModels: boolean,
     exportSchemas: boolean,
+    exportOptions: boolean,
     postfixServices: string,
     postfixModels: string,
     clientName?: string
@@ -41,6 +45,8 @@ export const writeClientIndex = async (
         exportServices,
         exportModels,
         exportSchemas,
+        exportOptions,
+        useOptions,
         useUnionTypes,
         postfixServices,
         postfixModels,

--- a/src/utils/writeClientServices.spec.ts
+++ b/src/utils/writeClientServices.spec.ts
@@ -40,7 +40,17 @@ describe('writeClientServices', () => {
             },
         };
 
-        await writeClientServices(services, templates, '/', HttpClient.FETCH, false, false, Indent.SPACE_4, 'Service');
+        await writeClientServices(
+            services,
+            templates,
+            '/',
+            HttpClient.FETCH,
+            false,
+            false,
+            false,
+            Indent.SPACE_4,
+            'Service'
+        );
 
         expect(writeFile).toBeCalledWith(resolve('/', '/UserService.ts'), `service${EOL}`);
     });

--- a/src/utils/writeClientServices.ts
+++ b/src/utils/writeClientServices.ts
@@ -17,6 +17,7 @@ import type { Templates } from './registerHandlebarTemplates';
  * @param httpClient The selected httpClient (fetch, xhr, node or axios)
  * @param useUnionTypes Use union types instead of enums
  * @param useOptions Use options or arguments functions
+ * @param exportOptions Generate function's options
  * @param indent Indentation options (4, 2 or tab)
  * @param postfix Service name postfix
  * @param clientName Custom client class name
@@ -28,6 +29,7 @@ export const writeClientServices = async (
     httpClient: HttpClient,
     useUnionTypes: boolean,
     useOptions: boolean,
+    exportOptions: boolean,
     indent: Indent,
     postfix: string,
     clientName?: string
@@ -39,6 +41,7 @@ export const writeClientServices = async (
             httpClient,
             useUnionTypes,
             useOptions,
+            exportOptions,
             postfix,
             exportClient: isDefined(clientName),
         });

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -3093,6 +3093,4526 @@ export class TypesService {
 "
 `;
 
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/core/ApiError.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+
+export class ApiError extends Error {
+    public readonly url: string;
+    public readonly status: number;
+    public readonly statusText: string;
+    public readonly body: any;
+    public readonly request: ApiRequestOptions;
+
+    constructor(request: ApiRequestOptions, response: ApiResult, message: string) {
+        super(message);
+
+        this.name = 'ApiError';
+        this.url = response.url;
+        this.status = response.status;
+        this.statusText = response.statusText;
+        this.body = response.body;
+        this.request = request;
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/core/ApiRequestOptions.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiRequestOptions = {
+    readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
+    readonly url: string;
+    readonly path?: Record<string, any>;
+    readonly cookies?: Record<string, any>;
+    readonly headers?: Record<string, any>;
+    readonly query?: Record<string, any>;
+    readonly formData?: Record<string, any>;
+    readonly body?: any;
+    readonly mediaType?: string;
+    readonly responseHeader?: string;
+    readonly errors?: Record<number, string>;
+};
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/core/ApiResult.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiResult = {
+    readonly url: string;
+    readonly ok: boolean;
+    readonly status: number;
+    readonly statusText: string;
+    readonly body: any;
+};
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/core/CancelablePromise.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export class CancelError extends Error {
+
+    constructor(message: string) {
+        super(message);
+        this.name = 'CancelError';
+    }
+
+    public get isCancelled(): boolean {
+        return true;
+    }
+}
+
+export interface OnCancel {
+    readonly isResolved: boolean;
+    readonly isRejected: boolean;
+    readonly isCancelled: boolean;
+
+    (cancelHandler: () => void): void;
+}
+
+export class CancelablePromise<T> implements Promise<T> {
+    #isResolved: boolean;
+    #isRejected: boolean;
+    #isCancelled: boolean;
+    readonly #cancelHandlers: (() => void)[];
+    readonly #promise: Promise<T>;
+    #resolve?: (value: T | PromiseLike<T>) => void;
+    #reject?: (reason?: any) => void;
+
+    constructor(
+        executor: (
+            resolve: (value: T | PromiseLike<T>) => void,
+            reject: (reason?: any) => void,
+            onCancel: OnCancel
+        ) => void
+    ) {
+        this.#isResolved = false;
+        this.#isRejected = false;
+        this.#isCancelled = false;
+        this.#cancelHandlers = [];
+        this.#promise = new Promise<T>((resolve, reject) => {
+            this.#resolve = resolve;
+            this.#reject = reject;
+
+            const onResolve = (value: T | PromiseLike<T>): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#isResolved = true;
+                if (this.#resolve) this.#resolve(value);
+            };
+
+            const onReject = (reason?: any): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#isRejected = true;
+                if (this.#reject) this.#reject(reason);
+            };
+
+            const onCancel = (cancelHandler: () => void): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#cancelHandlers.push(cancelHandler);
+            };
+
+            Object.defineProperty(onCancel, 'isResolved', {
+                get: (): boolean => this.#isResolved,
+            });
+
+            Object.defineProperty(onCancel, 'isRejected', {
+                get: (): boolean => this.#isRejected,
+            });
+
+            Object.defineProperty(onCancel, 'isCancelled', {
+                get: (): boolean => this.#isCancelled,
+            });
+
+            return executor(onResolve, onReject, onCancel as OnCancel);
+        });
+    }
+
+     get [Symbol.toStringTag]() {
+            return "Cancellable Promise";
+     }
+
+    public then<TResult1 = T, TResult2 = never>(
+        onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+        onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
+    ): Promise<TResult1 | TResult2> {
+        return this.#promise.then(onFulfilled, onRejected);
+    }
+
+    public catch<TResult = never>(
+        onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
+    ): Promise<T | TResult> {
+        return this.#promise.catch(onRejected);
+    }
+
+    public finally(onFinally?: (() => void) | null): Promise<T> {
+        return this.#promise.finally(onFinally);
+    }
+
+    public cancel(): void {
+        if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+            return;
+        }
+        this.#isCancelled = true;
+        if (this.#cancelHandlers.length) {
+            try {
+                for (const cancelHandler of this.#cancelHandlers) {
+                    cancelHandler();
+                }
+            } catch (error) {
+                console.warn('Cancellation threw an error', error);
+                return;
+            }
+        }
+        this.#cancelHandlers.length = 0;
+        if (this.#reject) this.#reject(new CancelError('Request aborted'));
+    }
+
+    public get isCancelled(): boolean {
+        return this.#isCancelled;
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/core/OpenAPI.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+type Headers = Record<string, string>;
+
+export type OpenAPIConfig = {
+    BASE: string;
+    VERSION: string;
+    WITH_CREDENTIALS: boolean;
+    CREDENTIALS: 'include' | 'omit' | 'same-origin';
+    TOKEN?: string | Resolver<string> | undefined;
+    USERNAME?: string | Resolver<string> | undefined;
+    PASSWORD?: string | Resolver<string> | undefined;
+    HEADERS?: Headers | Resolver<Headers> | undefined;
+    ENCODE_PATH?: ((path: string) => string) | undefined;
+};
+
+export const OpenAPI: OpenAPIConfig = {
+    BASE: 'http://localhost:3000/base',
+    VERSION: '1.0',
+    WITH_CREDENTIALS: false,
+    CREDENTIALS: 'include',
+    TOKEN: undefined,
+    USERNAME: undefined,
+    PASSWORD: undefined,
+    HEADERS: undefined,
+    ENCODE_PATH: undefined,
+};
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/core/request.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import { ApiError } from './ApiError';
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+import { CancelablePromise } from './CancelablePromise';
+import type { OnCancel } from './CancelablePromise';
+import type { OpenAPIConfig } from './OpenAPI';
+
+export const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
+    return value !== undefined && value !== null;
+};
+
+export const isString = (value: any): value is string => {
+    return typeof value === 'string';
+};
+
+export const isStringWithValue = (value: any): value is string => {
+    return isString(value) && value !== '';
+};
+
+export const isBlob = (value: any): value is Blob => {
+    return (
+        typeof value === 'object' &&
+        typeof value.type === 'string' &&
+        typeof value.stream === 'function' &&
+        typeof value.arrayBuffer === 'function' &&
+        typeof value.constructor === 'function' &&
+        typeof value.constructor.name === 'string' &&
+        /^(Blob|File)$/.test(value.constructor.name) &&
+        /^(Blob|File)$/.test(value[Symbol.toStringTag])
+    );
+};
+
+export const isFormData = (value: any): value is FormData => {
+    return value instanceof FormData;
+};
+
+export const base64 = (str: string): string => {
+    try {
+        return btoa(str);
+    } catch (err) {
+        // @ts-ignore
+        return Buffer.from(str).toString('base64');
+    }
+};
+
+export const getQueryString = (params: Record<string, any>): string => {
+    const qs: string[] = [];
+
+    const append = (key: string, value: any) => {
+        qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
+    };
+
+    const process = (key: string, value: any) => {
+        if (isDefined(value)) {
+            if (Array.isArray(value)) {
+                value.forEach(v => {
+                    process(key, v);
+                });
+            } else if (typeof value === 'object') {
+                Object.entries(value).forEach(([k, v]) => {
+                    process(\`\${key}[\${k}]\`, v);
+                });
+            } else {
+                append(key, value);
+            }
+        }
+    };
+
+    Object.entries(params).forEach(([key, value]) => {
+        process(key, value);
+    });
+
+    if (qs.length > 0) {
+        return \`?\${qs.join('&')}\`;
+    }
+
+    return '';
+};
+
+const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
+    const encoder = config.ENCODE_PATH || encodeURI;
+
+    const path = options.url
+        .replace('{api-version}', config.VERSION)
+        .replace(/{(.*?)}/g, (substring: string, group: string) => {
+            if (options.path?.hasOwnProperty(group)) {
+                return encoder(String(options.path[group]));
+            }
+            return substring;
+        });
+
+    const url = \`\${config.BASE}\${path}\`;
+    if (options.query) {
+        return \`\${url}\${getQueryString(options.query)}\`;
+    }
+    return url;
+};
+
+export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
+    if (options.formData) {
+        const formData = new FormData();
+
+        const process = (key: string, value: any) => {
+            if (isString(value) || isBlob(value)) {
+                formData.append(key, value);
+            } else {
+                formData.append(key, JSON.stringify(value));
+            }
+        };
+
+        Object.entries(options.formData)
+            .filter(([_, value]) => isDefined(value))
+            .forEach(([key, value]) => {
+                if (Array.isArray(value)) {
+                    value.forEach(v => process(key, v));
+                } else {
+                    process(key, value);
+                }
+            });
+
+        return formData;
+    }
+    return undefined;
+};
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+
+export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
+    if (typeof resolver === 'function') {
+        return (resolver as Resolver<T>)(options);
+    }
+    return resolver;
+};
+
+export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+    const token = await resolve(options, config.TOKEN);
+    const username = await resolve(options, config.USERNAME);
+    const password = await resolve(options, config.PASSWORD);
+    const additionalHeaders = await resolve(options, config.HEADERS);
+
+    const headers = Object.entries({
+        Accept: 'application/json',
+        ...additionalHeaders,
+        ...options.headers,
+    })
+        .filter(([_, value]) => isDefined(value))
+        .reduce((headers, [key, value]) => ({
+            ...headers,
+            [key]: String(value),
+        }), {} as Record<string, string>);
+
+    if (isStringWithValue(token)) {
+        headers['Authorization'] = \`Bearer \${token}\`;
+    }
+
+    if (isStringWithValue(username) && isStringWithValue(password)) {
+        const credentials = base64(\`\${username}:\${password}\`);
+        headers['Authorization'] = \`Basic \${credentials}\`;
+    }
+
+    if (options.body) {
+        if (options.mediaType) {
+            headers['Content-Type'] = options.mediaType;
+        } else if (isBlob(options.body)) {
+            headers['Content-Type'] = options.body.type || 'application/octet-stream';
+        } else if (isString(options.body)) {
+            headers['Content-Type'] = 'text/plain';
+        } else if (!isFormData(options.body)) {
+            headers['Content-Type'] = 'application/json';
+        }
+    }
+
+    return new Headers(headers);
+};
+
+export const getRequestBody = (options: ApiRequestOptions): any => {
+    if (options.body !== undefined) {
+        if (options.mediaType?.includes('/json')) {
+            return JSON.stringify(options.body)
+        } else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
+            return options.body;
+        } else {
+            return JSON.stringify(options.body);
+        }
+    }
+    return undefined;
+};
+
+export const sendRequest = async (
+    config: OpenAPIConfig,
+    options: ApiRequestOptions,
+    url: string,
+    body: any,
+    formData: FormData | undefined,
+    headers: Headers,
+    onCancel: OnCancel
+): Promise<Response> => {
+    const controller = new AbortController();
+
+    const request: RequestInit = {
+        headers,
+        body: body ?? formData,
+        method: options.method,
+        signal: controller.signal,
+    };
+
+    if (config.WITH_CREDENTIALS) {
+        request.credentials = config.CREDENTIALS;
+    }
+
+    onCancel(() => controller.abort());
+
+    return await fetch(url, request);
+};
+
+export const getResponseHeader = (response: Response, responseHeader?: string): string | undefined => {
+    if (responseHeader) {
+        const content = response.headers.get(responseHeader);
+        if (isString(content)) {
+            return content;
+        }
+    }
+    return undefined;
+};
+
+export const getResponseBody = async (response: Response): Promise<any> => {
+    if (response.status !== 204) {
+        try {
+            const contentType = response.headers.get('Content-Type');
+            if (contentType) {
+                const jsonTypes = ['application/json', 'application/problem+json']
+                const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
+                if (isJSON) {
+                    return await response.json();
+                } else {
+                    return await response.text();
+                }
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    }
+    return undefined;
+};
+
+export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
+    const errors: Record<number, string> = {
+        400: 'Bad Request',
+        401: 'Unauthorized',
+        403: 'Forbidden',
+        404: 'Not Found',
+        500: 'Internal Server Error',
+        502: 'Bad Gateway',
+        503: 'Service Unavailable',
+        ...options.errors,
+    }
+
+    const error = errors[result.status];
+    if (error) {
+        throw new ApiError(options, result, error);
+    }
+
+    if (!result.ok) {
+        const errorStatus = result.status ?? 'unknown';
+        const errorStatusText = result.statusText ?? 'unknown';
+        const errorBody = (() => {
+            try {
+                return JSON.stringify(result.body, null, 2);
+            } catch (e) {
+                return undefined;
+            }
+        })();
+
+        throw new ApiError(options, result,
+            \`Generic Error: status: \${errorStatus}; status text: \${errorStatusText}; body: \${errorBody}\`
+        );
+    }
+};
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+    return new CancelablePromise(async (resolve, reject, onCancel) => {
+        try {
+            const url = getUrl(config, options);
+            const formData = getFormData(options);
+            const body = getRequestBody(options);
+            const headers = await getHeaders(config, options);
+
+            if (!onCancel.isCancelled) {
+                const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
+                const responseBody = await getResponseBody(response);
+                const responseHeader = getResponseHeader(response, options.responseHeader);
+
+                const result: ApiResult = {
+                    url,
+                    ok: response.ok,
+                    status: response.status,
+                    statusText: response.statusText,
+                    body: responseHeader ?? responseBody,
+                };
+
+                catchErrorCodes(options, result);
+
+                resolve(result.body);
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+};
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/index.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export { ApiError } from './core/ApiError';
+export { CancelablePromise, CancelError } from './core/CancelablePromise';
+export { OpenAPI } from './core/OpenAPI';
+export type { OpenAPIConfig } from './core/OpenAPI';
+
+export type { _default } from './models/_default';
+export type { ArrayWithArray } from './models/ArrayWithArray';
+export type { ArrayWithBooleans } from './models/ArrayWithBooleans';
+export type { ArrayWithNumbers } from './models/ArrayWithNumbers';
+export type { ArrayWithProperties } from './models/ArrayWithProperties';
+export type { ArrayWithReferences } from './models/ArrayWithReferences';
+export type { ArrayWithStrings } from './models/ArrayWithStrings';
+export type { CommentWithBackticks } from './models/CommentWithBackticks';
+export type { CommentWithBreaks } from './models/CommentWithBreaks';
+export type { CommentWithExpressionPlaceholders } from './models/CommentWithExpressionPlaceholders';
+export type { CommentWithQuotes } from './models/CommentWithQuotes';
+export type { CommentWithReservedCharacters } from './models/CommentWithReservedCharacters';
+export type { CommentWithSlashes } from './models/CommentWithSlashes';
+export type { CompositionBaseModel } from './models/CompositionBaseModel';
+export type { CompositionExtendedModel } from './models/CompositionExtendedModel';
+export type { CompositionWithAllOfAndNullable } from './models/CompositionWithAllOfAndNullable';
+export type { CompositionWithAnyOf } from './models/CompositionWithAnyOf';
+export type { CompositionWithAnyOfAndNullable } from './models/CompositionWithAnyOfAndNullable';
+export type { CompositionWithAnyOfAnonymous } from './models/CompositionWithAnyOfAnonymous';
+export type { CompositionWithOneOf } from './models/CompositionWithOneOf';
+export type { CompositionWithOneOfAndComplexArrayDictionary } from './models/CompositionWithOneOfAndComplexArrayDictionary';
+export type { CompositionWithOneOfAndNullable } from './models/CompositionWithOneOfAndNullable';
+export type { CompositionWithOneOfAndSimpleArrayDictionary } from './models/CompositionWithOneOfAndSimpleArrayDictionary';
+export type { CompositionWithOneOfAndSimpleDictionary } from './models/CompositionWithOneOfAndSimpleDictionary';
+export type { CompositionWithOneOfAnonymous } from './models/CompositionWithOneOfAnonymous';
+export type { CompositionWithOneOfDiscriminator } from './models/CompositionWithOneOfDiscriminator';
+export type { DeprecatedModel } from './models/DeprecatedModel';
+export type { DictionaryWithArray } from './models/DictionaryWithArray';
+export type { DictionaryWithDictionary } from './models/DictionaryWithDictionary';
+export type { DictionaryWithProperties } from './models/DictionaryWithProperties';
+export type { DictionaryWithReference } from './models/DictionaryWithReference';
+export type { DictionaryWithString } from './models/DictionaryWithString';
+export type { EnumFromDescription } from './models/EnumFromDescription';
+export { EnumWithExtensions } from './models/EnumWithExtensions';
+export { EnumWithNumbers } from './models/EnumWithNumbers';
+export { EnumWithStrings } from './models/EnumWithStrings';
+export type { File } from './models/File';
+export type { FreeFormObjectWithAdditionalPropertiesEqEmptyObject } from './models/FreeFormObjectWithAdditionalPropertiesEqEmptyObject';
+export type { FreeFormObjectWithAdditionalPropertiesEqTrue } from './models/FreeFormObjectWithAdditionalPropertiesEqTrue';
+export type { FreeFormObjectWithoutAdditionalProperties } from './models/FreeFormObjectWithoutAdditionalProperties';
+export type { ModelCircle } from './models/ModelCircle';
+export type { ModelSquare } from './models/ModelSquare';
+export type { ModelThatExtends } from './models/ModelThatExtends';
+export type { ModelThatExtendsExtends } from './models/ModelThatExtendsExtends';
+export type { ModelWithArray } from './models/ModelWithArray';
+export type { ModelWithBoolean } from './models/ModelWithBoolean';
+export type { ModelWithCircularReference } from './models/ModelWithCircularReference';
+export type { ModelWithDictionary } from './models/ModelWithDictionary';
+export type { ModelWithDuplicateImports } from './models/ModelWithDuplicateImports';
+export type { ModelWithDuplicateProperties } from './models/ModelWithDuplicateProperties';
+export { ModelWithEnum } from './models/ModelWithEnum';
+export type { ModelWithEnumFromDescription } from './models/ModelWithEnumFromDescription';
+export type { ModelWithInteger } from './models/ModelWithInteger';
+export type { ModelWithNestedEnums } from './models/ModelWithNestedEnums';
+export type { ModelWithNestedProperties } from './models/ModelWithNestedProperties';
+export type { ModelWithNullableString } from './models/ModelWithNullableString';
+export type { ModelWithOrderedProperties } from './models/ModelWithOrderedProperties';
+export type { ModelWithPattern } from './models/ModelWithPattern';
+export type { ModelWithProperties } from './models/ModelWithProperties';
+export type { ModelWithReference } from './models/ModelWithReference';
+export type { ModelWithString } from './models/ModelWithString';
+export type { Pageable } from './models/Pageable';
+export type { SimpleBoolean } from './models/SimpleBoolean';
+export type { SimpleFile } from './models/SimpleFile';
+export type { SimpleInteger } from './models/SimpleInteger';
+export type { SimpleParameter } from './models/SimpleParameter';
+export type { SimpleReference } from './models/SimpleReference';
+export type { SimpleString } from './models/SimpleString';
+export type { SimpleStringWithPattern } from './models/SimpleStringWithPattern';
+
+export { $_default } from './schemas/$_default';
+export { $ArrayWithArray } from './schemas/$ArrayWithArray';
+export { $ArrayWithBooleans } from './schemas/$ArrayWithBooleans';
+export { $ArrayWithNumbers } from './schemas/$ArrayWithNumbers';
+export { $ArrayWithProperties } from './schemas/$ArrayWithProperties';
+export { $ArrayWithReferences } from './schemas/$ArrayWithReferences';
+export { $ArrayWithStrings } from './schemas/$ArrayWithStrings';
+export { $CommentWithBackticks } from './schemas/$CommentWithBackticks';
+export { $CommentWithBreaks } from './schemas/$CommentWithBreaks';
+export { $CommentWithExpressionPlaceholders } from './schemas/$CommentWithExpressionPlaceholders';
+export { $CommentWithQuotes } from './schemas/$CommentWithQuotes';
+export { $CommentWithReservedCharacters } from './schemas/$CommentWithReservedCharacters';
+export { $CommentWithSlashes } from './schemas/$CommentWithSlashes';
+export { $CompositionBaseModel } from './schemas/$CompositionBaseModel';
+export { $CompositionExtendedModel } from './schemas/$CompositionExtendedModel';
+export { $CompositionWithAllOfAndNullable } from './schemas/$CompositionWithAllOfAndNullable';
+export { $CompositionWithAnyOf } from './schemas/$CompositionWithAnyOf';
+export { $CompositionWithAnyOfAndNullable } from './schemas/$CompositionWithAnyOfAndNullable';
+export { $CompositionWithAnyOfAnonymous } from './schemas/$CompositionWithAnyOfAnonymous';
+export { $CompositionWithOneOf } from './schemas/$CompositionWithOneOf';
+export { $CompositionWithOneOfAndComplexArrayDictionary } from './schemas/$CompositionWithOneOfAndComplexArrayDictionary';
+export { $CompositionWithOneOfAndNullable } from './schemas/$CompositionWithOneOfAndNullable';
+export { $CompositionWithOneOfAndSimpleArrayDictionary } from './schemas/$CompositionWithOneOfAndSimpleArrayDictionary';
+export { $CompositionWithOneOfAndSimpleDictionary } from './schemas/$CompositionWithOneOfAndSimpleDictionary';
+export { $CompositionWithOneOfAnonymous } from './schemas/$CompositionWithOneOfAnonymous';
+export { $CompositionWithOneOfDiscriminator } from './schemas/$CompositionWithOneOfDiscriminator';
+export { $DeprecatedModel } from './schemas/$DeprecatedModel';
+export { $DictionaryWithArray } from './schemas/$DictionaryWithArray';
+export { $DictionaryWithDictionary } from './schemas/$DictionaryWithDictionary';
+export { $DictionaryWithProperties } from './schemas/$DictionaryWithProperties';
+export { $DictionaryWithReference } from './schemas/$DictionaryWithReference';
+export { $DictionaryWithString } from './schemas/$DictionaryWithString';
+export { $EnumFromDescription } from './schemas/$EnumFromDescription';
+export { $EnumWithExtensions } from './schemas/$EnumWithExtensions';
+export { $EnumWithNumbers } from './schemas/$EnumWithNumbers';
+export { $EnumWithStrings } from './schemas/$EnumWithStrings';
+export { $File } from './schemas/$File';
+export { $FreeFormObjectWithAdditionalPropertiesEqEmptyObject } from './schemas/$FreeFormObjectWithAdditionalPropertiesEqEmptyObject';
+export { $FreeFormObjectWithAdditionalPropertiesEqTrue } from './schemas/$FreeFormObjectWithAdditionalPropertiesEqTrue';
+export { $FreeFormObjectWithoutAdditionalProperties } from './schemas/$FreeFormObjectWithoutAdditionalProperties';
+export { $ModelCircle } from './schemas/$ModelCircle';
+export { $ModelSquare } from './schemas/$ModelSquare';
+export { $ModelThatExtends } from './schemas/$ModelThatExtends';
+export { $ModelThatExtendsExtends } from './schemas/$ModelThatExtendsExtends';
+export { $ModelWithArray } from './schemas/$ModelWithArray';
+export { $ModelWithBoolean } from './schemas/$ModelWithBoolean';
+export { $ModelWithCircularReference } from './schemas/$ModelWithCircularReference';
+export { $ModelWithDictionary } from './schemas/$ModelWithDictionary';
+export { $ModelWithDuplicateImports } from './schemas/$ModelWithDuplicateImports';
+export { $ModelWithDuplicateProperties } from './schemas/$ModelWithDuplicateProperties';
+export { $ModelWithEnum } from './schemas/$ModelWithEnum';
+export { $ModelWithEnumFromDescription } from './schemas/$ModelWithEnumFromDescription';
+export { $ModelWithInteger } from './schemas/$ModelWithInteger';
+export { $ModelWithNestedEnums } from './schemas/$ModelWithNestedEnums';
+export { $ModelWithNestedProperties } from './schemas/$ModelWithNestedProperties';
+export { $ModelWithNullableString } from './schemas/$ModelWithNullableString';
+export { $ModelWithOrderedProperties } from './schemas/$ModelWithOrderedProperties';
+export { $ModelWithPattern } from './schemas/$ModelWithPattern';
+export { $ModelWithProperties } from './schemas/$ModelWithProperties';
+export { $ModelWithReference } from './schemas/$ModelWithReference';
+export { $ModelWithString } from './schemas/$ModelWithString';
+export { $Pageable } from './schemas/$Pageable';
+export { $SimpleBoolean } from './schemas/$SimpleBoolean';
+export { $SimpleFile } from './schemas/$SimpleFile';
+export { $SimpleInteger } from './schemas/$SimpleInteger';
+export { $SimpleParameter } from './schemas/$SimpleParameter';
+export { $SimpleReference } from './schemas/$SimpleReference';
+export { $SimpleString } from './schemas/$SimpleString';
+export { $SimpleStringWithPattern } from './schemas/$SimpleStringWithPattern';
+
+export { CollectionFormatService, CollectionFormatOptions } from './services/CollectionFormatService';
+export { ComplexService, ComplexTypesOptions, ComplexParamsOptions } from './services/ComplexService';
+export { DefaultService } from './services/DefaultService';
+export { DefaultsService, CallWithDefaultParametersOptions, CallWithDefaultOptionalParametersOptions, CallToTestOrderOfParamsOptions } from './services/DefaultsService';
+export { DeprecatedService, DeprecatedCallOptions } from './services/DeprecatedService';
+export { DescriptionsService, CallWithDescriptionsOptions } from './services/DescriptionsService';
+export { DuplicateService } from './services/DuplicateService';
+export { ErrorService, TestErrorCodeOptions } from './services/ErrorService';
+export { FormDataService, PostApiFormDataOptions } from './services/FormDataService';
+export { HeaderService } from './services/HeaderService';
+export { MultipartService, MultipartRequestOptions } from './services/MultipartService';
+export { MultipleTags1Service } from './services/MultipleTags1Service';
+export { MultipleTags2Service } from './services/MultipleTags2Service';
+export { MultipleTags3Service } from './services/MultipleTags3Service';
+export { NoContentService } from './services/NoContentService';
+export { ParametersService, CallWithParametersOptions, CallWithWeirdParameterNamesOptions, GetCallWithOptionalParamOptions, PostCallWithOptionalParamOptions } from './services/ParametersService';
+export { RequestBodyService, PostApiRequestBodyOptions } from './services/RequestBodyService';
+export { ResponseService } from './services/ResponseService';
+export { SimpleService } from './services/SimpleService';
+export { TypesService, TypesOptions } from './services/TypesService';
+export { UploadService, UploadFileOptions } from './services/UploadService';
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/_default.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type _default = {
+    name?: string;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ArrayWithArray.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from './ModelWithString';
+/**
+ * This is a simple array containing an array
+ */
+export type ArrayWithArray = Array<Array<ModelWithString>>;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ArrayWithBooleans.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a simple array with booleans
+ */
+export type ArrayWithBooleans = Array<boolean>;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ArrayWithNumbers.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a simple array with numbers
+ */
+export type ArrayWithNumbers = Array<number>;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ArrayWithProperties.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a simple array with properties
+ */
+export type ArrayWithProperties = Array<{
+    foo?: string;
+    bar?: string;
+}>;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ArrayWithReferences.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from './ModelWithString';
+/**
+ * This is a simple array with references
+ */
+export type ArrayWithReferences = Array<ModelWithString>;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ArrayWithStrings.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a simple array with strings
+ */
+export type ArrayWithStrings = Array<string>;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CommentWithBackticks.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Testing backticks in string: \`backticks\` and \`\`\`multiple backticks\`\`\` should work
+ */
+export type CommentWithBackticks = number;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CommentWithBreaks.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Testing multiline comments in string: First line
+ * Second line
+ *
+ * Fourth line
+ */
+export type CommentWithBreaks = number;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CommentWithExpressionPlaceholders.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Testing expression placeholders in string: \${expression} should work
+ */
+export type CommentWithExpressionPlaceholders = number;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CommentWithQuotes.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Testing quotes in string: 'single quote''' and "double quotes""" should work
+ */
+export type CommentWithQuotes = number;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CommentWithReservedCharacters.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Testing reserved characters in string: * inline * and ** inline ** should work
+ */
+export type CommentWithReservedCharacters = number;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CommentWithSlashes.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Testing slashes in string: \\backwards\\\\\\ and /forwards/// should work
+ */
+export type CommentWithSlashes = number;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CompositionBaseModel.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a base model with two simple optional properties
+ */
+export type CompositionBaseModel = {
+    firstName?: string;
+    lastname?: string;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CompositionExtendedModel.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CompositionBaseModel } from './CompositionBaseModel';
+/**
+ * This is a model that extends the base model
+ */
+export type CompositionExtendedModel = (CompositionBaseModel & {
+    firstName: string;
+    lastname: string;
+    age: number;
+});
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CompositionWithAllOfAndNullable.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithArray } from './ModelWithArray';
+import type { ModelWithDictionary } from './ModelWithDictionary';
+import type { ModelWithEnum } from './ModelWithEnum';
+/**
+ * This is a model with one property with a 'all of' relationship
+ */
+export type CompositionWithAllOfAndNullable = {
+    propA?: ({
+        boolean?: boolean;
+    } & ModelWithEnum & ModelWithArray & ModelWithDictionary) | null;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CompositionWithAnyOf.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithArray } from './ModelWithArray';
+import type { ModelWithDictionary } from './ModelWithDictionary';
+import type { ModelWithEnum } from './ModelWithEnum';
+import type { ModelWithString } from './ModelWithString';
+/**
+ * This is a model with one property with a 'any of' relationship
+ */
+export type CompositionWithAnyOf = {
+    propA?: (ModelWithString | ModelWithEnum | ModelWithArray | ModelWithDictionary);
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CompositionWithAnyOfAndNullable.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithArray } from './ModelWithArray';
+import type { ModelWithDictionary } from './ModelWithDictionary';
+import type { ModelWithEnum } from './ModelWithEnum';
+/**
+ * This is a model with one property with a 'any of' relationship
+ */
+export type CompositionWithAnyOfAndNullable = {
+    propA?: ({
+        boolean?: boolean;
+    } | ModelWithEnum | ModelWithArray | ModelWithDictionary) | null;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CompositionWithAnyOfAnonymous.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model with one property with a 'any of' relationship where the options are not $ref
+ */
+export type CompositionWithAnyOfAnonymous = {
+    propA?: ({
+        propA?: string;
+    } | string | number);
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CompositionWithOneOf.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithArray } from './ModelWithArray';
+import type { ModelWithDictionary } from './ModelWithDictionary';
+import type { ModelWithEnum } from './ModelWithEnum';
+import type { ModelWithString } from './ModelWithString';
+/**
+ * This is a model with one property with a 'one of' relationship
+ */
+export type CompositionWithOneOf = {
+    propA?: (ModelWithString | ModelWithEnum | ModelWithArray | ModelWithDictionary);
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CompositionWithOneOfAndComplexArrayDictionary.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model that contains a dictionary of complex arrays (composited) within composition
+ */
+export type CompositionWithOneOfAndComplexArrayDictionary = {
+    propA?: (boolean | Record<string, Array<(number | string)>>);
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CompositionWithOneOfAndNullable.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithArray } from './ModelWithArray';
+import type { ModelWithDictionary } from './ModelWithDictionary';
+import type { ModelWithEnum } from './ModelWithEnum';
+/**
+ * This is a model with one property with a 'one of' relationship
+ */
+export type CompositionWithOneOfAndNullable = {
+    propA?: ({
+        boolean?: boolean;
+    } | ModelWithEnum | ModelWithArray | ModelWithDictionary) | null;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CompositionWithOneOfAndSimpleArrayDictionary.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model that contains a dictionary of simple arrays within composition
+ */
+export type CompositionWithOneOfAndSimpleArrayDictionary = {
+    propA?: (boolean | Record<string, Array<boolean>>);
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CompositionWithOneOfAndSimpleDictionary.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model that contains a simple dictionary within composition
+ */
+export type CompositionWithOneOfAndSimpleDictionary = {
+    propA?: (boolean | Record<string, number>);
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CompositionWithOneOfAnonymous.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model with one property with a 'one of' relationship where the options are not $ref
+ */
+export type CompositionWithOneOfAnonymous = {
+    propA?: ({
+        propA?: string;
+    } | string | number);
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/CompositionWithOneOfDiscriminator.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelCircle } from './ModelCircle';
+import type { ModelSquare } from './ModelSquare';
+/**
+ * This is a model with one property with a 'one of' relationship where the options are not $ref
+ */
+export type CompositionWithOneOfDiscriminator = (ModelCircle | ModelSquare);
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/DeprecatedModel.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a deprecated model with a deprecated property
+ * @deprecated
+ */
+export type DeprecatedModel = {
+    /**
+     * This is a deprecated property
+     * @deprecated
+     */
+    prop?: string;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/DictionaryWithArray.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from './ModelWithString';
+/**
+ * This is a complex dictionary
+ */
+export type DictionaryWithArray = Record<string, Array<ModelWithString>>;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/DictionaryWithDictionary.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a string dictionary
+ */
+export type DictionaryWithDictionary = Record<string, Record<string, string>>;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/DictionaryWithProperties.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a complex dictionary
+ */
+export type DictionaryWithProperties = Record<string, {
+    foo?: string;
+    bar?: string;
+}>;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/DictionaryWithReference.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from './ModelWithString';
+/**
+ * This is a string reference
+ */
+export type DictionaryWithReference = Record<string, ModelWithString>;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/DictionaryWithString.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a string dictionary
+ */
+export type DictionaryWithString = Record<string, string>;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/EnumFromDescription.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Success=1,Warning=2,Error=3
+ */
+export type EnumFromDescription = number;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/EnumWithExtensions.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a simple enum with numbers
+ */
+export enum EnumWithExtensions {
+    /**
+     * Used when the status of something is successful
+     */
+    CUSTOM_SUCCESS = 200,
+    /**
+     * Used when the status of something has a warning
+     */
+    CUSTOM_WARNING = 400,
+    /**
+     * Used when the status of something has an error
+     */
+    CUSTOM_ERROR = 500,
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/EnumWithNumbers.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a simple enum with numbers
+ */
+export enum EnumWithNumbers {
+    '_1' = 1,
+    '_2' = 2,
+    '_3' = 3,
+    '_1.1' = 1.1,
+    '_1.2' = 1.2,
+    '_1.3' = 1.3,
+    '_100' = 100,
+    '_200' = 200,
+    '_300' = 300,
+    '_-100' = -100,
+    '_-200' = -200,
+    '_-300' = -300,
+    '_-1.1' = -1.1,
+    '_-1.2' = -1.2,
+    '_-1.3' = -1.3,
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/EnumWithStrings.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a simple enum with strings
+ */
+export enum EnumWithStrings {
+    SUCCESS = 'Success',
+    WARNING = 'Warning',
+    ERROR = 'Error',
+    _SINGLE_QUOTE_ = '\\'Single Quote\\'',
+    _DOUBLE_QUOTES_ = '"Double Quotes"',
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/File.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type File = {
+    readonly id?: string;
+    readonly updated_at?: string;
+    readonly created_at?: string;
+    mime: string;
+    readonly file?: string;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/FreeFormObjectWithAdditionalPropertiesEqEmptyObject.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a free-form object with additionalProperties: {}.
+ */
+export type FreeFormObjectWithAdditionalPropertiesEqEmptyObject = Record<string, any>;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/FreeFormObjectWithAdditionalPropertiesEqTrue.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a free-form object with additionalProperties: true.
+ */
+export type FreeFormObjectWithAdditionalPropertiesEqTrue = Record<string, any>;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/FreeFormObjectWithoutAdditionalProperties.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a free-form object without additionalProperties.
+ */
+export type FreeFormObjectWithoutAdditionalProperties = Record<string, any>;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelCircle.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Circle
+ */
+export type ModelCircle = {
+    kind: 'circle';
+    radius?: number;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelSquare.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Square
+ */
+export type ModelSquare = {
+    kind: 'square';
+    sideLength?: number;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelThatExtends.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from './ModelWithString';
+/**
+ * This is a model that extends another model
+ */
+export type ModelThatExtends = (ModelWithString & {
+    propExtendsA?: string;
+    propExtendsB?: ModelWithString;
+});
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelThatExtendsExtends.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelThatExtends } from './ModelThatExtends';
+import type { ModelWithString } from './ModelWithString';
+/**
+ * This is a model that extends another model
+ */
+export type ModelThatExtendsExtends = (ModelWithString & ModelThatExtends & {
+    propExtendsC?: string;
+    propExtendsD?: ModelWithString;
+});
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithArray.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from './ModelWithString';
+/**
+ * This is a model with one property containing an array
+ */
+export type ModelWithArray = {
+    prop?: Array<ModelWithString>;
+    propWithFile?: Array<Blob>;
+    propWithNumber?: Array<number>;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithBoolean.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model with one boolean property
+ */
+export type ModelWithBoolean = {
+    /**
+     * This is a simple boolean property
+     */
+    prop?: boolean;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithCircularReference.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model with one property containing a circular reference
+ */
+export type ModelWithCircularReference = {
+    prop?: ModelWithCircularReference;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithDictionary.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model with one property containing a dictionary
+ */
+export type ModelWithDictionary = {
+    prop?: Record<string, string>;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithDuplicateImports.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from './ModelWithString';
+/**
+ * This is a model with duplicated imports
+ */
+export type ModelWithDuplicateImports = {
+    propA?: ModelWithString;
+    propB?: ModelWithString;
+    propC?: ModelWithString;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithDuplicateProperties.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from './ModelWithString';
+/**
+ * This is a model with duplicated properties
+ */
+export type ModelWithDuplicateProperties = {
+    prop?: ModelWithString;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithEnum.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model with one enum
+ */
+export type ModelWithEnum = {
+    /**
+     * This is a simple enum with strings
+     */
+    test?: ModelWithEnum.test;
+    /**
+     * These are the HTTP error code enums
+     */
+    statusCode?: ModelWithEnum.statusCode;
+    /**
+     * Simple boolean enum
+     */
+    bool?: boolean;
+};
+export namespace ModelWithEnum {
+    /**
+     * This is a simple enum with strings
+     */
+    export enum test {
+        SUCCESS = 'Success',
+        WARNING = 'Warning',
+        ERROR = 'Error',
+    }
+    /**
+     * These are the HTTP error code enums
+     */
+    export enum statusCode {
+        _100 = '100',
+        _200_FOO = '200 FOO',
+        _300_FOO_BAR = '300 FOO_BAR',
+        _400_FOO_BAR = '400 foo-bar',
+        _500_FOO_BAR = '500 foo.bar',
+        _600_FOO_BAR = '600 foo&bar',
+    }
+}
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithEnumFromDescription.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model with one enum
+ */
+export type ModelWithEnumFromDescription = {
+    /**
+     * Success=1,Warning=2,Error=3
+     */
+    test?: number;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithInteger.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model with one number property
+ */
+export type ModelWithInteger = {
+    /**
+     * This is a simple number property
+     */
+    prop?: number;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithNestedEnums.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model with nested enums
+ */
+export type ModelWithNestedEnums = {
+    dictionaryWithEnum?: Record<string, 'Success' | 'Warning' | 'Error'>;
+    dictionaryWithEnumFromDescription?: Record<string, number>;
+    arrayWithEnum?: Array<'Success' | 'Warning' | 'Error'>;
+    arrayWithDescription?: Array<number>;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithNestedProperties.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model with one nested property
+ */
+export type ModelWithNestedProperties = {
+    readonly first: {
+        readonly second: {
+            readonly third: string | null;
+        } | null;
+    } | null;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithNullableString.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model with one string property
+ */
+export type ModelWithNullableString = {
+    /**
+     * This is a simple string property
+     */
+    nullableProp1?: string | null;
+    /**
+     * This is a simple string property
+     */
+    nullableRequiredProp1: string | null;
+    /**
+     * This is a simple string property
+     */
+    nullableProp2?: string | null;
+    /**
+     * This is a simple string property
+     */
+    nullableRequiredProp2: string | null;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithOrderedProperties.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model with ordered properties
+ */
+export type ModelWithOrderedProperties = {
+    zebra?: string;
+    apple?: string;
+    hawaii?: string;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithPattern.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model that contains a some patterns
+ */
+export type ModelWithPattern = {
+    key: string;
+    name: string;
+    readonly enabled?: boolean;
+    readonly modified?: string;
+    id?: string;
+    text?: string;
+    patternWithSingleQuotes?: string;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithProperties.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from './ModelWithString';
+/**
+ * This is a model with one nested property
+ */
+export type ModelWithProperties = {
+    required: string;
+    readonly requiredAndReadOnly: string;
+    requiredAndNullable: string | null;
+    string?: string;
+    number?: number;
+    boolean?: boolean;
+    reference?: ModelWithString;
+    'property with space'?: string;
+    default?: string;
+    try?: string;
+    readonly '@namespace.string'?: string;
+    readonly '@namespace.integer'?: number;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithReference.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithProperties } from './ModelWithProperties';
+/**
+ * This is a model with one property containing a reference
+ */
+export type ModelWithReference = {
+    prop?: ModelWithProperties;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/ModelWithString.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a model with one string property
+ */
+export type ModelWithString = {
+    /**
+     * This is a simple string property
+     */
+    prop?: string;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/Pageable.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Pageable = {
+    page?: number;
+    size?: number;
+    sort?: Array<string>;
+};
+
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/SimpleBoolean.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a simple boolean
+ */
+export type SimpleBoolean = boolean;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/SimpleFile.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a simple file
+ */
+export type SimpleFile = Blob;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/SimpleInteger.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a simple number
+ */
+export type SimpleInteger = number;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/SimpleParameter.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a reusable parameter
+ */
+export type SimpleParameter = string;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/SimpleReference.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from './ModelWithString';
+/**
+ * This is a simple reference
+ */
+export type SimpleReference = ModelWithString;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/SimpleString.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a simple string
+ */
+export type SimpleString = string;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/models/SimpleStringWithPattern.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * This is a simple string
+ */
+export type SimpleStringWithPattern = string | null;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$_default.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $_default = {
+    properties: {
+        name: {
+            type: 'string',
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ArrayWithArray.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ArrayWithArray = {
+    type: 'array',
+    contains: {
+        type: 'array',
+        contains: {
+            type: 'ModelWithString',
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ArrayWithBooleans.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ArrayWithBooleans = {
+    type: 'array',
+    contains: {
+        type: 'boolean',
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ArrayWithNumbers.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ArrayWithNumbers = {
+    type: 'array',
+    contains: {
+        type: 'number',
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ArrayWithProperties.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ArrayWithProperties = {
+    type: 'array',
+    contains: {
+        properties: {
+            foo: {
+                type: 'string',
+            },
+            bar: {
+                type: 'string',
+            },
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ArrayWithReferences.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ArrayWithReferences = {
+    type: 'array',
+    contains: {
+        type: 'ModelWithString',
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ArrayWithStrings.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ArrayWithStrings = {
+    type: 'array',
+    contains: {
+        type: 'string',
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CommentWithBackticks.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CommentWithBackticks = {
+    type: 'number',
+    description: \`Testing backticks in string: \\\`backticks\\\` and \\\`\\\`\\\`multiple backticks\\\`\\\`\\\` should work\`,
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CommentWithBreaks.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CommentWithBreaks = {
+    type: 'number',
+    description: \`Testing multiline comments in string: First line
+    Second line
+    Fourth line\`,
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CommentWithExpressionPlaceholders.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CommentWithExpressionPlaceholders = {
+    type: 'number',
+    description: \`Testing expression placeholders in string: \\\${expression} should work\`,
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CommentWithQuotes.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CommentWithQuotes = {
+    type: 'number',
+    description: \`Testing quotes in string: 'single quote''' and "double quotes""" should work\`,
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CommentWithReservedCharacters.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CommentWithReservedCharacters = {
+    type: 'number',
+    description: \`Testing reserved characters in string: /* inline */ and /** inline **/ should work\`,
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CommentWithSlashes.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CommentWithSlashes = {
+    type: 'number',
+    description: \`Testing slashes in string: \\\\backwards\\\\\\\\\\\\ and /forwards/// should work\`,
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CompositionBaseModel.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionBaseModel = {
+    description: \`This is a base model with two simple optional properties\`,
+    properties: {
+        firstName: {
+            type: 'string',
+        },
+        lastname: {
+            type: 'string',
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CompositionExtendedModel.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionExtendedModel = {
+    type: 'all-of',
+    description: \`This is a model that extends the base model\`,
+    contains: [{
+        type: 'CompositionBaseModel',
+    }, {
+        properties: {
+            firstName: {
+                type: 'string',
+                isRequired: true,
+            },
+            lastname: {
+                type: 'string',
+                isRequired: true,
+            },
+            age: {
+                type: 'number',
+                isRequired: true,
+            },
+        },
+    }],
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CompositionWithAllOfAndNullable.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithAllOfAndNullable = {
+    description: \`This is a model with one property with a 'all of' relationship\`,
+    properties: {
+        propA: {
+            type: 'all-of',
+            contains: [{
+                properties: {
+                    boolean: {
+                        type: 'boolean',
+                    },
+                },
+            }, {
+                type: 'ModelWithEnum',
+            }, {
+                type: 'ModelWithArray',
+            }, {
+                type: 'ModelWithDictionary',
+            }],
+            isNullable: true,
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CompositionWithAnyOf.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithAnyOf = {
+    description: \`This is a model with one property with a 'any of' relationship\`,
+    properties: {
+        propA: {
+            type: 'any-of',
+            contains: [{
+                type: 'ModelWithString',
+            }, {
+                type: 'ModelWithEnum',
+            }, {
+                type: 'ModelWithArray',
+            }, {
+                type: 'ModelWithDictionary',
+            }],
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CompositionWithAnyOfAndNullable.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithAnyOfAndNullable = {
+    description: \`This is a model with one property with a 'any of' relationship\`,
+    properties: {
+        propA: {
+            type: 'any-of',
+            contains: [{
+                properties: {
+                    boolean: {
+                        type: 'boolean',
+                    },
+                },
+            }, {
+                type: 'ModelWithEnum',
+            }, {
+                type: 'ModelWithArray',
+            }, {
+                type: 'ModelWithDictionary',
+            }],
+            isNullable: true,
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CompositionWithAnyOfAnonymous.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithAnyOfAnonymous = {
+    description: \`This is a model with one property with a 'any of' relationship where the options are not $ref\`,
+    properties: {
+        propA: {
+            type: 'any-of',
+            contains: [{
+                description: \`Anonymous object type\`,
+                properties: {
+                    propA: {
+                        type: 'string',
+                    },
+                },
+            }, {
+                type: 'string',
+                description: \`Anonymous string type\`,
+            }, {
+                type: 'number',
+                description: \`Anonymous integer type\`,
+            }],
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CompositionWithOneOf.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithOneOf = {
+    description: \`This is a model with one property with a 'one of' relationship\`,
+    properties: {
+        propA: {
+            type: 'one-of',
+            contains: [{
+                type: 'ModelWithString',
+            }, {
+                type: 'ModelWithEnum',
+            }, {
+                type: 'ModelWithArray',
+            }, {
+                type: 'ModelWithDictionary',
+            }],
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CompositionWithOneOfAndComplexArrayDictionary.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithOneOfAndComplexArrayDictionary = {
+    description: \`This is a model that contains a dictionary of complex arrays (composited) within composition\`,
+    properties: {
+        propA: {
+            type: 'one-of',
+            contains: [{
+                type: 'boolean',
+            }, {
+                type: 'dictionary',
+                contains: {
+                    type: 'array',
+                    contains: {
+                        type: 'one-of',
+                        contains: [{
+                            type: 'number',
+                        }, {
+                            type: 'string',
+                        }],
+                    },
+                },
+            }],
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CompositionWithOneOfAndNullable.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithOneOfAndNullable = {
+    description: \`This is a model with one property with a 'one of' relationship\`,
+    properties: {
+        propA: {
+            type: 'one-of',
+            contains: [{
+                properties: {
+                    boolean: {
+                        type: 'boolean',
+                    },
+                },
+            }, {
+                type: 'ModelWithEnum',
+            }, {
+                type: 'ModelWithArray',
+            }, {
+                type: 'ModelWithDictionary',
+            }],
+            isNullable: true,
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CompositionWithOneOfAndSimpleArrayDictionary.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithOneOfAndSimpleArrayDictionary = {
+    description: \`This is a model that contains a dictionary of simple arrays within composition\`,
+    properties: {
+        propA: {
+            type: 'one-of',
+            contains: [{
+                type: 'boolean',
+            }, {
+                type: 'dictionary',
+                contains: {
+                    type: 'array',
+                    contains: {
+                        type: 'boolean',
+                    },
+                },
+            }],
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CompositionWithOneOfAndSimpleDictionary.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithOneOfAndSimpleDictionary = {
+    description: \`This is a model that contains a simple dictionary within composition\`,
+    properties: {
+        propA: {
+            type: 'one-of',
+            contains: [{
+                type: 'boolean',
+            }, {
+                type: 'dictionary',
+                contains: {
+                    type: 'number',
+                },
+            }],
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CompositionWithOneOfAnonymous.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithOneOfAnonymous = {
+    description: \`This is a model with one property with a 'one of' relationship where the options are not $ref\`,
+    properties: {
+        propA: {
+            type: 'one-of',
+            contains: [{
+                description: \`Anonymous object type\`,
+                properties: {
+                    propA: {
+                        type: 'string',
+                    },
+                },
+            }, {
+                type: 'string',
+                description: \`Anonymous string type\`,
+            }, {
+                type: 'number',
+                description: \`Anonymous integer type\`,
+            }],
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$CompositionWithOneOfDiscriminator.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $CompositionWithOneOfDiscriminator = {
+    type: 'one-of',
+    description: \`This is a model with one property with a 'one of' relationship where the options are not $ref\`,
+    contains: [{
+        type: 'ModelCircle',
+    }, {
+        type: 'ModelSquare',
+    }],
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$DeprecatedModel.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $DeprecatedModel = {
+    description: \`This is a deprecated model with a deprecated property\`,
+    properties: {
+        prop: {
+            type: 'string',
+            description: \`This is a deprecated property\`,
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$DictionaryWithArray.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $DictionaryWithArray = {
+    type: 'dictionary',
+    contains: {
+        type: 'array',
+        contains: {
+            type: 'ModelWithString',
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$DictionaryWithDictionary.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $DictionaryWithDictionary = {
+    type: 'dictionary',
+    contains: {
+        type: 'dictionary',
+        contains: {
+            type: 'string',
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$DictionaryWithProperties.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $DictionaryWithProperties = {
+    type: 'dictionary',
+    contains: {
+        properties: {
+            foo: {
+                type: 'string',
+            },
+            bar: {
+                type: 'string',
+            },
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$DictionaryWithReference.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $DictionaryWithReference = {
+    type: 'dictionary',
+    contains: {
+        type: 'ModelWithString',
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$DictionaryWithString.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $DictionaryWithString = {
+    type: 'dictionary',
+    contains: {
+        type: 'string',
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$EnumFromDescription.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $EnumFromDescription = {
+    type: 'number',
+    description: \`Success=1,Warning=2,Error=3\`,
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$EnumWithExtensions.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $EnumWithExtensions = {
+    type: 'Enum',
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$EnumWithNumbers.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $EnumWithNumbers = {
+    type: 'Enum',
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$EnumWithStrings.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $EnumWithStrings = {
+    type: 'Enum',
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$File.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $File = {
+    properties: {
+        id: {
+            type: 'string',
+            isReadOnly: true,
+            minLength: 1,
+        },
+        updated_at: {
+            type: 'string',
+            isReadOnly: true,
+            format: 'date-time',
+        },
+        created_at: {
+            type: 'string',
+            isReadOnly: true,
+            format: 'date-time',
+        },
+        mime: {
+            type: 'string',
+            isRequired: true,
+            maxLength: 24,
+            minLength: 1,
+        },
+        file: {
+            type: 'string',
+            isReadOnly: true,
+            format: 'uri',
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$FreeFormObjectWithAdditionalPropertiesEqEmptyObject.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $FreeFormObjectWithAdditionalPropertiesEqEmptyObject = {
+    type: 'dictionary',
+    contains: {
+        properties: {
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$FreeFormObjectWithAdditionalPropertiesEqTrue.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $FreeFormObjectWithAdditionalPropertiesEqTrue = {
+    type: 'dictionary',
+    contains: {
+        properties: {
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$FreeFormObjectWithoutAdditionalProperties.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $FreeFormObjectWithoutAdditionalProperties = {
+    type: 'dictionary',
+    contains: {
+        properties: {
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelCircle.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelCircle = {
+    description: \`Circle\`,
+    properties: {
+        kind: {
+            type: 'string',
+            isRequired: true,
+        },
+        radius: {
+            type: 'number',
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelSquare.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelSquare = {
+    description: \`Square\`,
+    properties: {
+        kind: {
+            type: 'string',
+            isRequired: true,
+        },
+        sideLength: {
+            type: 'number',
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelThatExtends.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelThatExtends = {
+    type: 'all-of',
+    description: \`This is a model that extends another model\`,
+    contains: [{
+        type: 'ModelWithString',
+    }, {
+        properties: {
+            propExtendsA: {
+                type: 'string',
+            },
+            propExtendsB: {
+                type: 'ModelWithString',
+            },
+        },
+    }],
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelThatExtendsExtends.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelThatExtendsExtends = {
+    type: 'all-of',
+    description: \`This is a model that extends another model\`,
+    contains: [{
+        type: 'ModelWithString',
+    }, {
+        type: 'ModelThatExtends',
+    }, {
+        properties: {
+            propExtendsC: {
+                type: 'string',
+            },
+            propExtendsD: {
+                type: 'ModelWithString',
+            },
+        },
+    }],
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithArray.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithArray = {
+    description: \`This is a model with one property containing an array\`,
+    properties: {
+        prop: {
+            type: 'array',
+            contains: {
+                type: 'ModelWithString',
+            },
+        },
+        propWithFile: {
+            type: 'array',
+            contains: {
+                type: 'binary',
+            },
+        },
+        propWithNumber: {
+            type: 'array',
+            contains: {
+                type: 'number',
+            },
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithBoolean.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithBoolean = {
+    description: \`This is a model with one boolean property\`,
+    properties: {
+        prop: {
+            type: 'boolean',
+            description: \`This is a simple boolean property\`,
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithCircularReference.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithCircularReference = {
+    description: \`This is a model with one property containing a circular reference\`,
+    properties: {
+        prop: {
+            type: 'ModelWithCircularReference',
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithDictionary.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithDictionary = {
+    description: \`This is a model with one property containing a dictionary\`,
+    properties: {
+        prop: {
+            type: 'dictionary',
+            contains: {
+                type: 'string',
+            },
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithDuplicateImports.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithDuplicateImports = {
+    description: \`This is a model with duplicated imports\`,
+    properties: {
+        propA: {
+            type: 'ModelWithString',
+        },
+        propB: {
+            type: 'ModelWithString',
+        },
+        propC: {
+            type: 'ModelWithString',
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithDuplicateProperties.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithDuplicateProperties = {
+    description: \`This is a model with duplicated properties\`,
+    properties: {
+        prop: {
+            type: 'ModelWithString',
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithEnum.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithEnum = {
+    description: \`This is a model with one enum\`,
+    properties: {
+        test: {
+            type: 'Enum',
+        },
+        statusCode: {
+            type: 'Enum',
+        },
+        bool: {
+            type: 'boolean',
+            description: \`Simple boolean enum\`,
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithEnumFromDescription.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithEnumFromDescription = {
+    description: \`This is a model with one enum\`,
+    properties: {
+        test: {
+            type: 'number',
+            description: \`Success=1,Warning=2,Error=3\`,
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithInteger.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithInteger = {
+    description: \`This is a model with one number property\`,
+    properties: {
+        prop: {
+            type: 'number',
+            description: \`This is a simple number property\`,
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithNestedEnums.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithNestedEnums = {
+    description: \`This is a model with nested enums\`,
+    properties: {
+        dictionaryWithEnum: {
+            type: 'dictionary',
+            contains: {
+                type: 'Enum',
+            },
+        },
+        dictionaryWithEnumFromDescription: {
+            type: 'dictionary',
+            contains: {
+                type: 'number',
+                description: \`Success=1,Warning=2,Error=3\`,
+            },
+        },
+        arrayWithEnum: {
+            type: 'array',
+            contains: {
+                type: 'Enum',
+            },
+        },
+        arrayWithDescription: {
+            type: 'array',
+            contains: {
+                type: 'number',
+                description: \`Success=1,Warning=2,Error=3\`,
+            },
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithNestedProperties.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithNestedProperties = {
+    description: \`This is a model with one nested property\`,
+    properties: {
+        first: {
+            properties: {
+                second: {
+                    properties: {
+                        third: {
+                            type: 'string',
+                            isReadOnly: true,
+                            isRequired: true,
+                            isNullable: true,
+                        },
+                    },
+                    isReadOnly: true,
+                    isRequired: true,
+                    isNullable: true,
+                },
+            },
+            isReadOnly: true,
+            isRequired: true,
+            isNullable: true,
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithNullableString.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithNullableString = {
+    description: \`This is a model with one string property\`,
+    properties: {
+        nullableProp1: {
+            type: 'string',
+            description: \`This is a simple string property\`,
+            isNullable: true,
+        },
+        nullableRequiredProp1: {
+            type: 'string',
+            description: \`This is a simple string property\`,
+            isRequired: true,
+            isNullable: true,
+        },
+        nullableProp2: {
+            type: 'string',
+            description: \`This is a simple string property\`,
+            isNullable: true,
+        },
+        nullableRequiredProp2: {
+            type: 'string',
+            description: \`This is a simple string property\`,
+            isRequired: true,
+            isNullable: true,
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithOrderedProperties.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithOrderedProperties = {
+    description: \`This is a model with ordered properties\`,
+    properties: {
+        zebra: {
+            type: 'string',
+        },
+        apple: {
+            type: 'string',
+        },
+        hawaii: {
+            type: 'string',
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithPattern.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithPattern = {
+    description: \`This is a model that contains a some patterns\`,
+    properties: {
+        key: {
+            type: 'string',
+            isRequired: true,
+            maxLength: 64,
+            pattern: '^[a-zA-Z0-9_]*$',
+        },
+        name: {
+            type: 'string',
+            isRequired: true,
+            maxLength: 255,
+        },
+        enabled: {
+            type: 'boolean',
+            isReadOnly: true,
+        },
+        modified: {
+            type: 'string',
+            isReadOnly: true,
+            format: 'date-time',
+        },
+        id: {
+            type: 'string',
+            pattern: '^\\\\d{2}-\\\\d{3}-\\\\d{4}$',
+        },
+        text: {
+            type: 'string',
+            pattern: '^\\\\w+$',
+        },
+        patternWithSingleQuotes: {
+            type: 'string',
+            pattern: '^[a-zA-Z0-9\\']*$',
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithProperties.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithProperties = {
+    description: \`This is a model with one nested property\`,
+    properties: {
+        required: {
+            type: 'string',
+            isRequired: true,
+        },
+        requiredAndReadOnly: {
+            type: 'string',
+            isReadOnly: true,
+            isRequired: true,
+        },
+        requiredAndNullable: {
+            type: 'string',
+            isRequired: true,
+            isNullable: true,
+        },
+        string: {
+            type: 'string',
+        },
+        number: {
+            type: 'number',
+        },
+        boolean: {
+            type: 'boolean',
+        },
+        reference: {
+            type: 'ModelWithString',
+        },
+        'property with space': {
+            type: 'string',
+        },
+        default: {
+            type: 'string',
+        },
+        try: {
+            type: 'string',
+        },
+        '@namespace.string': {
+            type: 'string',
+            isReadOnly: true,
+        },
+        '@namespace.integer': {
+            type: 'number',
+            isReadOnly: true,
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithReference.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithReference = {
+    description: \`This is a model with one property containing a reference\`,
+    properties: {
+        prop: {
+            type: 'ModelWithProperties',
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$ModelWithString.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithString = {
+    description: \`This is a model with one string property\`,
+    properties: {
+        prop: {
+            type: 'string',
+            description: \`This is a simple string property\`,
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$Pageable.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $Pageable = {
+    properties: {
+        page: {
+            type: 'number',
+            format: 'int32',
+        },
+        size: {
+            type: 'number',
+            format: 'int32',
+            minimum: 1,
+        },
+        sort: {
+            type: 'array',
+            contains: {
+                type: 'string',
+            },
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$SimpleBoolean.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $SimpleBoolean = {
+    type: 'boolean',
+    description: \`This is a simple boolean\`,
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$SimpleFile.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $SimpleFile = {
+    type: 'binary',
+    description: \`This is a simple file\`,
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$SimpleInteger.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $SimpleInteger = {
+    type: 'number',
+    description: \`This is a simple number\`,
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$SimpleParameter.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $SimpleParameter = {
+    type: 'string',
+    description: \`This is a reusable parameter\`,
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$SimpleReference.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $SimpleReference = {
+    type: 'ModelWithString',
+    description: \`This is a simple reference\`,
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$SimpleString.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $SimpleString = {
+    type: 'string',
+    description: \`This is a simple string\`,
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/schemas/$SimpleStringWithPattern.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $SimpleStringWithPattern = {
+    type: 'string',
+    description: \`This is a simple string\`,
+    isNullable: true,
+    maxLength: 64,
+    pattern: '^[a-zA-Z0-9_]*$',
+} as const;
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/CollectionFormatService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export type CollectionFormatOptions = {
+    /**
+     * This is an array parameter that is sent as csv format (comma-separated values)
+     */
+    parameterArrayCsv: Array<string> | null,
+    /**
+     * This is an array parameter that is sent as ssv format (space-separated values)
+     */
+    parameterArraySsv: Array<string> | null,
+    /**
+     * This is an array parameter that is sent as tsv format (tab-separated values)
+     */
+    parameterArrayTsv: Array<string> | null,
+    /**
+     * This is an array parameter that is sent as pipes format (pipe-separated values)
+     */
+    parameterArrayPipes: Array<string> | null,
+    /**
+     * This is an array parameter that is sent as multi format (multiple parameter instances)
+     */
+    parameterArrayMulti: Array<string> | null,
+};
+export class CollectionFormatService {
+    /**
+     * @throws ApiError
+     */
+    public static collectionFormat({
+        parameterArrayCsv,
+        parameterArraySsv,
+        parameterArrayTsv,
+        parameterArrayPipes,
+        parameterArrayMulti,
+    }: CollectionFormatOptions): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/collectionFormat',
+            query: {
+                'parameterArrayCSV': parameterArrayCsv,
+                'parameterArraySSV': parameterArraySsv,
+                'parameterArrayTSV': parameterArrayTsv,
+                'parameterArrayPipes': parameterArrayPipes,
+                'parameterArrayMulti': parameterArrayMulti,
+            },
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/ComplexService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithArray } from '../models/ModelWithArray';
+import type { ModelWithDictionary } from '../models/ModelWithDictionary';
+import type { ModelWithEnum } from '../models/ModelWithEnum';
+import type { ModelWithString } from '../models/ModelWithString';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export type ComplexTypesOptions = {
+    /**
+     * Parameter containing object
+     */
+    parameterObject: {
+        first?: {
+            second?: {
+                third?: string;
+            };
+        };
+    },
+    /**
+     * Parameter containing reference
+     */
+    parameterReference: ModelWithString,
+};
+export type ComplexParamsOptions = {
+    id: number,
+    requestBody?: {
+        readonly key: string | null;
+        name: string | null;
+        enabled?: boolean;
+        readonly type: 'Monkey' | 'Horse' | 'Bird';
+        listOfModels?: Array<ModelWithString> | null;
+        listOfStrings?: Array<string> | null;
+        parameters: (ModelWithString | ModelWithEnum | ModelWithArray | ModelWithDictionary);
+        readonly user?: {
+            readonly id?: number;
+            readonly name?: string | null;
+        };
+    },
+};
+export class ComplexService {
+    /**
+     * @returns ModelWithString Successful response
+     * @throws ApiError
+     */
+    public static complexTypes({
+        parameterObject,
+        parameterReference,
+    }: ComplexTypesOptions): CancelablePromise<Array<ModelWithString>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/complex',
+            query: {
+                'parameterObject': parameterObject,
+                'parameterReference': parameterReference,
+            },
+            errors: {
+                400: \`400 server error\`,
+                500: \`500 server error\`,
+            },
+        });
+    }
+    /**
+     * @returns ModelWithString Success
+     * @throws ApiError
+     */
+    public static complexParams({
+        id,
+        requestBody,
+    }: ComplexParamsOptions): CancelablePromise<ModelWithString> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/api/v{api-version}/complex/{id}',
+            path: {
+                'id': id,
+            },
+            body: requestBody,
+            mediaType: 'application/json-patch+json',
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/DefaultService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class DefaultService {
+    /**
+     * @throws ApiError
+     */
+    public static serviceWithEmptyTag(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/no-tag',
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/DefaultsService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from '../models/ModelWithString';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export type CallWithDefaultParametersOptions = {
+    /**
+     * This is a simple string with default value
+     */
+    parameterString?: string | null,
+    /**
+     * This is a simple number with default value
+     */
+    parameterNumber?: number | null,
+    /**
+     * This is a simple boolean with default value
+     */
+    parameterBoolean?: boolean | null,
+    /**
+     * This is a simple enum with default value
+     */
+    parameterEnum?: 'Success' | 'Warning' | 'Error',
+    /**
+     * This is a simple model with default value
+     */
+    parameterModel?: ModelWithString | null,
+};
+export type CallWithDefaultOptionalParametersOptions = {
+    /**
+     * This is a simple string that is optional with default value
+     */
+    parameterString?: string,
+    /**
+     * This is a simple number that is optional with default value
+     */
+    parameterNumber?: number,
+    /**
+     * This is a simple boolean that is optional with default value
+     */
+    parameterBoolean?: boolean,
+    /**
+     * This is a simple enum that is optional with default value
+     */
+    parameterEnum?: 'Success' | 'Warning' | 'Error',
+    /**
+     * This is a simple model that is optional with default value
+     */
+    parameterModel?: ModelWithString,
+};
+export type CallToTestOrderOfParamsOptions = {
+    /**
+     * This is a string with no default
+     */
+    parameterStringWithNoDefault: string,
+    /**
+     * This is a optional string with default
+     */
+    parameterOptionalStringWithDefault?: string,
+    /**
+     * This is a optional string with empty default
+     */
+    parameterOptionalStringWithEmptyDefault?: string,
+    /**
+     * This is a optional string with no default
+     */
+    parameterOptionalStringWithNoDefault?: string,
+    /**
+     * This is a string with default
+     */
+    parameterStringWithDefault?: string,
+    /**
+     * This is a string with empty default
+     */
+    parameterStringWithEmptyDefault?: string,
+    /**
+     * This is a string that can be null with no default
+     */
+    parameterStringNullableWithNoDefault?: string | null,
+    /**
+     * This is a string that can be null with default
+     */
+    parameterStringNullableWithDefault?: string | null,
+};
+export class DefaultsService {
+    /**
+     * @throws ApiError
+     */
+    public static callWithDefaultParameters({
+        parameterString = 'Hello World!',
+        parameterNumber = 123,
+        parameterBoolean = true,
+        parameterEnum = 'Success',
+        parameterModel = {
+            "prop": "Hello World!"
+        },
+    }: CallWithDefaultParametersOptions): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/defaults',
+            query: {
+                'parameterString': parameterString,
+                'parameterNumber': parameterNumber,
+                'parameterBoolean': parameterBoolean,
+                'parameterEnum': parameterEnum,
+                'parameterModel': parameterModel,
+            },
+        });
+    }
+    /**
+     * @throws ApiError
+     */
+    public static callWithDefaultOptionalParameters({
+        parameterString = 'Hello World!',
+        parameterNumber = 123,
+        parameterBoolean = true,
+        parameterEnum = 'Success',
+        parameterModel = {
+            "prop": "Hello World!"
+        },
+    }: CallWithDefaultOptionalParametersOptions): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/defaults',
+            query: {
+                'parameterString': parameterString,
+                'parameterNumber': parameterNumber,
+                'parameterBoolean': parameterBoolean,
+                'parameterEnum': parameterEnum,
+                'parameterModel': parameterModel,
+            },
+        });
+    }
+    /**
+     * @throws ApiError
+     */
+    public static callToTestOrderOfParams({
+        parameterStringWithNoDefault,
+        parameterOptionalStringWithDefault = 'Hello World!',
+        parameterOptionalStringWithEmptyDefault = '',
+        parameterOptionalStringWithNoDefault,
+        parameterStringWithDefault = 'Hello World!',
+        parameterStringWithEmptyDefault = '',
+        parameterStringNullableWithNoDefault,
+        parameterStringNullableWithDefault = null,
+    }: CallToTestOrderOfParamsOptions): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/api/v{api-version}/defaults',
+            query: {
+                'parameterOptionalStringWithDefault': parameterOptionalStringWithDefault,
+                'parameterOptionalStringWithEmptyDefault': parameterOptionalStringWithEmptyDefault,
+                'parameterOptionalStringWithNoDefault': parameterOptionalStringWithNoDefault,
+                'parameterStringWithDefault': parameterStringWithDefault,
+                'parameterStringWithEmptyDefault': parameterStringWithEmptyDefault,
+                'parameterStringWithNoDefault': parameterStringWithNoDefault,
+                'parameterStringNullableWithNoDefault': parameterStringNullableWithNoDefault,
+                'parameterStringNullableWithDefault': parameterStringNullableWithDefault,
+            },
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/DeprecatedService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { DeprecatedModel } from '../models/DeprecatedModel';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export type DeprecatedCallOptions = {
+    /**
+     * This parameter is deprecated
+     * @deprecated
+     */
+    parameter: DeprecatedModel | null,
+};
+export class DeprecatedService {
+    /**
+     * @deprecated
+     * @throws ApiError
+     */
+    public static deprecatedCall({
+        parameter,
+    }: DeprecatedCallOptions): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/parameters/deprecated',
+            headers: {
+                'parameter': parameter,
+            },
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/DescriptionsService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export type CallWithDescriptionsOptions = {
+    /**
+     * Testing multiline comments in string: First line
+     * Second line
+     *
+     * Fourth line
+     */
+    parameterWithBreaks?: any,
+    /**
+     * Testing backticks in string: \`backticks\` and \`\`\`multiple backticks\`\`\` should work
+     */
+    parameterWithBackticks?: any,
+    /**
+     * Testing slashes in string: \\backwards\\\\\\ and /forwards/// should work
+     */
+    parameterWithSlashes?: any,
+    /**
+     * Testing expression placeholders in string: \${expression} should work
+     */
+    parameterWithExpressionPlaceholders?: any,
+    /**
+     * Testing quotes in string: 'single quote''' and "double quotes""" should work
+     */
+    parameterWithQuotes?: any,
+    /**
+     * Testing reserved characters in string: * inline * and ** inline ** should work
+     */
+    parameterWithReservedCharacters?: any,
+};
+export class DescriptionsService {
+    /**
+     * @throws ApiError
+     */
+    public static callWithDescriptions({
+        parameterWithBreaks,
+        parameterWithBackticks,
+        parameterWithSlashes,
+        parameterWithExpressionPlaceholders,
+        parameterWithQuotes,
+        parameterWithReservedCharacters,
+    }: CallWithDescriptionsOptions): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/descriptions/',
+            query: {
+                'parameterWithBreaks': parameterWithBreaks,
+                'parameterWithBackticks': parameterWithBackticks,
+                'parameterWithSlashes': parameterWithSlashes,
+                'parameterWithExpressionPlaceholders': parameterWithExpressionPlaceholders,
+                'parameterWithQuotes': parameterWithQuotes,
+                'parameterWithReservedCharacters': parameterWithReservedCharacters,
+            },
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/DuplicateService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class DuplicateService {
+    /**
+     * @throws ApiError
+     */
+    public static duplicateName(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/duplicate',
+        });
+    }
+    /**
+     * @throws ApiError
+     */
+    public static duplicateName1(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/duplicate',
+        });
+    }
+    /**
+     * @throws ApiError
+     */
+    public static duplicateName2(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/api/v{api-version}/duplicate',
+        });
+    }
+    /**
+     * @throws ApiError
+     */
+    public static duplicateName3(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v{api-version}/duplicate',
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/ErrorService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export type TestErrorCodeOptions = {
+    /**
+     * Status code to return
+     */
+    status: number,
+};
+export class ErrorService {
+    /**
+     * @returns any Custom message: Successful response
+     * @throws ApiError
+     */
+    public static testErrorCode({
+        status,
+    }: TestErrorCodeOptions): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/error',
+            query: {
+                'status': status,
+            },
+            errors: {
+                500: \`Custom message: Internal Server Error\`,
+                501: \`Custom message: Not Implemented\`,
+                502: \`Custom message: Bad Gateway\`,
+                503: \`Custom message: Service Unavailable\`,
+            },
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/FormDataService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from '../models/ModelWithString';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export type PostApiFormDataOptions = {
+    /**
+     * This is a reusable parameter
+     */
+    parameter?: string,
+    /**
+     * A reusable request body
+     */
+    formData?: ModelWithString,
+};
+export class FormDataService {
+    /**
+     * @throws ApiError
+     */
+    public static postApiFormData({
+        parameter,
+        formData,
+    }: PostApiFormDataOptions): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/formData/',
+            query: {
+                'parameter': parameter,
+            },
+            formData: formData,
+            mediaType: 'multipart/form-data',
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/HeaderService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class HeaderService {
+    /**
+     * @returns string Successful response
+     * @throws ApiError
+     */
+    public static callWithResultFromHeader(): CancelablePromise<string> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/header',
+            responseHeader: 'operation-location',
+            errors: {
+                400: \`400 server error\`,
+                500: \`500 server error\`,
+            },
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/MultipartService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from '../models/ModelWithString';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export type MultipartRequestOptions = {
+    formData?: {
+        content?: Blob;
+        data?: ModelWithString | null;
+    },
+};
+export class MultipartService {
+    /**
+     * @throws ApiError
+     */
+    public static multipartRequest({
+        formData,
+    }: MultipartRequestOptions): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/multipart',
+            formData: formData,
+            mediaType: 'multipart/form-data',
+        });
+    }
+    /**
+     * @returns any OK
+     * @throws ApiError
+     */
+    public static multipartResponse(): CancelablePromise<{
+        file?: Blob;
+        metadata?: {
+            foo?: string;
+            bar?: string;
+        };
+    }> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/multipart',
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/MultipleTags1Service.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class MultipleTags1Service {
+    /**
+     * @returns void
+     * @throws ApiError
+     */
+    public static dummyA(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/multiple-tags/a',
+        });
+    }
+    /**
+     * @returns void
+     * @throws ApiError
+     */
+    public static dummyB(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/multiple-tags/b',
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/MultipleTags2Service.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class MultipleTags2Service {
+    /**
+     * @returns void
+     * @throws ApiError
+     */
+    public static dummyA(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/multiple-tags/a',
+        });
+    }
+    /**
+     * @returns void
+     * @throws ApiError
+     */
+    public static dummyB(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/multiple-tags/b',
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/MultipleTags3Service.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class MultipleTags3Service {
+    /**
+     * @returns void
+     * @throws ApiError
+     */
+    public static dummyB(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/multiple-tags/b',
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/NoContentService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class NoContentService {
+    /**
+     * @returns void
+     * @throws ApiError
+     */
+    public static callWithNoContentResponse(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/no-content',
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/ParametersService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from '../models/ModelWithString';
+import type { Pageable } from '../models/Pageable';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export type CallWithParametersOptions = {
+    /**
+     * This is the parameter that goes into the header
+     */
+    parameterHeader: string | null,
+    /**
+     * This is the parameter that goes into the query params
+     */
+    parameterQuery: string | null,
+    /**
+     * This is the parameter that goes into the form data
+     */
+    parameterForm: string | null,
+    /**
+     * This is the parameter that goes into the cookie
+     */
+    parameterCookie: string | null,
+    /**
+     * This is the parameter that goes into the path
+     */
+    parameterPath: string | null,
+    /**
+     * This is the parameter that goes into the body
+     */
+    requestBody: ModelWithString | null,
+};
+export type CallWithWeirdParameterNamesOptions = {
+    /**
+     * This is the parameter that goes into the request header
+     */
+    parameterHeader: string | null,
+    /**
+     * This is the parameter that goes into the request query params
+     */
+    parameterQuery: string | null,
+    /**
+     * This is the parameter that goes into the request form data
+     */
+    parameterForm: string | null,
+    /**
+     * This is the parameter that goes into the cookie
+     */
+    parameterCookie: string | null,
+    /**
+     * This is the parameter that goes into the body
+     */
+    requestBody: ModelWithString | null,
+    /**
+     * This is the parameter that goes into the path
+     */
+    parameterPath1?: string,
+    /**
+     * This is the parameter that goes into the path
+     */
+    parameterPath2?: string,
+    /**
+     * This is the parameter that goes into the path
+     */
+    parameterPath3?: string,
+    /**
+     * This is the parameter with a reserved keyword
+     */
+    _default?: string,
+};
+export type GetCallWithOptionalParamOptions = {
+    /**
+     * This is a required parameter
+     */
+    requestBody: ModelWithString,
+    /**
+     * This is an optional parameter
+     */
+    parameter?: string,
+};
+export type PostCallWithOptionalParamOptions = {
+    /**
+     * This is a required parameter
+     */
+    parameter: Pageable,
+    /**
+     * This is an optional parameter
+     */
+    requestBody?: ModelWithString,
+};
+export class ParametersService {
+    /**
+     * @throws ApiError
+     */
+    public static callWithParameters({
+        parameterHeader,
+        parameterQuery,
+        parameterForm,
+        parameterCookie,
+        parameterPath,
+        requestBody,
+    }: CallWithParametersOptions): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/parameters/{parameterPath}',
+            path: {
+                'parameterPath': parameterPath,
+            },
+            cookies: {
+                'parameterCookie': parameterCookie,
+            },
+            headers: {
+                'parameterHeader': parameterHeader,
+            },
+            query: {
+                'parameterQuery': parameterQuery,
+            },
+            formData: {
+                'parameterForm': parameterForm,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
+     * @throws ApiError
+     */
+    public static callWithWeirdParameterNames({
+        parameterHeader,
+        parameterQuery,
+        parameterForm,
+        parameterCookie,
+        requestBody,
+        parameterPath1,
+        parameterPath2,
+        parameterPath3,
+        _default,
+    }: CallWithWeirdParameterNamesOptions): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
+            path: {
+                'parameter.path.1': parameterPath1,
+                'parameter-path-2': parameterPath2,
+                'PARAMETER-PATH-3': parameterPath3,
+            },
+            cookies: {
+                'PARAMETER-COOKIE': parameterCookie,
+            },
+            headers: {
+                'parameter.header': parameterHeader,
+            },
+            query: {
+                'default': _default,
+                'parameter-query': parameterQuery,
+            },
+            formData: {
+                'parameter_form': parameterForm,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
+     * @throws ApiError
+     */
+    public static getCallWithOptionalParam({
+        requestBody,
+        parameter,
+    }: GetCallWithOptionalParamOptions): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/parameters/',
+            query: {
+                'parameter': parameter,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
+     * @throws ApiError
+     */
+    public static postCallWithOptionalParam({
+        parameter,
+        requestBody,
+    }: PostCallWithOptionalParamOptions): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/parameters/',
+            query: {
+                'parameter': parameter,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/RequestBodyService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelWithString } from '../models/ModelWithString';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export type PostApiRequestBodyOptions = {
+    /**
+     * This is a reusable parameter
+     */
+    parameter?: string,
+    /**
+     * A reusable request body
+     */
+    requestBody?: ModelWithString,
+};
+export class RequestBodyService {
+    /**
+     * @throws ApiError
+     */
+    public static postApiRequestBody({
+        parameter,
+        requestBody,
+    }: PostApiRequestBodyOptions): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/requestBody/',
+            query: {
+                'parameter': parameter,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/ResponseService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ModelThatExtends } from '../models/ModelThatExtends';
+import type { ModelThatExtendsExtends } from '../models/ModelThatExtendsExtends';
+import type { ModelWithString } from '../models/ModelWithString';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class ResponseService {
+    /**
+     * @returns ModelWithString
+     * @throws ApiError
+     */
+    public static callWithResponse(): CancelablePromise<ModelWithString> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/response',
+        });
+    }
+    /**
+     * @returns ModelWithString Message for default response
+     * @throws ApiError
+     */
+    public static callWithDuplicateResponses(): CancelablePromise<ModelWithString> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/response',
+            errors: {
+                500: \`Message for 500 error\`,
+                501: \`Message for 501 error\`,
+                502: \`Message for 502 error\`,
+            },
+        });
+    }
+    /**
+     * @returns any Message for 200 response
+     * @returns ModelWithString Message for default response
+     * @returns ModelThatExtends Message for 201 response
+     * @returns ModelThatExtendsExtends Message for 202 response
+     * @throws ApiError
+     */
+    public static callWithResponses(): CancelablePromise<{
+        readonly '@namespace.string'?: string;
+        readonly '@namespace.integer'?: number;
+        readonly value?: Array<ModelWithString>;
+    } | ModelWithString | ModelThatExtends | ModelThatExtendsExtends> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/api/v{api-version}/response',
+            errors: {
+                500: \`Message for 500 error\`,
+                501: \`Message for 501 error\`,
+                502: \`Message for 502 error\`,
+            },
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/SimpleService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class SimpleService {
+    /**
+     * @throws ApiError
+     */
+    public static getCallWithoutParametersAndResponse(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/simple',
+        });
+    }
+    /**
+     * @throws ApiError
+     */
+    public static putCallWithoutParametersAndResponse(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/api/v{api-version}/simple',
+        });
+    }
+    /**
+     * @throws ApiError
+     */
+    public static postCallWithoutParametersAndResponse(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/simple',
+        });
+    }
+    /**
+     * @throws ApiError
+     */
+    public static deleteCallWithoutParametersAndResponse(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v{api-version}/simple',
+        });
+    }
+    /**
+     * @throws ApiError
+     */
+    public static optionsCallWithoutParametersAndResponse(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'OPTIONS',
+            url: '/api/v{api-version}/simple',
+        });
+    }
+    /**
+     * @throws ApiError
+     */
+    public static headCallWithoutParametersAndResponse(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'HEAD',
+            url: '/api/v{api-version}/simple',
+        });
+    }
+    /**
+     * @throws ApiError
+     */
+    public static patchCallWithoutParametersAndResponse(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'PATCH',
+            url: '/api/v{api-version}/simple',
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/TypesService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export type TypesOptions = {
+    /**
+     * This is an array parameter
+     */
+    parameterArray: Array<string> | null,
+    /**
+     * This is a dictionary parameter
+     */
+    parameterDictionary: Record<string, any> | null,
+    /**
+     * This is an enum parameter
+     */
+    parameterEnum: 'Success' | 'Warning' | 'Error' | null,
+    /**
+     * This is a number parameter
+     */
+    parameterNumber?: number,
+    /**
+     * This is a string parameter
+     */
+    parameterString?: string | null,
+    /**
+     * This is a boolean parameter
+     */
+    parameterBoolean?: boolean | null,
+    /**
+     * This is an object parameter
+     */
+    parameterObject?: Record<string, any> | null,
+    /**
+     * This is a number parameter
+     */
+    id?: number,
+};
+export class TypesService {
+    /**
+     * @returns number Response is a simple number
+     * @returns string Response is a simple string
+     * @returns boolean Response is a simple boolean
+     * @returns any Response is a simple object
+     * @throws ApiError
+     */
+    public static types({
+        parameterArray,
+        parameterDictionary,
+        parameterEnum,
+        parameterNumber = 123,
+        parameterString = 'default',
+        parameterBoolean = true,
+        parameterObject = null,
+        id,
+    }: TypesOptions): CancelablePromise<number | string | boolean | Record<string, any>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/types',
+            path: {
+                'id': id,
+            },
+            query: {
+                'parameterNumber': parameterNumber,
+                'parameterString': parameterString,
+                'parameterBoolean': parameterBoolean,
+                'parameterObject': parameterObject,
+                'parameterArray': parameterArray,
+                'parameterDictionary': parameterDictionary,
+                'parameterEnum': parameterEnum,
+            },
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate w/ --useOptions --exportOptions: test/generated/v3-options/services/UploadService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export type UploadFileOptions = {
+    /**
+     * Supply a file reference for upload
+     */
+    file: Blob,
+};
+export class UploadService {
+    /**
+     * @returns boolean
+     * @throws ApiError
+     */
+    public static uploadFile({
+        file,
+    }: UploadFileOptions): CancelablePromise<boolean> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/upload',
+            formData: {
+                'file': file,
+            },
+        });
+    }
+}
+"
+`;
+
 exports[`v3 should generate: test/generated/v3/core/ApiError.ts 1`] = `
 "/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -43,4 +43,24 @@ describe('v3', () => {
             expect(content).toMatchSnapshot(file);
         });
     });
+
+    it('should generate w/ --useOptions --exportOptions', async () => {
+        await generate({
+            input: './test/spec/v3.json',
+            output: './test/generated/v3-options/',
+            httpClient: HttpClient.FETCH,
+            useOptions: true,
+            useUnionTypes: false,
+            exportCore: true,
+            exportSchemas: true,
+            exportModels: true,
+            exportServices: true,
+            exportOptions: true,
+        });
+
+        sync('./test/generated/v3-options/**/*.ts').forEach(file => {
+            const content = readFileSync(file, 'utf8').toString();
+            expect(content).toMatchSnapshot(file);
+        });
+    });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,6 +23,7 @@ export type Options = {
     exportServices?: boolean;
     exportModels?: boolean;
     exportSchemas?: boolean;
+    exportOptions?: boolean;
     indent?: Indent | '4' | '2' | 'tab';
     postfixServices?: string;
     postfixModels?: string;


### PR DESCRIPTION
Hey👋🏻

Thanks again @ferdikoomen for your amazing job on this library 🙏🏻

### add exportOptions

The idea here is to export service operation's options to disk using a new option called `--exportOptions`.

* **It has to be used alongside** `--exportServices=true` **and** `--useOptions`.
* option type will only be written if operation have **at least one parameter**

### to be determined 🤔 
- should we rename cli option to a more explicit one like `exportServiceOperationTypes` or `exportServiceFunctionParameters` ?
- should we add a postfix option to change type postfix (here default to `Options`) ?

---

Example without `--exportOptions` (_current behavior_) :

```typescript
import type { ModelWithString } from '../models/ModelWithString';
import type { CancelablePromise } from '../core/CancelablePromise';
import { OpenAPI } from '../core/OpenAPI';
import { request as __request } from '../core/request';
export class RequestBodyService {
    /**
     * @throws ApiError
     */
    public static postApiRequestBody({
        parameter,
        requestBody,
    }: {
    /**
     * This is a reusable parameter
     */
    parameter?: string,
    /**
     * A reusable request body
     */
    requestBody?: ModelWithString,
}): CancelablePromise<void> {
        return __request(OpenAPI, {
            method: 'POST',
            url: '/api/v{api-version}/requestBody/',
            query: {
                'parameter': parameter,
            },
            body: requestBody,
            mediaType: 'application/json',
        });
    }
}
```

Example with `--exportOptions` (_see PostApiRequestBodyOptions exported type_):

```typescript
import type { ModelWithString } from '../models/ModelWithString';
import type { CancelablePromise } from '../core/CancelablePromise';
import { OpenAPI } from '../core/OpenAPI';
import { request as __request } from '../core/request';
export type PostApiRequestBodyOptions = {
    /**
     * This is a reusable parameter
     */
    parameter?: string,
    /**
     * A reusable request body
     */
    requestBody?: ModelWithString,
};
export class RequestBodyService {
    /**
     * @throws ApiError
     */
    public static postApiRequestBody({
        parameter,
        requestBody,
    }: PostApiRequestBodyOptions): CancelablePromise<void> {
        return __request(OpenAPI, {
            method: 'POST',
            url: '/api/v{api-version}/requestBody/',
            query: {
                'parameter': parameter,
            },
            body: requestBody,
            mediaType: 'application/json',
        });
    }
}
```

---

I remain at your disposal for any feedback on the implementation.

I wish you a great day ☀️

Best regards ☮️