### PR TITLE
fix: timeout error

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -24,6 +24,7 @@ const params = program
     .option('--postfixServices <value>', 'Service name postfix', 'Service')
     .option('--postfixModels <value>', 'Model name postfix')
     .option('--request <value>', 'Path to custom request file')
+    .option('--timeout <value>', 'Network request timeout', 5000)
     .parse(process.argv)
     .opts();
 
@@ -45,6 +46,7 @@ if (OpenAPI) {
         postfixServices: params.postfixServices,
         postfixModels: params.postfixModels,
         request: params.request,
+        timeoutTime: params.timeout,
     })
         .then(() => {
             process.exit(0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export type Options = {
     postfixModels?: string;
     request?: string;
     write?: boolean;
+    timeoutTime?: number;
 };
 
 /**
@@ -49,6 +50,7 @@ export type Options = {
  * @param postfixModels Model name postfix
  * @param request Path to custom request file
  * @param write Write the files to disk (true or false)
+ * @param set Timeout time for http requests
  */
 export const generate = async ({
     input,
@@ -65,9 +67,10 @@ export const generate = async ({
     postfixServices = 'Service',
     postfixModels = '',
     request,
+    timeoutTime = 5000,
     write = true,
 }: Options): Promise<void> => {
-    const openApi = isString(input) ? await getOpenApiSpec(input) : input;
+    const openApi = isString(input) ? await getOpenApiSpec(input, timeoutTime) : input;
     const openApiVersion = getOpenApiVersion(openApi);
     const templates = registerHandlebarTemplates({
         httpClient,

--- a/src/utils/getOpenApiSpec.ts
+++ b/src/utils/getOpenApiSpec.ts
@@ -6,6 +6,6 @@ import RefParser from '@apidevtools/json-schema-ref-parser';
  * on parsing the file as JSON.
  * @param location: Path or url
  */
-export const getOpenApiSpec = async (location: string): Promise<any> => {
-    return await RefParser.bundle(location, location, {});
+export const getOpenApiSpec = async (location: string, timeoutTime: number): Promise<any> => {
+    return await RefParser.bundle(location, location, { resolve: { http: { timeout: timeoutTime } } });
 };


### PR DESCRIPTION
When the input is a link and the json file is very big, it will result in an error.
```
'This operation was aborted\n' +
    '    at download (D:\\openapi-typescript-codegen\\node_modules\\@apidevtools\\json-schema-ref-parser\\dist\\lib\\resolvers\\http.js:113:15)\n' +
    '    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)',
```
or socket hang up error.
This problem also occurs with the same type of tools. https://github.com/cyclosproject/ng-swagger-gen/issues/217
So I add a timeout option to solve the problem.