### PR TITLE
feat(operationalParameter): Default to config headers for header params

### DIFF
--- a/src/openApi/v3/parser/getOperationParameter.ts
+++ b/src/openApi/v3/parser/getOperationParameter.ts
@@ -54,7 +54,11 @@ export const getOperationParameter = (openApi: OpenApi, parameter: OpenApiParame
             operationParameter.base = model.base;
             operationParameter.template = model.template;
             operationParameter.imports.push(...model.imports);
-            operationParameter.default = getModelDefault(schema);
+            operationParameter.default =
+                parameter.in === 'header'
+                    ? `this.httpRequest.config.HEADERS['${parameter.name}']`
+                    : getModelDefault(schema);
+
             return operationParameter;
         } else {
             const model = getModel(openApi, schema);
@@ -80,11 +84,14 @@ export const getOperationParameter = (openApi: OpenApi, parameter: OpenApiParame
             operationParameter.maxProperties = model.maxProperties;
             operationParameter.minProperties = model.minProperties;
             operationParameter.pattern = getPattern(model.pattern);
-            operationParameter.default = model.default;
             operationParameter.imports.push(...model.imports);
             operationParameter.enum.push(...model.enum);
             operationParameter.enums.push(...model.enums);
             operationParameter.properties.push(...model.properties);
+
+            // param default if the value is a header should be the config header
+            operationParameter.default =
+                parameter.in === 'header' ? `this.httpRequest.config.HEADERS['${parameter.name}']` : model.default;
             return operationParameter;
         }
     }


### PR DESCRIPTION
If OpenAPI has paramaters that will be sent as headers, allow configuration to set those headers for the entire client.

This PR generates the following typescript

```ts
 public listWorkflows({
        instanceId,
        amazonAdvertisingApiClientId = this.httpRequest.config.HEADERS['Amazon-Advertising-API-ClientId'],
        amazonAdvertisingApiAdvertiserId = this.httpRequest.config.HEADERS['Amazon-Advertising-API-AdvertiserId'],
        amazonAdvertisingApiMarketplaceId = this.httpRequest.config.HEADERS['Amazon-Advertising-API-MarketplaceId'],
        nextToken,
        limit,
    }
```

Which allows a user to use the library as follows

```ts
const myClient = new MyClient({
		TOKEN: token,
		HEADERS: {
			'Amazon-Advertising-API-ClientId': AMAZON_ADS_CLIENT_ID,
			'Amazon-Advertising-API-AdvertiserId': AMAZON_ADS_ADVERTISING_ID,
			'Amazon-Advertising-API-MarketplaceId': AMAZON_ADS_US_MARKETPLACE
		}
	});
```

And then method calls no longer require you to pass these headers every time. This is a welcome change to verbosity.

Feedback is welcome.