### PR TITLE
feature: add support for constant values

### DIFF
--- a/src/client/interfaces/Model.d.ts
+++ b/src/client/interfaces/Model.d.ts
@@ -3,7 +3,17 @@ import type { Schema } from './Schema';
 
 export interface Model extends Schema {
     name: string;
-    export: 'reference' | 'generic' | 'enum' | 'array' | 'dictionary' | 'interface' | 'one-of' | 'any-of' | 'all-of';
+    export:
+        | 'reference'
+        | 'generic'
+        | 'enum'
+        | 'array'
+        | 'dictionary'
+        | 'interface'
+        | 'one-of'
+        | 'any-of'
+        | 'all-of'
+        | 'const';
     type: string;
     base: string;
     template: string | null;

--- a/src/openApi/v3/interfaces/OpenApiSchema.d.ts
+++ b/src/openApi/v3/interfaces/OpenApiSchema.d.ts
@@ -26,6 +26,7 @@ export interface OpenApiSchema extends OpenApiReference, WithEnumExtension {
     required?: string[];
     enum?: (string | number)[];
     type?: string | string[];
+    const?: string | number | boolean | null;
     allOf?: OpenApiSchema[];
     oneOf?: OpenApiSchema[];
     anyOf?: OpenApiSchema[];

--- a/src/openApi/v3/parser/getModel.ts
+++ b/src/openApi/v3/parser/getModel.ts
@@ -192,5 +192,14 @@ export const getModel = (
         return model;
     }
 
+    if (definition.const !== undefined) {
+        model.export = 'const';
+        const definitionConst = definition.const;
+        const modelConst = typeof definitionConst === 'string' ? `"${definitionConst}"` : `${definitionConst}`;
+        model.type = modelConst;
+        model.base = modelConst;
+        return model;
+    }
+
     return model;
 };

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -3710,6 +3710,7 @@ export type { ModelThatExtendsExtends } from './models/ModelThatExtendsExtends';
 export type { ModelWithArray } from './models/ModelWithArray';
 export type { ModelWithBoolean } from './models/ModelWithBoolean';
 export type { ModelWithCircularReference } from './models/ModelWithCircularReference';
+export type { ModelWithConst } from './models/ModelWithConst';
 export type { ModelWithDictionary } from './models/ModelWithDictionary';
 export type { ModelWithDuplicateImports } from './models/ModelWithDuplicateImports';
 export type { ModelWithDuplicateProperties } from './models/ModelWithDuplicateProperties';
@@ -3780,6 +3781,7 @@ export { $ModelThatExtendsExtends } from './schemas/$ModelThatExtendsExtends';
 export { $ModelWithArray } from './schemas/$ModelWithArray';
 export { $ModelWithBoolean } from './schemas/$ModelWithBoolean';
 export { $ModelWithCircularReference } from './schemas/$ModelWithCircularReference';
+export { $ModelWithConst } from './schemas/$ModelWithConst';
 export { $ModelWithDictionary } from './schemas/$ModelWithDictionary';
 export { $ModelWithDuplicateImports } from './schemas/$ModelWithDuplicateImports';
 export { $ModelWithDuplicateProperties } from './schemas/$ModelWithDuplicateProperties';
@@ -4550,6 +4552,21 @@ exports[`v3 should generate: test/generated/v3/models/ModelWithCircularReference
  */
 export type ModelWithCircularReference = {
     prop?: ModelWithCircularReference;
+};
+
+"
+`;
+
+exports[`v3 should generate: test/generated/v3/models/ModelWithConst.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ModelWithConst = {
+    string?: "string";
+    number?: 0;
+    boolean?: false;
+    null?: null;
 };
 
 "
@@ -5860,6 +5877,30 @@ export const $ModelWithCircularReference = {
     properties: {
         prop: {
             type: 'ModelWithCircularReference',
+        },
+    },
+} as const;
+"
+`;
+
+exports[`v3 should generate: test/generated/v3/schemas/$ModelWithConst.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithConst = {
+    properties: {
+        string: {
+            type: '"string"',
+        },
+        number: {
+            type: '0',
+        },
+        boolean: {
+            type: 'false',
+        },
+        null: {
+            type: 'null',
         },
     },
 } as const;

--- a/test/spec/v3.json
+++ b/test/spec/v3.json
@@ -2553,6 +2553,23 @@
                 "description": "This is a free-form object with additionalProperties: {}.",
                 "type": "object",
                 "additionalProperties": {}
+            },
+            "ModelWithConst": {
+                "type": "object",
+                "properties": {
+                    "string": {
+                        "const": "string"
+                    },
+                    "number": {
+                        "const": 0
+                    },
+                    "boolean": {
+                        "const": false
+                    },
+                    "null": {
+                        "const": null
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #1834

See the issue above for a description of a usecase where support for the [`const` keyword](https://json-schema.org/understanding-json-schema/reference/const) is useful. Updated the snapshot tests to verify correct output.