### PR TITLE
Fix for Object.entries(formData) in getFormData

### DIFF
--- a/src/templates/core/functions/getFormData.hbs
+++ b/src/templates/core/functions/getFormData.hbs
@@ -10,15 +10,15 @@ export const getFormData = (options: ApiRequestOptions): FormData | undefined =>
 			}
 		};
 
-		Object.entries(options.formData)
-			.filter(([_, value]) => isDefined(value))
-			.forEach(([key, value]) => {
-				if (Array.isArray(value)) {
-					value.forEach(v => process(key, v));
-				} else {
-					process(key, value);
-				}
-			});
+		for (let [key, value] of options.formData.entries()) {
+	      if (isDefined(value)) {
+	        if (Array.isArray(value)) {
+	          value.forEach((v) => process(key, v));
+	        } else {
+	          process(key, value);
+	        }
+	      }
+	    }
 
 		return formData;
 	}


### PR DESCRIPTION
When you use Object.entries(formData), it attempts to convert the FormData object into an array of key-value pairs, as it would with a regular JavaScript object. However, since FormData doesn't store its data in enumerable properties, Object.entries returns an empty array.

This will not work: 
Object.entries(options.formData) 
        .filter(([_, value]) => isDefined(value))
        .forEach(([key, value]) => {
            if (Array.isArray(value)) {
                value.forEach(v => process(key, v));
            } else {
                process(key, value);
            }
        });

On the other hand, formData.entries() is a method specifically provided by the FormData interface. It returns an iterator allowing for the traversal of all key/value pairs contained in the FormData object. This method is designed to understand and interact with the internal structure of FormData, so it successfully retrieves the data.

This will work:
for (let [key, value] of options.formData.entries()) {
      if (isDefined(value)) {
        if (Array.isArray(value)) {
          value.forEach((v) => process(key, v));
        } else {
          process(key, value);
        }
      }
    }