### PR TITLE
Parse models without `type: object` as objects if they contain properties?

### DIFF
--- a/src/openApi/v2/parser/getModel.ts
+++ b/src/openApi/v2/parser/getModel.ts
@@ -89,7 +89,7 @@ export const getModel = (
         }
     }
 
-    if (definition.type === 'object' && typeof definition.additionalProperties === 'object') {
+    if (typeof definition.additionalProperties === 'object') {
         if (definition.additionalProperties.$ref) {
             const additionalProperties = getType(definition.additionalProperties.$ref);
             model.export = 'dictionary';
@@ -119,7 +119,7 @@ export const getModel = (
         return model;
     }
 
-    if (definition.type === 'object') {
+    if (definition.type === 'object' || typeof definition.properties === 'object') {
         model.export = 'interface';
         model.type = 'any';
         model.base = 'any';

--- a/src/openApi/v3/parser/getModel.ts
+++ b/src/openApi/v3/parser/getModel.ts
@@ -95,10 +95,7 @@ export const getModel = (
         }
     }
 
-    if (
-        definition.type === 'object' &&
-        (typeof definition.additionalProperties === 'object' || definition.additionalProperties === true)
-    ) {
+    if (typeof definition.additionalProperties === 'object' || definition.additionalProperties === true) {
         const ap = typeof definition.additionalProperties === 'object' ? definition.additionalProperties : {};
         if (ap.$ref) {
             const additionalProperties = getType(ap.$ref);
@@ -149,34 +146,32 @@ export const getModel = (
         return model;
     }
 
-    if (definition.type === 'object') {
-        if (definition.properties) {
-            model.export = 'interface';
-            model.type = 'any';
-            model.base = 'any';
-            model.default = getModelDefault(definition, model);
+    if (definition.properties) {
+        model.export = 'interface';
+        model.type = 'any';
+        model.base = 'any';
+        model.default = getModelDefault(definition, model);
 
-            const modelProperties = getModelProperties(openApi, definition, getModel, model);
-            modelProperties.forEach(modelProperty => {
-                model.imports.push(...modelProperty.imports);
-                model.enums.push(...modelProperty.enums);
-                model.properties.push(modelProperty);
-                if (modelProperty.export === 'enum') {
-                    model.enums.push(modelProperty);
-                }
-            });
-            return model;
-        } else {
-            const additionalProperties = getModel(openApi, {});
-            model.export = 'dictionary';
-            model.type = additionalProperties.type;
-            model.base = additionalProperties.base;
-            model.template = additionalProperties.template;
-            model.link = additionalProperties;
-            model.imports.push(...additionalProperties.imports);
-            model.default = getModelDefault(definition, model);
-            return model;
-        }
+        const modelProperties = getModelProperties(openApi, definition, getModel, model);
+        modelProperties.forEach(modelProperty => {
+            model.imports.push(...modelProperty.imports);
+            model.enums.push(...modelProperty.enums);
+            model.properties.push(modelProperty);
+            if (modelProperty.export === 'enum') {
+                model.enums.push(modelProperty);
+            }
+        });
+        return model;
+    } else if (definition.type === 'object') {
+        const additionalProperties = getModel(openApi, {});
+        model.export = 'dictionary';
+        model.type = additionalProperties.type;
+        model.base = additionalProperties.base;
+        model.template = additionalProperties.template;
+        model.link = additionalProperties;
+        model.imports.push(...additionalProperties.imports);
+        model.default = getModelDefault(definition, model);
+        return model;
     }
 
     // If the schema has a type than it can be a basic or generic type.


### PR DESCRIPTION
Follow-up from https://github.com/ferdikoomen/openapi-typescript-codegen/issues/1178#issuecomment-1680690220 :

It seems like most OpenAPI tooling supports objects to be defined implicitly, without `type: object`. What do you think about supporting that in openapi-typescript-codegen too?

I've tried to dig into the JSON Schema spec to find out what's the correct way to handle this case, but unsuccessfully. 

I'm not sure if this PR is complete, but I've created it to start the discussion of whether implicit objects should be supported or not.