### PR TITLE
feat: added creation of model/schema for inline query parameters

### DIFF
--- a/src/openApi/v3/parser/getModels.ts
+++ b/src/openApi/v3/parser/getModels.ts
@@ -3,9 +3,48 @@ import { reservedWords } from '../../../utils/reservedWords';
 import type { OpenApi } from '../interfaces/OpenApi';
 import { getModel } from './getModel';
 import { getType } from './getType';
+import type { OpenApiPaths } from '../interfaces/OpenApiPaths';
+import { OpenApiSchema } from '../interfaces/OpenApiSchema';
+import { OpenApiParameter } from '../interfaces/OpenApiParameter';
 
 export const getModels = (openApi: OpenApi): Model[] => {
     const models: Model[] = [];
+    for (const url in openApi.paths) {
+        if (!openApi.paths.hasOwnProperty(url)) {
+            continue;
+        }
+        const path = openApi.paths[url];
+        for (const method in path) {
+            if (!path.hasOwnProperty(method)) {
+               continue;
+            }
+            if(method !== 'get') {
+                continue;
+            }
+            const operation = path[method]!;
+            const parameters = operation.parameters;
+            if(!parameters) {
+                continue;
+            }
+            const operationId = operation.operationId;
+            const openApiSchema: OpenApiSchema = {};
+            openApiSchema.type = 'object'
+            openApiSchema.required = []
+            openApiSchema.properties = {};
+            parameters.forEach(param=> {
+                const schema = param.schema;
+                if(schema) {
+                    openApiSchema.properties![param.name] = schema;
+                    if(param.required) {
+                        openApiSchema.required!.push(param.name);
+                    }
+                }
+            })
+            const definitionType = getType(`${operationId}Query`);
+            const model = getModel(openApi, openApiSchema, true, definitionType.base.replace(reservedWords, '_$1'));
+            models.push(model);
+        }
+    }
     if (openApi.components) {
         for (const definitionName in openApi.components.schemas) {
             if (openApi.components.schemas.hasOwnProperty(definitionName)) {


### PR DESCRIPTION
When using inline query parameters inside a get method, the model/schema was not generated at all.

See: https://swagger.io/docs/specification/describing-parameters/

With this change it is possibile to do so.
The name of the Query Dto is {$OperationIdQuery}. 

What this change **does not** consider:
- Reference of model inside a service (you can still cast the model manually during the call)
- Content inline parameters
- Response inline parameters
