### PR TITLE
Add option to pass in custom handlebars templates #1268

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -5,6 +5,12 @@
 const path = require('path');
 const { program } = require('commander');
 const pkg = require('../package.json');
+const getTemplateOverrides = list =>
+    list?.reduce((result, override) => {
+        const [name, value] = override.split(':');
+        if (name && value) result[name] = value;
+        return result;
+    }, {});
 
 const params = program
     .name('openapi')
@@ -24,6 +30,7 @@ const params = program
     .option('--postfixServices <value>', 'Service name postfix', 'Service')
     .option('--postfixModels <value>', 'Model name postfix')
     .option('--request <value>', 'Path to custom request file')
+    .option('--templateOverrides <name:template...>', 'List of template overrides in the format name:template')
     .parse(process.argv)
     .opts();
 
@@ -45,6 +52,7 @@ if (OpenAPI) {
         postfixServices: params.postfixServices,
         postfixModels: params.postfixModels,
         request: params.request,
+        templateOverrides: getTemplateOverrides(params.templateOverrides),
     })
         .then(() => {
             process.exit(0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { getOpenApiSpec } from './utils/getOpenApiSpec';
 import { getOpenApiVersion, OpenApiVersion } from './utils/getOpenApiVersion';
 import { isString } from './utils/isString';
 import { postProcessClient } from './utils/postProcessClient';
-import { registerHandlebarTemplates } from './utils/registerHandlebarTemplates';
+import { registerHandlebarTemplates, TemplateOverrideNames } from './utils/registerHandlebarTemplates';
 import { writeClient } from './utils/writeClient';
 
 export { HttpClient } from './HttpClient';
@@ -28,6 +28,7 @@ export type Options = {
     postfixModels?: string;
     request?: string;
     write?: boolean;
+    templateOverrides?: Partial<Record<TemplateOverrideNames, string>>;
 };
 
 /**
@@ -49,6 +50,7 @@ export type Options = {
  * @param postfixModels Model name postfix
  * @param request Path to custom request file
  * @param write Write the files to disk (true or false)
+ * @param templateOverrides Override any template with a custom implementation
  */
 export const generate = async ({
     input,
@@ -66,6 +68,7 @@ export const generate = async ({
     postfixModels = '',
     request,
     write = true,
+    templateOverrides,
 }: Options): Promise<void> => {
     const openApi = isString(input) ? await getOpenApiSpec(input) : input;
     const openApiVersion = getOpenApiVersion(openApi);
@@ -73,6 +76,7 @@ export const generate = async ({
         httpClient,
         useUnionTypes,
         useOptions,
+        templateOverrides,
     });
 
     switch (openApiVersion) {

--- a/src/utils/preCompileTemplate.spec.ts
+++ b/src/utils/preCompileTemplate.spec.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'fs';
+import handlebars from 'handlebars';
+
+import { preCompileTemplate } from './preCompileTemplate';
+
+jest.mock('fs');
+jest.mock('handlebars');
+
+describe('preCompileTemplate', () => {
+    it('returns undefined if no file is provided', () => {
+        expect(preCompileTemplate()).toBeUndefined();
+    });
+
+    it('reads the file, trims it, and precompiles it', () => {
+        (readFileSync as jest.Mock).mockReturnValue({ toString: () => ' mock template ' });
+        (handlebars.precompile as jest.Mock).mockReturnValue('"mock template spec"');
+
+        const result = preCompileTemplate('mock-file.hbs');
+
+        expect(readFileSync).toHaveBeenCalledWith('mock-file.hbs', 'utf8');
+        expect(handlebars.precompile).toHaveBeenCalledWith('mock template', {
+            strict: true,
+            noEscape: true,
+            preventIndent: true,
+            knownHelpersOnly: true,
+            knownHelpers: {
+                ifdef: true,
+                equals: true,
+                notEquals: true,
+                containsSpaces: true,
+                union: true,
+                intersection: true,
+                enumerator: true,
+                escapeComment: true,
+                escapeDescription: true,
+                camelCase: true,
+            },
+        });
+        expect(result).toBe('mock template spec');
+    });
+});

--- a/src/utils/preCompileTemplate.ts
+++ b/src/utils/preCompileTemplate.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'fs';
+import handlebars from 'handlebars';
+import { extname } from 'path';
+
+/**
+ * Precompiles a Handlebars template from a given file.
+ *
+ * @param {string | undefined} file - The path to the file containing the Handlebars template.
+ * @returns {TemplateSpecification | undefined} - The precompiled template as a string, ready to be exported.
+ */
+export function preCompileTemplate(file?: string): TemplateSpecification | undefined {
+    if (!file) return;
+
+    const template = extname(file) === '.hbs' ? readFileSync(file, 'utf8').toString().trim() : file;
+    const templateSpec = handlebars.precompile(template, {
+        strict: true,
+        noEscape: true,
+        preventIndent: true,
+        knownHelpersOnly: true,
+        knownHelpers: {
+            ifdef: true,
+            equals: true,
+            notEquals: true,
+            containsSpaces: true,
+            union: true,
+            intersection: true,
+            enumerator: true,
+            escapeComment: true,
+            escapeDescription: true,
+            camelCase: true,
+        },
+    });
+
+    return eval(`(function(){return ${templateSpec} }());`);
+}

--- a/src/utils/registerHandlebarTemplates.spec.ts
+++ b/src/utils/registerHandlebarTemplates.spec.ts
@@ -1,21 +1,74 @@
+import Handlebars from 'handlebars/runtime';
+
 import { HttpClient } from '../HttpClient';
+import * as preCompiler from './preCompileTemplate';
 import { registerHandlebarTemplates } from './registerHandlebarTemplates';
 
+jest.mock('handlebars/runtime', () => ({
+    template: jest.fn((file: string) => file),
+    registerPartial: jest.fn((file: string) => file),
+    registerHelper: jest.fn((file: string) => file),
+}));
+
+jest.mock('./preCompileTemplate', () => ({
+    preCompileTemplate: jest.fn((file: string) => file),
+}));
+
 describe('registerHandlebarTemplates', () => {
-    it('should return correct templates', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should register handlebar templates', () => {
+        registerHandlebarTemplates({
+            httpClient: HttpClient.FETCH,
+            useOptions: false,
+            useUnionTypes: false,
+        });
+
+        expect(Handlebars.template).toHaveBeenCalled();
+        expect(Handlebars.registerPartial).toHaveBeenCalled();
+        expect(preCompiler.preCompileTemplate).toHaveBeenCalled();
+    });
+
+    it('should return default templates', () => {
         const templates = registerHandlebarTemplates({
             httpClient: HttpClient.FETCH,
             useOptions: false,
             useUnionTypes: false,
         });
-        expect(templates.index).toBeDefined();
-        expect(templates.exports.model).toBeDefined();
-        expect(templates.exports.schema).toBeDefined();
-        expect(templates.exports.service).toBeDefined();
-        expect(templates.core.settings).toBeDefined();
-        expect(templates.core.apiError).toBeDefined();
-        expect(templates.core.apiRequestOptions).toBeDefined();
-        expect(templates.core.apiResult).toBeDefined();
-        expect(templates.core.request).toBeDefined();
+
+        expect(templates.index).toHaveProperty('compiler');
+        expect(templates.exports.model).toHaveProperty('compiler');
+        expect(templates.exports.schema).toHaveProperty('compiler');
+        expect(templates.exports.service).toHaveProperty('compiler');
+        expect(templates.core.settings).toHaveProperty('compiler');
+        expect(templates.core.apiError).toHaveProperty('compiler');
+        expect(templates.core.apiRequestOptions).toHaveProperty('compiler');
+        expect(templates.core.apiResult).toHaveProperty('compiler');
+        expect(templates.core.request).toHaveProperty('compiler');
+    });
+
+    it('should allow template overrides', () => {
+        const templates = registerHandlebarTemplates({
+            httpClient: HttpClient.FETCH,
+            useOptions: false,
+            useUnionTypes: false,
+            templateOverrides: {
+                index: 'override',
+                service: 'override',
+                settings: 'override',
+            },
+        });
+
+        expect(templates.index).toBe('override');
+        expect(templates.exports.model).toHaveProperty('compiler');
+        expect(templates.exports.schema).toHaveProperty('compiler');
+        expect(templates.exports.service).toBe('override');
+        expect(templates.core.settings).toBe('override');
+        expect(templates.core.apiError).toHaveProperty('compiler');
+        expect(templates.core.apiRequestOptions).toHaveProperty('compiler');
+        expect(templates.core.apiResult).toHaveProperty('compiler');
+        expect(templates.core.request).toHaveProperty('compiler');
     });
 });

--- a/src/utils/registerHandlebarTemplates.ts
+++ b/src/utils/registerHandlebarTemplates.ts
@@ -83,7 +83,100 @@ import partialTypeInterface from '../templates/partials/typeInterface.hbs';
 import partialTypeIntersection from '../templates/partials/typeIntersection.hbs';
 import partialTypeReference from '../templates/partials/typeReference.hbs';
 import partialTypeUnion from '../templates/partials/typeUnion.hbs';
+import { preCompileTemplate } from './preCompileTemplate';
 import { registerHandlebarHelpers } from './registerHandlebarHelpers';
+
+export type TemplateOverrideNames =
+    // Main templates (entry points for the files we write to disk)
+    | 'index'
+    | 'client'
+    | 'model'
+    | 'schema'
+    | 'service'
+    | 'settings'
+    | 'apiError'
+    | 'apiRequestOptions'
+    | 'apiResult'
+    | 'cancelablePromise'
+    | 'request'
+    | 'baseHttpRequest'
+    | 'httpRequest'
+    // Partials for the generations of the models, services, etc.
+    | 'exportEnum'
+    | 'exportInterface'
+    | 'exportComposition'
+    | 'exportType'
+    | 'header'
+    | 'isNullable'
+    | 'isReadOnly'
+    | 'isRequired'
+    | 'parameters'
+    | 'result'
+    | 'schema'
+    | 'schemaArray'
+    | 'schemaDictionary'
+    | 'schemaEnum'
+    | 'schemaGeneric'
+    | 'schemaInterface'
+    | 'schemaComposition'
+    | 'type'
+    | 'typeArray'
+    | 'typeDictionary'
+    | 'typeEnum'
+    | 'typeGeneric'
+    | 'typeInterface'
+    | 'typeReference'
+    | 'typeUnion'
+    | 'typeIntersection'
+    | 'base'
+    // Generic functions used in 'request' file @see src/templates/core/request.hbs for more info
+    | 'functions/catchErrorCodes'
+    | 'functions/getFormData'
+    | 'functions/getQueryString'
+    | 'functions/getUrl'
+    | 'functions/isBlob'
+    | 'functions/isDefined'
+    | 'functions/isFormData'
+    | 'functions/isString'
+    | 'functions/isStringWithValue'
+    | 'functions/isSuccess'
+    | 'functions/base64'
+    | 'functions/resolve'
+    // Specific files for the fetch client implementation
+    | 'fetch/getHeaders'
+    | 'fetch/getRequestBody'
+    | 'fetch/getResponseBody'
+    | 'fetch/getResponseHeader'
+    | 'fetch/sendRequest'
+    | 'fetch/request'
+    // Specific files for the xhr client implementation
+    | 'xhr/getHeaders'
+    | 'xhr/getRequestBody'
+    | 'xhr/getResponseBody'
+    | 'xhr/getResponseHeader'
+    | 'xhr/sendRequest'
+    | 'xhr/request'
+    // Specific files for the node client implementation
+    | 'node/getHeaders'
+    | 'node/getRequestBody'
+    | 'node/getResponseBody'
+    | 'node/getResponseHeader'
+    | 'node/sendRequest'
+    | 'node/request'
+    // Specific files for the axios client implementation
+    | 'axios/getHeaders'
+    | 'axios/getRequestBody'
+    | 'axios/getResponseBody'
+    | 'axios/getResponseHeader'
+    | 'axios/sendRequest'
+    | 'axios/request'
+    // Specific files for the angular client implementation
+    | 'angular/getHeaders'
+    | 'angular/getRequestBody'
+    | 'angular/getResponseBody'
+    | 'angular/getResponseHeader'
+    | 'angular/sendRequest'
+    | 'angular/request';
 
 export interface Templates {
     index: Handlebars.TemplateDelegate;
@@ -113,112 +206,119 @@ export const registerHandlebarTemplates = (root: {
     httpClient: HttpClient;
     useOptions: boolean;
     useUnionTypes: boolean;
+    templateOverrides?: Partial<Record<TemplateOverrideNames, string>>;
 }): Templates => {
     registerHandlebarHelpers(root);
+    const useOverride = (builtIn: TemplateSpecification, override?: string) => {
+        return Handlebars.template(preCompileTemplate(override) ?? builtIn);
+    };
+    const registerPartialOverride = (name: TemplateOverrideNames, builtIn: TemplateSpecification) => {
+        return Handlebars.registerPartial(name, useOverride(builtIn, root.templateOverrides?.[name]));
+    };
 
     // Main templates (entry points for the files we write to disk)
     const templates: Templates = {
-        index: Handlebars.template(templateIndex),
-        client: Handlebars.template(templateClient),
+        index: useOverride(templateIndex, root.templateOverrides?.index),
+        client: useOverride(templateClient, root.templateOverrides?.client),
         exports: {
-            model: Handlebars.template(templateExportModel),
-            schema: Handlebars.template(templateExportSchema),
-            service: Handlebars.template(templateExportService),
+            model: useOverride(templateExportModel, root.templateOverrides?.model),
+            schema: useOverride(templateExportSchema, root.templateOverrides?.schema),
+            service: useOverride(templateExportService, root.templateOverrides?.service),
         },
         core: {
-            settings: Handlebars.template(templateCoreSettings),
-            apiError: Handlebars.template(templateCoreApiError),
-            apiRequestOptions: Handlebars.template(templateCoreApiRequestOptions),
-            apiResult: Handlebars.template(templateCoreApiResult),
-            cancelablePromise: Handlebars.template(templateCancelablePromise),
-            request: Handlebars.template(templateCoreRequest),
-            baseHttpRequest: Handlebars.template(templateCoreBaseHttpRequest),
-            httpRequest: Handlebars.template(templateCoreHttpRequest),
+            settings: useOverride(templateCoreSettings, root.templateOverrides?.settings),
+            apiError: useOverride(templateCoreApiError, root.templateOverrides?.apiError),
+            apiRequestOptions: useOverride(templateCoreApiRequestOptions, root.templateOverrides?.apiRequestOptions),
+            apiResult: useOverride(templateCoreApiResult, root.templateOverrides?.apiResult),
+            cancelablePromise: useOverride(templateCancelablePromise, root.templateOverrides?.cancelablePromise),
+            request: useOverride(templateCoreRequest, root.templateOverrides?.request),
+            baseHttpRequest: useOverride(templateCoreBaseHttpRequest, root.templateOverrides?.baseHttpRequest),
+            httpRequest: useOverride(templateCoreHttpRequest, root.templateOverrides?.httpRequest),
         },
     };
 
     // Partials for the generations of the models, services, etc.
-    Handlebars.registerPartial('exportEnum', Handlebars.template(partialExportEnum));
-    Handlebars.registerPartial('exportInterface', Handlebars.template(partialExportInterface));
-    Handlebars.registerPartial('exportComposition', Handlebars.template(partialExportComposition));
-    Handlebars.registerPartial('exportType', Handlebars.template(partialExportType));
-    Handlebars.registerPartial('header', Handlebars.template(partialHeader));
-    Handlebars.registerPartial('isNullable', Handlebars.template(partialIsNullable));
-    Handlebars.registerPartial('isReadOnly', Handlebars.template(partialIsReadOnly));
-    Handlebars.registerPartial('isRequired', Handlebars.template(partialIsRequired));
-    Handlebars.registerPartial('parameters', Handlebars.template(partialParameters));
-    Handlebars.registerPartial('result', Handlebars.template(partialResult));
-    Handlebars.registerPartial('schema', Handlebars.template(partialSchema));
-    Handlebars.registerPartial('schemaArray', Handlebars.template(partialSchemaArray));
-    Handlebars.registerPartial('schemaDictionary', Handlebars.template(partialSchemaDictionary));
-    Handlebars.registerPartial('schemaEnum', Handlebars.template(partialSchemaEnum));
-    Handlebars.registerPartial('schemaGeneric', Handlebars.template(partialSchemaGeneric));
-    Handlebars.registerPartial('schemaInterface', Handlebars.template(partialSchemaInterface));
-    Handlebars.registerPartial('schemaComposition', Handlebars.template(partialSchemaComposition));
-    Handlebars.registerPartial('type', Handlebars.template(partialType));
-    Handlebars.registerPartial('typeArray', Handlebars.template(partialTypeArray));
-    Handlebars.registerPartial('typeDictionary', Handlebars.template(partialTypeDictionary));
-    Handlebars.registerPartial('typeEnum', Handlebars.template(partialTypeEnum));
-    Handlebars.registerPartial('typeGeneric', Handlebars.template(partialTypeGeneric));
-    Handlebars.registerPartial('typeInterface', Handlebars.template(partialTypeInterface));
-    Handlebars.registerPartial('typeReference', Handlebars.template(partialTypeReference));
-    Handlebars.registerPartial('typeUnion', Handlebars.template(partialTypeUnion));
-    Handlebars.registerPartial('typeIntersection', Handlebars.template(partialTypeIntersection));
-    Handlebars.registerPartial('base', Handlebars.template(partialBase));
+    registerPartialOverride('exportEnum', partialExportEnum);
+    registerPartialOverride('exportInterface', partialExportInterface);
+    registerPartialOverride('exportComposition', partialExportComposition);
+    registerPartialOverride('exportType', partialExportType);
+    registerPartialOverride('header', partialHeader);
+    registerPartialOverride('isNullable', partialIsNullable);
+    registerPartialOverride('isReadOnly', partialIsReadOnly);
+    registerPartialOverride('isRequired', partialIsRequired);
+    registerPartialOverride('parameters', partialParameters);
+    registerPartialOverride('result', partialResult);
+    registerPartialOverride('schema', partialSchema);
+    registerPartialOverride('schemaArray', partialSchemaArray);
+    registerPartialOverride('schemaDictionary', partialSchemaDictionary);
+    registerPartialOverride('schemaEnum', partialSchemaEnum);
+    registerPartialOverride('schemaGeneric', partialSchemaGeneric);
+    registerPartialOverride('schemaInterface', partialSchemaInterface);
+    registerPartialOverride('schemaComposition', partialSchemaComposition);
+    registerPartialOverride('type', partialType);
+    registerPartialOverride('typeArray', partialTypeArray);
+    registerPartialOverride('typeDictionary', partialTypeDictionary);
+    registerPartialOverride('typeEnum', partialTypeEnum);
+    registerPartialOverride('typeGeneric', partialTypeGeneric);
+    registerPartialOverride('typeInterface', partialTypeInterface);
+    registerPartialOverride('typeReference', partialTypeReference);
+    registerPartialOverride('typeUnion', partialTypeUnion);
+    registerPartialOverride('typeIntersection', partialTypeIntersection);
+    registerPartialOverride('base', partialBase);
 
     // Generic functions used in 'request' file @see src/templates/core/request.hbs for more info
-    Handlebars.registerPartial('functions/catchErrorCodes', Handlebars.template(functionCatchErrorCodes));
-    Handlebars.registerPartial('functions/getFormData', Handlebars.template(functionGetFormData));
-    Handlebars.registerPartial('functions/getQueryString', Handlebars.template(functionGetQueryString));
-    Handlebars.registerPartial('functions/getUrl', Handlebars.template(functionGetUrl));
-    Handlebars.registerPartial('functions/isBlob', Handlebars.template(functionIsBlob));
-    Handlebars.registerPartial('functions/isDefined', Handlebars.template(functionIsDefined));
-    Handlebars.registerPartial('functions/isFormData', Handlebars.template(functionIsFormData));
-    Handlebars.registerPartial('functions/isString', Handlebars.template(functionIsString));
-    Handlebars.registerPartial('functions/isStringWithValue', Handlebars.template(functionIsStringWithValue));
-    Handlebars.registerPartial('functions/isSuccess', Handlebars.template(functionIsSuccess));
-    Handlebars.registerPartial('functions/base64', Handlebars.template(functionBase64));
-    Handlebars.registerPartial('functions/resolve', Handlebars.template(functionResolve));
+    registerPartialOverride('functions/catchErrorCodes', functionCatchErrorCodes);
+    registerPartialOverride('functions/getFormData', functionGetFormData);
+    registerPartialOverride('functions/getQueryString', functionGetQueryString);
+    registerPartialOverride('functions/getUrl', functionGetUrl);
+    registerPartialOverride('functions/isBlob', functionIsBlob);
+    registerPartialOverride('functions/isDefined', functionIsDefined);
+    registerPartialOverride('functions/isFormData', functionIsFormData);
+    registerPartialOverride('functions/isString', functionIsString);
+    registerPartialOverride('functions/isStringWithValue', functionIsStringWithValue);
+    registerPartialOverride('functions/isSuccess', functionIsSuccess);
+    registerPartialOverride('functions/base64', functionBase64);
+    registerPartialOverride('functions/resolve', functionResolve);
 
     // Specific files for the fetch client implementation
-    Handlebars.registerPartial('fetch/getHeaders', Handlebars.template(fetchGetHeaders));
-    Handlebars.registerPartial('fetch/getRequestBody', Handlebars.template(fetchGetRequestBody));
-    Handlebars.registerPartial('fetch/getResponseBody', Handlebars.template(fetchGetResponseBody));
-    Handlebars.registerPartial('fetch/getResponseHeader', Handlebars.template(fetchGetResponseHeader));
-    Handlebars.registerPartial('fetch/sendRequest', Handlebars.template(fetchSendRequest));
-    Handlebars.registerPartial('fetch/request', Handlebars.template(fetchRequest));
+    registerPartialOverride('fetch/getHeaders', fetchGetHeaders);
+    registerPartialOverride('fetch/getRequestBody', fetchGetRequestBody);
+    registerPartialOverride('fetch/getResponseBody', fetchGetResponseBody);
+    registerPartialOverride('fetch/getResponseHeader', fetchGetResponseHeader);
+    registerPartialOverride('fetch/sendRequest', fetchSendRequest);
+    registerPartialOverride('fetch/request', fetchRequest);
 
     // Specific files for the xhr client implementation
-    Handlebars.registerPartial('xhr/getHeaders', Handlebars.template(xhrGetHeaders));
-    Handlebars.registerPartial('xhr/getRequestBody', Handlebars.template(xhrGetRequestBody));
-    Handlebars.registerPartial('xhr/getResponseBody', Handlebars.template(xhrGetResponseBody));
-    Handlebars.registerPartial('xhr/getResponseHeader', Handlebars.template(xhrGetResponseHeader));
-    Handlebars.registerPartial('xhr/sendRequest', Handlebars.template(xhrSendRequest));
-    Handlebars.registerPartial('xhr/request', Handlebars.template(xhrRequest));
+    registerPartialOverride('xhr/getHeaders', xhrGetHeaders);
+    registerPartialOverride('xhr/getRequestBody', xhrGetRequestBody);
+    registerPartialOverride('xhr/getResponseBody', xhrGetResponseBody);
+    registerPartialOverride('xhr/getResponseHeader', xhrGetResponseHeader);
+    registerPartialOverride('xhr/sendRequest', xhrSendRequest);
+    registerPartialOverride('xhr/request', xhrRequest);
 
     // Specific files for the node client implementation
-    Handlebars.registerPartial('node/getHeaders', Handlebars.template(nodeGetHeaders));
-    Handlebars.registerPartial('node/getRequestBody', Handlebars.template(nodeGetRequestBody));
-    Handlebars.registerPartial('node/getResponseBody', Handlebars.template(nodeGetResponseBody));
-    Handlebars.registerPartial('node/getResponseHeader', Handlebars.template(nodeGetResponseHeader));
-    Handlebars.registerPartial('node/sendRequest', Handlebars.template(nodeSendRequest));
-    Handlebars.registerPartial('node/request', Handlebars.template(nodeRequest));
+    registerPartialOverride('node/getHeaders', nodeGetHeaders);
+    registerPartialOverride('node/getRequestBody', nodeGetRequestBody);
+    registerPartialOverride('node/getResponseBody', nodeGetResponseBody);
+    registerPartialOverride('node/getResponseHeader', nodeGetResponseHeader);
+    registerPartialOverride('node/sendRequest', nodeSendRequest);
+    registerPartialOverride('node/request', nodeRequest);
 
     // Specific files for the axios client implementation
-    Handlebars.registerPartial('axios/getHeaders', Handlebars.template(axiosGetHeaders));
-    Handlebars.registerPartial('axios/getRequestBody', Handlebars.template(axiosGetRequestBody));
-    Handlebars.registerPartial('axios/getResponseBody', Handlebars.template(axiosGetResponseBody));
-    Handlebars.registerPartial('axios/getResponseHeader', Handlebars.template(axiosGetResponseHeader));
-    Handlebars.registerPartial('axios/sendRequest', Handlebars.template(axiosSendRequest));
-    Handlebars.registerPartial('axios/request', Handlebars.template(axiosRequest));
+    registerPartialOverride('axios/getHeaders', axiosGetHeaders);
+    registerPartialOverride('axios/getRequestBody', axiosGetRequestBody);
+    registerPartialOverride('axios/getResponseBody', axiosGetResponseBody);
+    registerPartialOverride('axios/getResponseHeader', axiosGetResponseHeader);
+    registerPartialOverride('axios/sendRequest', axiosSendRequest);
+    registerPartialOverride('axios/request', axiosRequest);
 
     // Specific files for the angular client implementation
-    Handlebars.registerPartial('angular/getHeaders', Handlebars.template(angularGetHeaders));
-    Handlebars.registerPartial('angular/getRequestBody', Handlebars.template(angularGetRequestBody));
-    Handlebars.registerPartial('angular/getResponseBody', Handlebars.template(angularGetResponseBody));
-    Handlebars.registerPartial('angular/getResponseHeader', Handlebars.template(angularGetResponseHeader));
-    Handlebars.registerPartial('angular/sendRequest', Handlebars.template(angularSendRequest));
-    Handlebars.registerPartial('angular/request', Handlebars.template(angularRequest));
+    registerPartialOverride('angular/getHeaders', angularGetHeaders);
+    registerPartialOverride('angular/getRequestBody', angularGetRequestBody);
+    registerPartialOverride('angular/getResponseBody', angularGetResponseBody);
+    registerPartialOverride('angular/getResponseHeader', angularGetResponseHeader);
+    registerPartialOverride('angular/sendRequest', angularSendRequest);
+    registerPartialOverride('angular/request', angularRequest);
 
     return templates;
 };


### PR DESCRIPTION
Introducing a simple, yet dynamic solution to conquer issue #1268 with unparalleled flexibility! 🚀🌟

# Overriding Built-In Templates
The parameter `templateOverrides` allows the override of *any* template or partial with a custom implementation.

## Example:

### package.json
```json
{
    "scripts": {
        "generate": "openapi --input ./spec.json --output ./generated --templateOverrides index:\"Hello World\" service:./templates/service.hbs"
    },
}
```

### NodeJs
```typescript
const OpenAPI = require('openapi-typescript-codegen');

OpenAPI.generate({
    input: './spec.json',
    output: './generated',
    templateOverrides: {
        index: 'Hello World', // the template itslef
        service: 'templates/service.hbs', // or a file path
    },
});
```