### PR TITLE
Fixes #1636 Fixes "blank" enums by providing the fallback name

### DIFF
--- a/src/openApi/v2/parser/getEnum.ts
+++ b/src/openApi/v2/parser/getEnum.ts
@@ -18,12 +18,13 @@ export const getEnum = (values?: (string | number)[]): Enum[] => {
                         description: null,
                     };
                 }
+                const sanitizedName = String(value)
+                    .replace(/\W+/g, '_')
+                    .replace(/^(\d+)/g, '_$1')
+                    .replace(/([a-z])([A-Z]+)/g, '$1_$2')
+                    .toUpperCase();
                 return {
-                    name: String(value)
-                        .replace(/\W+/g, '_')
-                        .replace(/^(\d+)/g, '_$1')
-                        .replace(/([a-z])([A-Z]+)/g, '$1_$2')
-                        .toUpperCase(),
+                    name: sanitizedName === '' ? 'BLANK' : sanitizedName,
                     value: `'${value.replace(/'/g, "\\'")}'`,
                     type: 'string',
                     description: null,

--- a/src/openApi/v3/parser/getEnum.ts
+++ b/src/openApi/v3/parser/getEnum.ts
@@ -18,12 +18,13 @@ export const getEnum = (values?: (string | number)[]): Enum[] => {
                         description: null,
                     };
                 }
+                const sanitizedName = String(value)
+                    .replace(/\W+/g, '_')
+                    .replace(/^(\d+)/g, '_$1')
+                    .replace(/([a-z])([A-Z]+)/g, '$1_$2')
+                    .toUpperCase();
                 return {
-                    name: String(value)
-                        .replace(/\W+/g, '_')
-                        .replace(/^(\d+)/g, '_$1')
-                        .replace(/([a-z])([A-Z]+)/g, '$1_$2')
-                        .toUpperCase(),
+                    name: sanitizedName === '' ? 'BLANK' : sanitizedName,
                     value: `'${value.replace(/'/g, "\\'")}'`,
                     type: 'string',
                     description: null,


### PR DESCRIPTION
Fixes issue #1636 

Some frameworks (e.g. django rest framework, I guess) generate following schema:

```
openapi: 3.0.3
info:
    version: 1.0.0
components:
    schemas:
        BlankEnum:
            enum:
                - ''
```
right now this library generates invalid typescript:
```
export enum BlankEnum {
     = '',
}
```

This happens in `getEnum` functions that don't check for invalid input (`getEnum([''])`) in our case. 

I decided to give such enum values `BLANK` name so that generated files are correct
```
export enum BlankEnum {
    BLANK = '',
}
```

Not sure if it would be a better idea to just omit these values (I mean, the name says **Blank**Enum) but everything's better than broken syntax