### PR TITLE
Non ascii character support

### DIFF
--- a/src/openApi/v2/parser/escapeName.ts
+++ b/src/openApi/v2/parser/escapeName.ts
@@ -1,6 +1,8 @@
+import validTypescriptIdentifierRegex from '../../../utils/validTypescriptIdentifierRegex';
+
 export const escapeName = (value: string): string => {
     if (value || value === '') {
-        const validName = /^[a-zA-Z_$][\w$]+$/g.test(value);
+        const validName = validTypescriptIdentifierRegex.test(value);
         if (!validName) {
             return `'${value}'`;
         }

--- a/src/openApi/v2/parser/getEnum.ts
+++ b/src/openApi/v2/parser/getEnum.ts
@@ -1,4 +1,5 @@
 import type { Enum } from '../../../client/interfaces/Enum';
+import sanitizeEnumName from '../../../utils/sanitizeEnumName';
 
 export const getEnum = (values?: (string | number)[]): Enum[] => {
     if (Array.isArray(values)) {
@@ -19,11 +20,7 @@ export const getEnum = (values?: (string | number)[]): Enum[] => {
                     };
                 }
                 return {
-                    name: String(value)
-                        .replace(/\W+/g, '_')
-                        .replace(/^(\d+)/g, '_$1')
-                        .replace(/([a-z])([A-Z]+)/g, '$1_$2')
-                        .toUpperCase(),
+                    name: sanitizeEnumName(String(value)),
                     value: `'${value.replace(/'/g, "\\'")}'`,
                     type: 'string',
                     description: null,

--- a/src/openApi/v2/parser/getOperationName.ts
+++ b/src/openApi/v2/parser/getOperationName.ts
@@ -1,5 +1,7 @@
 import camelCase from 'camelcase';
 
+import sanitizeOperationName from '../../../utils/sanitizeOperationName';
+
 /**
  * Convert the input value to a correct operation (method) classname.
  * This will use the operation ID - if available - and otherwise fallback
@@ -7,12 +9,7 @@ import camelCase from 'camelcase';
  */
 export const getOperationName = (url: string, method: string, operationId?: string): string => {
     if (operationId) {
-        return camelCase(
-            operationId
-                .replace(/^[^a-zA-Z]+/g, '')
-                .replace(/[^\w\-]+/g, '-')
-                .trim()
-        );
+        return camelCase(sanitizeOperationName(operationId).trim());
     }
 
     const urlWithoutPlaceholders = url

--- a/src/openApi/v2/parser/getOperationParameterName.ts
+++ b/src/openApi/v2/parser/getOperationParameterName.ts
@@ -1,15 +1,13 @@
 import camelCase from 'camelcase';
 
 import { reservedWords } from '../../../utils/reservedWords';
+import sanitizeOperationParameterName from '../../../utils/sanitizeOperationParameterName';
 
 /**
  * Replaces any invalid characters from a parameter name.
  * For example: 'filter.someProperty' becomes 'filterSomeProperty'.
  */
 export const getOperationParameterName = (value: string): string => {
-    const clean = value
-        .replace(/^[^a-zA-Z]+/g, '')
-        .replace(/[^\w\-]+/g, '-')
-        .trim();
+    const clean = sanitizeOperationParameterName(value).trim();
     return camelCase(clean).replace(reservedWords, '_$1');
 };

--- a/src/openApi/v2/parser/getServiceName.ts
+++ b/src/openApi/v2/parser/getServiceName.ts
@@ -1,13 +1,12 @@
 import camelCase from 'camelcase';
 
+import sanitizeServiceName from '../../../utils/sanitizeServiceName';
+
 /**
  * Convert the input value to a correct service name. This converts
  * the input string to PascalCase.
  */
 export const getServiceName = (value: string): string => {
-    const clean = value
-        .replace(/^[^a-zA-Z]+/g, '')
-        .replace(/[^\w\-]+/g, '-')
-        .trim();
+    const clean = sanitizeServiceName(value).trim();
     return camelCase(clean, { pascalCase: true });
 };

--- a/src/openApi/v2/parser/getType.ts
+++ b/src/openApi/v2/parser/getType.ts
@@ -1,10 +1,9 @@
 import type { Type } from '../../../client/interfaces/Type';
+import sanitizeTypeName from '../../../utils/sanitizeTypeName';
 import { getMappedType } from './getMappedType';
 import { stripNamespace } from './stripNamespace';
 
-const encode = (value: string): string => {
-    return value.replace(/^[^a-zA-Z_$]+/g, '').replace(/[^\w$]+/g, '_');
-};
+const encode = (value: string): string => sanitizeTypeName(value);
 
 /**
  * Parse any string value into a type object.

--- a/src/openApi/v3/parser/escapeName.ts
+++ b/src/openApi/v3/parser/escapeName.ts
@@ -1,6 +1,8 @@
+import validTypescriptIdentifierRegex from '../../../utils/validTypescriptIdentifierRegex';
+
 export const escapeName = (value: string): string => {
     if (value || value === '') {
-        const validName = /^[a-zA-Z_$][\w$]+$/g.test(value);
+        const validName = validTypescriptIdentifierRegex.test(value);
         if (!validName) {
             return `'${value}'`;
         }

--- a/src/openApi/v3/parser/getEnum.ts
+++ b/src/openApi/v3/parser/getEnum.ts
@@ -1,4 +1,5 @@
 import type { Enum } from '../../../client/interfaces/Enum';
+import sanitizeEnumName from '../../../utils/sanitizeEnumName';
 
 export const getEnum = (values?: (string | number)[]): Enum[] => {
     if (Array.isArray(values)) {
@@ -19,11 +20,7 @@ export const getEnum = (values?: (string | number)[]): Enum[] => {
                     };
                 }
                 return {
-                    name: String(value)
-                        .replace(/\W+/g, '_')
-                        .replace(/^(\d+)/g, '_$1')
-                        .replace(/([a-z])([A-Z]+)/g, '$1_$2')
-                        .toUpperCase(),
+                    name: sanitizeEnumName(String(value)),
                     value: `'${value.replace(/'/g, "\\'")}'`,
                     type: 'string',
                     description: null,

--- a/src/openApi/v3/parser/getOperationName.ts
+++ b/src/openApi/v3/parser/getOperationName.ts
@@ -1,5 +1,7 @@
 import camelCase from 'camelcase';
 
+import sanitizeOperationName from '../../../utils/sanitizeOperationName';
+
 /**
  * Convert the input value to a correct operation (method) classname.
  * This will use the operation ID - if available - and otherwise fallback
@@ -7,12 +9,7 @@ import camelCase from 'camelcase';
  */
 export const getOperationName = (url: string, method: string, operationId?: string): string => {
     if (operationId) {
-        return camelCase(
-            operationId
-                .replace(/^[^a-zA-Z]+/g, '')
-                .replace(/[^\w\-]+/g, '-')
-                .trim()
-        );
+        return camelCase(sanitizeOperationName(operationId).trim());
     }
 
     const urlWithoutPlaceholders = url

--- a/src/openApi/v3/parser/getOperationParameterName.ts
+++ b/src/openApi/v3/parser/getOperationParameterName.ts
@@ -1,16 +1,13 @@
 import camelCase from 'camelcase';
 
 import { reservedWords } from '../../../utils/reservedWords';
+import sanitizeOperationParameterName from '../../../utils/sanitizeOperationParameterName';
 
 /**
  * Replaces any invalid characters from a parameter name.
  * For example: 'filter.someProperty' becomes 'filterSomeProperty'.
  */
 export const getOperationParameterName = (value: string): string => {
-    const clean = value
-        .replace(/^[^a-zA-Z]+/g, '')
-        .replace('[]', 'Array')
-        .replace(/[^\w\-]+/g, '-')
-        .trim();
+    const clean = sanitizeOperationParameterName(value).trim();
     return camelCase(clean).replace(reservedWords, '_$1');
 };

--- a/src/openApi/v3/parser/getServiceName.spec.ts
+++ b/src/openApi/v3/parser/getServiceName.spec.ts
@@ -9,5 +9,6 @@ describe('getServiceName', () => {
         expect(getServiceName('@fooBar')).toEqual('FooBar');
         expect(getServiceName('$fooBar')).toEqual('FooBar');
         expect(getServiceName('123fooBar')).toEqual('FooBar');
+        expect(getServiceName('non-ascii-æøåÆØÅöôêÊ字符串')).toEqual('NonAsciiÆøåÆøÅöôêÊ字符串');
     });
 });

--- a/src/openApi/v3/parser/getServiceName.ts
+++ b/src/openApi/v3/parser/getServiceName.ts
@@ -1,13 +1,12 @@
 import camelCase from 'camelcase';
 
+import sanitizeServiceName from '../../../utils/sanitizeServiceName';
+
 /**
  * Convert the input value to a correct service name. This converts
  * the input string to PascalCase.
  */
 export const getServiceName = (value: string): string => {
-    const clean = value
-        .replace(/^[^a-zA-Z]+/g, '')
-        .replace(/[^\w\-]+/g, '-')
-        .trim();
+    const clean = sanitizeServiceName(value).trim();
     return camelCase(clean, { pascalCase: true });
 };

--- a/src/openApi/v3/parser/getType.ts
+++ b/src/openApi/v3/parser/getType.ts
@@ -1,11 +1,10 @@
 import type { Type } from '../../../client/interfaces/Type';
 import { isDefined } from '../../../utils/isDefined';
+import sanitizeTypeName from '../../../utils/sanitizeTypeName';
 import { getMappedType } from './getMappedType';
 import { stripNamespace } from './stripNamespace';
 
-const encode = (value: string): string => {
-    return value.replace(/^[^a-zA-Z_$]+/g, '').replace(/[^\w$]+/g, '_');
-};
+const encode = (value: string): string => sanitizeTypeName(value);
 
 /**
  * Parse any string value into a type object.

--- a/src/utils/sanitizeEnumName.spec.ts
+++ b/src/utils/sanitizeEnumName.spec.ts
@@ -1,0 +1,11 @@
+import sanitizeEnumName from './sanitizeEnumName';
+
+describe('sanitizeEnumName', () => {
+    it('should replace illegal characters', () => {
+        expect(sanitizeEnumName('abc')).toEqual('ABC');
+        expect(sanitizeEnumName('æbc')).toEqual('ÆBC');
+        expect(sanitizeEnumName('æb.c')).toEqual('ÆB_C');
+        expect(sanitizeEnumName('1æb.c')).toEqual('_1ÆB_C');
+        expect(sanitizeEnumName("'quoted'")).toEqual('_QUOTED_');
+    });
+});

--- a/src/utils/sanitizeEnumName.ts
+++ b/src/utils/sanitizeEnumName.ts
@@ -1,0 +1,18 @@
+/**
+ * Sanitizes names of enums, so they are valid typescript identifiers of a certain form.
+ *
+ * 1: Replace all characters not legal as part of identifier with '_'
+ * 2: Add '_' prefix if first character of enum name has character not legal for start of identifier
+ * 3: Add '_' where the string transitions from lowercase to uppercase
+ * 4: Transform the whole string to uppercase
+ *
+ * Javascript identifier regexp pattern retrieved from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers
+ */
+const sanitizeEnumName = (name: string) =>
+    name
+        .replace(/[^$\u200c\u200d\p{ID_Continue}]/gu, '_')
+        .replace(/^([^$_\p{ID_Start}])/u, '_$1')
+        .replace(/(\p{Lowercase})(\p{Uppercase}+)/gu, '$1_$2')
+        .toUpperCase();
+
+export default sanitizeEnumName;

--- a/src/utils/sanitizeOperationName.ts
+++ b/src/utils/sanitizeOperationName.ts
@@ -1,0 +1,7 @@
+import sanitizeServiceName from './sanitizeServiceName';
+
+/**
+ * sanitizeOperationName does the same as sanitizeServiceName.
+ */
+const sanitizeOperationName = sanitizeServiceName;
+export default sanitizeOperationName;

--- a/src/utils/sanitizeOperationParameterName.ts
+++ b/src/utils/sanitizeOperationParameterName.ts
@@ -1,0 +1,7 @@
+import sanitizeOperationName from './sanitizeOperationName';
+
+const sanitizeOperationParameterName = (name: string): string => {
+    const withoutBrackets = name.replace('[]', 'Array');
+    return sanitizeOperationName(withoutBrackets);
+};
+export default sanitizeOperationParameterName;

--- a/src/utils/sanitizeServiceName.ts
+++ b/src/utils/sanitizeServiceName.ts
@@ -1,0 +1,18 @@
+/**
+ * Sanitizes service names, so they are valid typescript identifiers of a certain form.
+ *
+ * 1: Remove any leading characters that are illegal as starting character of a typescript identifier.
+ * 2: Replace illegal characters in remaining part of type name with underscore (-).
+ *
+ * Step 1 should perhaps instead also replace illegal characters with underscore, or prefix with it, like sanitizeEnumName
+ * does. The way this is now one could perhaps end up removing all characters, if all are illegal start characters. It
+ * would be sort of a breaking change to do so, though, previously generated code might change then.
+ *
+ * Javascript identifier regexp pattern retrieved from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers
+ *
+ * The output of this is expected to be converted to PascalCase
+ */
+const sanitizeServiceName = (name: string) =>
+    name.replace(/^[^\p{ID_Start}]+/u, '').replace(/[^$\u200c\u200d\p{ID_Continue}]/gu, '-');
+
+export default sanitizeServiceName;

--- a/src/utils/sanitizeTypeName.spec.ts
+++ b/src/utils/sanitizeTypeName.spec.ts
@@ -1,0 +1,10 @@
+import sanitizeTypeName from './sanitizeTypeName';
+
+describe('sanitizeTypeName', () => {
+    it('should remove/replace illegal characters', () => {
+        expect(sanitizeTypeName('abc')).toEqual('abc');
+        expect(sanitizeTypeName('æbc')).toEqual('æbc');
+        expect(sanitizeTypeName('æb.c')).toEqual('æb_c');
+        expect(sanitizeTypeName('1æb.c')).toEqual('æb_c');
+    });
+});

--- a/src/utils/sanitizeTypeName.ts
+++ b/src/utils/sanitizeTypeName.ts
@@ -1,0 +1,16 @@
+/**
+ * Sanitizes names of types, so they are valid typescript identifiers of a certain form.
+ *
+ * 1: Remove any leading characters that are illegal as starting character of a typescript identifier.
+ * 2: Replace illegal characters in remaining part of type name with underscore (_).
+ *
+ * Step 1 should perhaps instead also replace illegal characters with underscore, or prefix with it, like sanitizeEnumName
+ * does. The way this is now one could perhaps end up removing all characters, if all are illegal start characters. It
+ * would be sort of a breaking change to do so, though, previously generated code might change then.
+ *
+ * Javascript identifier regexp pattern retrieved from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers
+ */
+const sanitizeTypeName = (name: string) =>
+    name.replace(/^[^$_\p{ID_Start}]+/u, '').replace(/[^$\u200c\u200d\p{ID_Continue}]/gu, '_');
+
+export default sanitizeTypeName;

--- a/src/utils/validTypescriptIdentifierRegex.ts
+++ b/src/utils/validTypescriptIdentifierRegex.ts
@@ -1,0 +1,4 @@
+// Javascript identifier regexp pattern retrieved from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers
+const validTypescriptIdentifierRegex = /^[$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*$/u;
+
+export default validTypescriptIdentifierRegex;

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -614,6 +614,7 @@ export type { ModelWithPattern } from './models/ModelWithPattern';
 export type { ModelWithProperties } from './models/ModelWithProperties';
 export type { ModelWithReference } from './models/ModelWithReference';
 export type { ModelWithString } from './models/ModelWithString';
+export type { NonAsciiStringæøåÆØÅöôêÊ } from './models/NonAsciiStringæøåÆØÅöôêÊ';
 export type { SimpleBoolean } from './models/SimpleBoolean';
 export type { SimpleFile } from './models/SimpleFile';
 export type { SimpleInteger } from './models/SimpleInteger';
@@ -663,6 +664,7 @@ export { $ModelWithPattern } from './schemas/$ModelWithPattern';
 export { $ModelWithProperties } from './schemas/$ModelWithProperties';
 export { $ModelWithReference } from './schemas/$ModelWithReference';
 export { $ModelWithString } from './schemas/$ModelWithString';
+export { $NonAsciiStringæøåÆØÅöôêÊ } from './schemas/$NonAsciiStringæøåÆØÅöôêÊ';
 export { $SimpleBoolean } from './schemas/$SimpleBoolean';
 export { $SimpleFile } from './schemas/$SimpleFile';
 export { $SimpleInteger } from './schemas/$SimpleInteger';
@@ -1009,6 +1011,7 @@ export enum EnumWithStrings {
     ERROR = 'Error',
     _SINGLE_QUOTE_ = '\\'Single Quote\\'',
     _DOUBLE_QUOTES_ = '"Double Quotes"',
+    NON_ASCII__ØÆÅÔÖ_ØÆÅÔÖ = 'Non-ascii: øæåôöØÆÅÔÖ',
 }
 "
 `;
@@ -1178,6 +1181,7 @@ export namespace ModelWithEnum {
         SUCCESS = 'Success',
         WARNING = 'Warning',
         ERROR = 'Error',
+        ØÆÅ = 'ØÆÅ',
     }
     /**
      * These are the HTTP error code enums
@@ -1385,6 +1389,30 @@ export type ModelWithString = {
     prop?: string;
 };
 
+"
+`;
+
+exports[`v2 should generate: test/generated/v2/models/NonAsciiStringæøåÆØÅöôêÊ.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * A string with non-ascii (unicode) characters valid in typescript identifiers (æøåÆØÅöÔèÈ)
+ */
+export type NonAsciiStringæøåÆØÅöôêÊ = string;
+"
+`;
+
+exports[`v2 should generate: test/generated/v2/models/NonAsciiStringæøåÆØÅöôêÊ字符串.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * A string with non-ascii (unicode) characters valid in typescript identifiers (æøåÆØÅöÔèÈ字符串)
+ */
+export type NonAsciiStringæøåÆØÅöôêÊ字符串 = string;
 "
 `;
 
@@ -2252,6 +2280,30 @@ export const $ModelWithString = {
             description: \`This is a simple string property\`,
         },
     },
+} as const;
+"
+`;
+
+exports[`v2 should generate: test/generated/v2/schemas/$NonAsciiStringæøåÆØÅöôêÊ.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $NonAsciiStringæøåÆØÅöôêÊ = {
+    type: 'string',
+    description: \`A string with non-ascii (unicode) characters valid in typescript identifiers (æøåÆØÅöÔèÈ)\`,
+} as const;
+"
+`;
+
+exports[`v2 should generate: test/generated/v2/schemas/$NonAsciiStringæøåÆØÅöôêÊ字符串.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $NonAsciiStringæøåÆØÅöôêÊ字符串 = {
+    type: 'string',
+    description: \`A string with non-ascii (unicode) characters valid in typescript identifiers (æøåÆØÅöÔèÈ字符串)\`,
 } as const;
 "
 `;
@@ -3728,6 +3780,7 @@ export type { ModelWithPattern } from './models/ModelWithPattern';
 export type { ModelWithProperties } from './models/ModelWithProperties';
 export type { ModelWithReference } from './models/ModelWithReference';
 export type { ModelWithString } from './models/ModelWithString';
+export type { NonAsciiStringæøåÆØÅöôêÊ } from './models/NonAsciiStringæøåÆØÅöôêÊ';
 export type { Pageable } from './models/Pageable';
 export type { SimpleBoolean } from './models/SimpleBoolean';
 export type { SimpleFile } from './models/SimpleFile';
@@ -3798,6 +3851,7 @@ export { $ModelWithPattern } from './schemas/$ModelWithPattern';
 export { $ModelWithProperties } from './schemas/$ModelWithProperties';
 export { $ModelWithReference } from './schemas/$ModelWithReference';
 export { $ModelWithString } from './schemas/$ModelWithString';
+export { $NonAsciiStringæøåÆØÅöôêÊ } from './schemas/$NonAsciiStringæøåÆØÅöôêÊ';
 export { $Pageable } from './schemas/$Pageable';
 export { $SimpleBoolean } from './schemas/$SimpleBoolean';
 export { $SimpleFile } from './schemas/$SimpleFile';
@@ -4385,6 +4439,7 @@ export enum EnumWithStrings {
     ERROR = 'Error',
     _SINGLE_QUOTE_ = '\\'Single Quote\\'',
     _DOUBLE_QUOTES_ = '"Double Quotes"',
+    NON_ASCII__ØÆÅÔÖ_ØÆÅÔÖ = 'Non-ascii: øæåôöØÆÅÔÖ',
 }
 "
 `;
@@ -4638,6 +4693,7 @@ export namespace ModelWithEnum {
         SUCCESS = 'Success',
         WARNING = 'Warning',
         ERROR = 'Error',
+        ØÆÅ = 'ØÆÅ',
     }
     /**
      * These are the HTTP error code enums
@@ -4854,6 +4910,30 @@ export type ModelWithString = {
     prop?: string;
 };
 
+"
+`;
+
+exports[`v3 should generate: test/generated/v3/models/NonAsciiStringæøåÆØÅöôêÊ.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * A string with non-ascii (unicode) characters valid in typescript identifiers (æøåÆØÅöÔèÈ)
+ */
+export type NonAsciiStringæøåÆØÅöôêÊ = string;
+"
+`;
+
+exports[`v3 should generate: test/generated/v3/models/NonAsciiStringæøåÆØÅöôêÊ字符串.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * A string with non-ascii (unicode) characters valid in typescript identifiers (æøåÆØÅöÔèÈ字符串)
+ */
+export type NonAsciiStringæøåÆØÅöôêÊ字符串 = string;
 "
 `;
 
@@ -6243,6 +6323,30 @@ export const $ModelWithString = {
             description: \`This is a simple string property\`,
         },
     },
+} as const;
+"
+`;
+
+exports[`v3 should generate: test/generated/v3/schemas/$NonAsciiStringæøåÆØÅöôêÊ.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $NonAsciiStringæøåÆØÅöôêÊ = {
+    type: 'string',
+    description: \`A string with non-ascii (unicode) characters valid in typescript identifiers (æøåÆØÅöÔèÈ)\`,
+} as const;
+"
+`;
+
+exports[`v3 should generate: test/generated/v3/schemas/$NonAsciiStringæøåÆØÅöôêÊ字符串.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $NonAsciiStringæøåÆØÅöôêÊ字符串 = {
+    type: 'string',
+    description: \`A string with non-ascii (unicode) characters valid in typescript identifiers (æøåÆØÅöÔèÈ字符串)\`,
 } as const;
 "
 `;

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -684,6 +684,7 @@ export { MultipleTags1Service } from './services/MultipleTags1Service';
 export { MultipleTags2Service } from './services/MultipleTags2Service';
 export { MultipleTags3Service } from './services/MultipleTags3Service';
 export { NoContentService } from './services/NoContentService';
+export { NonAsciiÆøåÆøÅöôêÊService } from './services/NonAsciiÆøåÆøÅöôêÊService';
 export { ParametersService } from './services/ParametersService';
 export { ResponseService } from './services/ResponseService';
 export { SimpleService } from './services/SimpleService';
@@ -2841,6 +2842,36 @@ export class NoContentService {
 "
 `;
 
+exports[`v2 should generate: test/generated/v2/services/NonAsciiÆøåÆøÅöôêÊService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { NonAsciiStringæøåÆØÅöôêÊ字符串 } from '../models/NonAsciiStringæøåÆØÅöôêÊ字符串';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class NonAsciiÆøåÆøÅöôêÊService {
+    /**
+     * @param nonAsciiParamæøåÆøÅöôêÊ Dummy input param
+     * @returns NonAsciiStringæøåÆØÅöôêÊ字符串 Successful response
+     * @throws ApiError
+     */
+    public static nonAsciiæøåÆøÅöôêÊ字符串(
+        nonAsciiParamæøåÆøÅöôêÊ: number,
+    ): CancelablePromise<NonAsciiStringæøåÆØÅöôêÊ字符串> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',
+            query: {
+                'nonAsciiParamæøåÆØÅöôêÊ': nonAsciiParamæøåÆøÅöôêÊ,
+            },
+        });
+    }
+}
+"
+`;
+
 exports[`v2 should generate: test/generated/v2/services/ParametersService.ts 1`] = `
 "/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
@@ -3852,6 +3883,7 @@ export { MultipleTags1Service } from './services/MultipleTags1Service';
 export { MultipleTags2Service } from './services/MultipleTags2Service';
 export { MultipleTags3Service } from './services/MultipleTags3Service';
 export { NoContentService } from './services/NoContentService';
+export { NonAsciiÆøåÆøÅöôêÊService } from './services/NonAsciiÆøåÆøÅöôêÊService';
 export { ParametersService } from './services/ParametersService';
 export { RequestBodyService } from './services/RequestBodyService';
 export { ResponseService } from './services/ResponseService';
@@ -7039,6 +7071,36 @@ export class NoContentService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v{api-version}/no-content',
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate: test/generated/v3/services/NonAsciiÆøåÆøÅöôêÊService.ts 1`] = `
+"/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { NonAsciiStringæøåÆØÅöôêÊ字符串 } from '../models/NonAsciiStringæøåÆØÅöôêÊ字符串';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class NonAsciiÆøåÆøÅöôêÊService {
+    /**
+     * @param nonAsciiParamæøåÆøÅöôêÊ Dummy input param
+     * @returns NonAsciiStringæøåÆØÅöôêÊ字符串 Successful response
+     * @throws ApiError
+     */
+    public static nonAsciiæøåÆøÅöôêÊ字符串(
+        nonAsciiParamæøåÆøÅöôêÊ: number,
+    ): CancelablePromise<Array<NonAsciiStringæøåÆØÅöôêÊ字符串>> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',
+            query: {
+                'nonAsciiParamæøåÆØÅöôêÊ': nonAsciiParamæøåÆøÅöôêÊ,
+            },
         });
     }
 }

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -614,7 +614,7 @@ export type { ModelWithPattern } from './models/ModelWithPattern';
 export type { ModelWithProperties } from './models/ModelWithProperties';
 export type { ModelWithReference } from './models/ModelWithReference';
 export type { ModelWithString } from './models/ModelWithString';
-export type { NonAsciiStringæøåÆØÅöôêÊ } from './models/NonAsciiStringæøåÆØÅöôêÊ';
+export type { NonAsciiStringæøåÆØÅöôêÊ字符串 } from './models/NonAsciiStringæøåÆØÅöôêÊ字符串';
 export type { SimpleBoolean } from './models/SimpleBoolean';
 export type { SimpleFile } from './models/SimpleFile';
 export type { SimpleInteger } from './models/SimpleInteger';
@@ -664,7 +664,7 @@ export { $ModelWithPattern } from './schemas/$ModelWithPattern';
 export { $ModelWithProperties } from './schemas/$ModelWithProperties';
 export { $ModelWithReference } from './schemas/$ModelWithReference';
 export { $ModelWithString } from './schemas/$ModelWithString';
-export { $NonAsciiStringæøåÆØÅöôêÊ } from './schemas/$NonAsciiStringæøåÆØÅöôêÊ';
+export { $NonAsciiStringæøåÆØÅöôêÊ字符串 } from './schemas/$NonAsciiStringæøåÆØÅöôêÊ字符串';
 export { $SimpleBoolean } from './schemas/$SimpleBoolean';
 export { $SimpleFile } from './schemas/$SimpleFile';
 export { $SimpleInteger } from './schemas/$SimpleInteger';
@@ -1011,7 +1011,7 @@ export enum EnumWithStrings {
     ERROR = 'Error',
     _SINGLE_QUOTE_ = '\\'Single Quote\\'',
     _DOUBLE_QUOTES_ = '"Double Quotes"',
-    NON_ASCII__ØÆÅÔÖ_ØÆÅÔÖ = 'Non-ascii: øæåôöØÆÅÔÖ',
+    NON_ASCII__ØÆÅÔÖ_ØÆÅÔÖ字符串 = 'Non-ascii: øæåôöØÆÅÔÖ字符串',
 }
 "
 `;
@@ -1181,7 +1181,7 @@ export namespace ModelWithEnum {
         SUCCESS = 'Success',
         WARNING = 'Warning',
         ERROR = 'Error',
-        ØÆÅ = 'ØÆÅ',
+        ØÆÅ字符串 = 'ØÆÅ字符串',
     }
     /**
      * These are the HTTP error code enums
@@ -1389,18 +1389,6 @@ export type ModelWithString = {
     prop?: string;
 };
 
-"
-`;
-
-exports[`v2 should generate: test/generated/v2/models/NonAsciiStringæøåÆØÅöôêÊ.ts 1`] = `
-"/* generated using openapi-typescript-codegen -- do no edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
-/**
- * A string with non-ascii (unicode) characters valid in typescript identifiers (æøåÆØÅöÔèÈ)
- */
-export type NonAsciiStringæøåÆØÅöôêÊ = string;
 "
 `;
 
@@ -2280,18 +2268,6 @@ export const $ModelWithString = {
             description: \`This is a simple string property\`,
         },
     },
-} as const;
-"
-`;
-
-exports[`v2 should generate: test/generated/v2/schemas/$NonAsciiStringæøåÆØÅöôêÊ.ts 1`] = `
-"/* generated using openapi-typescript-codegen -- do no edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
-export const $NonAsciiStringæøåÆØÅöôêÊ = {
-    type: 'string',
-    description: \`A string with non-ascii (unicode) characters valid in typescript identifiers (æøåÆØÅöÔèÈ)\`,
 } as const;
 "
 `;
@@ -3780,7 +3756,7 @@ export type { ModelWithPattern } from './models/ModelWithPattern';
 export type { ModelWithProperties } from './models/ModelWithProperties';
 export type { ModelWithReference } from './models/ModelWithReference';
 export type { ModelWithString } from './models/ModelWithString';
-export type { NonAsciiStringæøåÆØÅöôêÊ } from './models/NonAsciiStringæøåÆØÅöôêÊ';
+export type { NonAsciiStringæøåÆØÅöôêÊ字符串 } from './models/NonAsciiStringæøåÆØÅöôêÊ字符串';
 export type { Pageable } from './models/Pageable';
 export type { SimpleBoolean } from './models/SimpleBoolean';
 export type { SimpleFile } from './models/SimpleFile';
@@ -3851,7 +3827,7 @@ export { $ModelWithPattern } from './schemas/$ModelWithPattern';
 export { $ModelWithProperties } from './schemas/$ModelWithProperties';
 export { $ModelWithReference } from './schemas/$ModelWithReference';
 export { $ModelWithString } from './schemas/$ModelWithString';
-export { $NonAsciiStringæøåÆØÅöôêÊ } from './schemas/$NonAsciiStringæøåÆØÅöôêÊ';
+export { $NonAsciiStringæøåÆØÅöôêÊ字符串 } from './schemas/$NonAsciiStringæøåÆØÅöôêÊ字符串';
 export { $Pageable } from './schemas/$Pageable';
 export { $SimpleBoolean } from './schemas/$SimpleBoolean';
 export { $SimpleFile } from './schemas/$SimpleFile';
@@ -4439,7 +4415,7 @@ export enum EnumWithStrings {
     ERROR = 'Error',
     _SINGLE_QUOTE_ = '\\'Single Quote\\'',
     _DOUBLE_QUOTES_ = '"Double Quotes"',
-    NON_ASCII__ØÆÅÔÖ_ØÆÅÔÖ = 'Non-ascii: øæåôöØÆÅÔÖ',
+    NON_ASCII__ØÆÅÔÖ_ØÆÅÔÖ字符串 = 'Non-ascii: øæåôöØÆÅÔÖ字符串',
 }
 "
 `;
@@ -4693,7 +4669,7 @@ export namespace ModelWithEnum {
         SUCCESS = 'Success',
         WARNING = 'Warning',
         ERROR = 'Error',
-        ØÆÅ = 'ØÆÅ',
+        ØÆÅ字符串 = 'ØÆÅ字符串',
     }
     /**
      * These are the HTTP error code enums
@@ -4910,18 +4886,6 @@ export type ModelWithString = {
     prop?: string;
 };
 
-"
-`;
-
-exports[`v3 should generate: test/generated/v3/models/NonAsciiStringæøåÆØÅöôêÊ.ts 1`] = `
-"/* generated using openapi-typescript-codegen -- do no edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
-/**
- * A string with non-ascii (unicode) characters valid in typescript identifiers (æøåÆØÅöÔèÈ)
- */
-export type NonAsciiStringæøåÆØÅöôêÊ = string;
 "
 `;
 
@@ -6323,18 +6287,6 @@ export const $ModelWithString = {
             description: \`This is a simple string property\`,
         },
     },
-} as const;
-"
-`;
-
-exports[`v3 should generate: test/generated/v3/schemas/$NonAsciiStringæøåÆØÅöôêÊ.ts 1`] = `
-"/* generated using openapi-typescript-codegen -- do no edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
-export const $NonAsciiStringæøåÆØÅöôêÊ = {
-    type: 'string',
-    description: \`A string with non-ascii (unicode) characters valid in typescript identifiers (æøåÆØÅöÔèÈ)\`,
 } as const;
 "
 `;

--- a/test/spec/v2.json
+++ b/test/spec/v2.json
@@ -905,6 +905,33 @@
                     }
                 }
             }
+        },
+        "/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串": {
+            "post": {
+                "tags": [
+                    "Non-Ascii-æøåÆØÅöôêÊ"
+                ],
+                "operationId": "nonAsciiæøåÆØÅöôêÊ字符串",
+                "parameters": [
+                    {
+                        "description": "Dummy input param",
+                        "name": "nonAsciiParamæøåÆØÅöôêÊ",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "schema": {
+                            "$ref": "#/definitions/NonAsciiStringæøåÆØÅöôêÊ字符串"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {

--- a/test/spec/v2.json
+++ b/test/spec/v2.json
@@ -944,6 +944,10 @@
             "description": "This is a simple string",
             "type": "string"
         },
+        "NonAsciiStringæøåÆØÅöôêÊ字符串": {
+            "description": "A string with non-ascii (unicode) characters valid in typescript identifiers (æøåÆØÅöÔèÈ字符串)",
+            "type": "string"
+        },
         "SimpleFile": {
             "description": "This is a simple file",
             "type": "file"
@@ -965,7 +969,8 @@
                 "Warning",
                 "Error",
                 "'Single Quote'",
-                "\"Double Quotes\""
+                "\"Double Quotes\"",
+                "Non-ascii: øæåôöØÆÅÔÖ字符串"
             ]
         },
         "EnumWithNumbers": {
@@ -1174,7 +1179,8 @@
                     "enum": [
                         "Success",
                         "Warning",
-                        "Error"
+                        "Error",
+                        "ØÆÅ字符串"
                     ]
                 },
                 "statusCode": {

--- a/test/spec/v3.json
+++ b/test/spec/v3.json
@@ -1464,6 +1464,40 @@
                     }
                 }
             }
+        },
+        "/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串": {
+            "post": {
+                "tags": [
+                    "Non-Ascii-æøåÆØÅöôêÊ"
+                ],
+                "operationId": "nonAsciiæøåÆØÅöôêÊ字符串",
+                "parameters": [
+                    {
+                        "description": "Dummy input param",
+                        "name": "nonAsciiParamæøåÆØÅöôêÊ",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/NonAsciiStringæøåÆØÅöôêÊ字符串"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {

--- a/test/spec/v3.json
+++ b/test/spec/v3.json
@@ -1539,6 +1539,10 @@
                 "description": "This is a simple string",
                 "type": "string"
             },
+            "NonAsciiStringæøåÆØÅöôêÊ字符串": {
+                "description": "A string with non-ascii (unicode) characters valid in typescript identifiers (æøåÆØÅöÔèÈ字符串)",
+                "type": "string"
+            },
             "SimpleFile": {
                 "description": "This is a simple file",
                 "type": "file"
@@ -1561,7 +1565,8 @@
                     "Warning",
                     "Error",
                     "'Single Quote'",
-                    "\"Double Quotes\""
+                    "\"Double Quotes\"",
+                    "Non-ascii: øæåôöØÆÅÔÖ字符串"
                 ]
             },
             "EnumWithNumbers": {
@@ -1781,7 +1786,8 @@
                         "enum": [
                             "Success",
                             "Warning",
-                            "Error"
+                            "Error",
+                            "ØÆÅ字符串"
                         ]
                     },
                     "statusCode": {


### PR DESCRIPTION
This replaces regexp patterns that only worked with ascii characters with more proper matching that supports unicode identifiers in typescript/javascript.

So that the generated code can have valid unicode characters in enum, type, service, operation and parameter names.

The platform must support "unicode-aware mode" (the u flag) for this to work. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode

This PR replaces #2038 