### PR TITLE
Accept the commonly used `x-body-name` property in the operation schema to override this name. #2011

### DIFF
--- a/src/openApi/v3/interfaces/OpenApiRequestBody.d.ts
+++ b/src/openApi/v3/interfaces/OpenApiRequestBody.d.ts
@@ -10,4 +10,5 @@ export interface OpenApiRequestBody extends OpenApiReference {
     content: Dictionary<OpenApiMediaType>;
     required?: boolean;
     nullable?: boolean;
+    'x-body-name'?: string;
 }

--- a/src/openApi/v3/parser/getOperationRequestBody.ts
+++ b/src/openApi/v3/parser/getOperationRequestBody.ts
@@ -10,8 +10,8 @@ export const getOperationRequestBody = (openApi: OpenApi, body: OpenApiRequestBo
     const requestBody: OperationParameter = {
         in: 'body',
         export: 'interface',
-        prop: 'requestBody',
-        name: 'requestBody',
+        prop: body['x-body-name'] ?? 'requestBody',
+        name: body['x-body-name'] ?? 'requestBody',
         type: 'any',
         base: 'any',
         template: null,

--- a/src/utils/writeClient.ts
+++ b/src/utils/writeClient.ts
@@ -26,7 +26,6 @@ import { writeClientServices } from './writeClientServices';
  * @param exportServices Generate services
  * @param exportModels Generate models
  * @param exportSchemas Generate schemas
- * @param exportSchemas Generate schemas
  * @param indent Indentation options (4, 2 or tab)
  * @param postfixServices Service name postfix
  * @param postfixModels Model name postfix


### PR DESCRIPTION
In the OpenAPI v3 spec, the `requestBody` does not have a name. By default, it will be passed into the generated function as `requestBody`. Accept the commonly used `x-body-name` property in the operation schema to override this name. #2011