### PR TITLE
add support for response header rendering for status code 204

### DIFF
--- a/src/openApi/v3/parser/getOperationResults.ts
+++ b/src/openApi/v3/parser/getOperationResults.ts
@@ -18,6 +18,10 @@ export const getOperationResults = (operationResponses: OperationResponse[]): Op
         if (code && code !== 204 && code >= 200 && code < 300) {
             operationResults.push(operationResponse);
         }
+        // If response code is 204 and we are expecting something in header lets add
+        else if(code === 204 && operationResponse.in === "header"){
+            operationResults.push(operationResponse);
+        }
     });
 
     if (!operationResults.length) {


### PR DESCRIPTION
While having a spec like 
```json
"responses": {
                    "204": {
                        "description": "Success",
                        "headers": {
                            "X-Auth-Token": {
                                "description": "header containing the auth token",
                                "schema": {
                                    "type": "string"
                                }
                            }
                        }
                    },
                    "401": {
                        "description": "Unauthorized"
                    },
                    "422": {
                        "description": "Validation Error",
                        "content": {
                            "application/json": {
                                "schema": {
                                    "$ref": "#/components/schemas/HTTPValidationError"
                                }
                            }
                        }
                    }
                }
```
we don't get the responseheader hook in the generated clientservice since it is filtered out. Whereas according to HTTP spec(https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.5-1) and MDN docs(https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#successful_responses) 204 can include headers