### PR TITLE
allow operationId be ignored when generating operation names

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -19,6 +19,7 @@ const params = program
     .option('--exportCore <value>', 'Write core files to disk', true)
     .option('--exportServices <value>', 'Write services to disk', true)
     .option('--exportModels <value>', 'Write models to disk', true)
+    .option('--ignoreOperationId <value>', 'Use operation id', true)
     .option('--exportSchemas <value>', 'Write schemas to disk', false)
     .option('--indent <value>', 'Indentation options [4, 2, tabs]', '4')
     .option('--postfixServices <value>', 'Service name postfix', 'Service')
@@ -41,6 +42,7 @@ if (OpenAPI) {
         exportServices: JSON.parse(params.exportServices) === true,
         exportModels: JSON.parse(params.exportModels) === true,
         exportSchemas: JSON.parse(params.exportSchemas) === true,
+        ignoreOperationId: JSON.parse(params.ignoreOperationId) === true,
         indent: params.indent,
         postfixServices: params.postfixServices,
         postfixModels: params.postfixModels,

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export type Options = {
     exportServices?: boolean;
     exportModels?: boolean;
     exportSchemas?: boolean;
+    ignoreOperationId?: boolean;
     indent?: Indent;
     postfixServices?: string;
     postfixModels?: string;
@@ -44,6 +45,7 @@ export type Options = {
  * @param exportServices Generate services
  * @param exportModels Generate models
  * @param exportSchemas Generate schemas
+ * @param ignoreOperationId Ignore operationId
  * @param indent Indentation options (4, 2 or tab)
  * @param postfixServices Service name postfix
  * @param postfixModels Model name postfix
@@ -61,6 +63,7 @@ export const generate = async ({
     exportServices = true,
     exportModels = true,
     exportSchemas = false,
+    ignoreOperationId = false,
     indent = Indent.SPACE_4,
     postfixServices = 'Service',
     postfixModels = '',
@@ -101,7 +104,7 @@ export const generate = async ({
         }
 
         case OpenApiVersion.V3: {
-            const client = parseV3(openApi);
+            const client = parseV3(openApi, ignoreOperationId);
             const clientFinal = postProcessClient(client);
             if (!write) break;
             await writeClient(

--- a/src/openApi/v3/index.ts
+++ b/src/openApi/v3/index.ts
@@ -8,13 +8,14 @@ import { getServiceVersion } from './parser/getServiceVersion';
 /**
  * Parse the OpenAPI specification to a Client model that contains
  * all the models, services and schema's we should output.
- * @param openApi The OpenAPI spec  that we have loaded from disk.
+ * @param openApi The OpenAPI spec that we have loaded from disk.
+ * @param ignoreOperationId should the operationId be ignored when generating operation names
  */
-export const parse = (openApi: OpenApi): Client => {
+export const parse = (openApi: OpenApi, ignoreOperationId: boolean): Client => {
     const version = getServiceVersion(openApi.info.version);
     const server = getServer(openApi);
     const models = getModels(openApi);
-    const services = getServices(openApi);
+    const services = getServices(openApi, ignoreOperationId);
 
     return { version, server, models, services };
 };

--- a/src/openApi/v3/parser/getOperation.ts
+++ b/src/openApi/v3/parser/getOperation.ts
@@ -20,10 +20,11 @@ export const getOperation = (
     method: string,
     tag: string,
     op: OpenApiOperation,
-    pathParams: OperationParameters
+    pathParams: OperationParameters,
+    ignoreOperationId: boolean
 ): Operation => {
     const serviceName = getServiceName(tag);
-    const operationName = getOperationName(url, method, op.operationId);
+    const operationName = getOperationName(url, method, ignoreOperationId, op.operationId);
 
     // Create a new operation object for this method.
     const operation: Operation = {

--- a/src/openApi/v3/parser/getOperationName.spec.ts
+++ b/src/openApi/v3/parser/getOperationName.spec.ts
@@ -2,26 +2,32 @@ import { getOperationName } from './getOperationName';
 
 describe('getOperationName', () => {
     it('should produce correct result', () => {
-        expect(getOperationName('/api/v{api-version}/users', 'GET', 'GetAllUsers')).toEqual('getAllUsers');
-        expect(getOperationName('/api/v{api-version}/users', 'GET', undefined)).toEqual('getApiUsers');
-        expect(getOperationName('/api/v{api-version}/users', 'POST', undefined)).toEqual('postApiUsers');
-        expect(getOperationName('/api/v1/users', 'GET', 'GetAllUsers')).toEqual('getAllUsers');
-        expect(getOperationName('/api/v1/users', 'GET', undefined)).toEqual('getApiV1Users');
-        expect(getOperationName('/api/v1/users', 'POST', undefined)).toEqual('postApiV1Users');
-        expect(getOperationName('/api/v1/users/{id}', 'GET', undefined)).toEqual('getApiV1Users');
-        expect(getOperationName('/api/v1/users/{id}', 'POST', undefined)).toEqual('postApiV1Users');
+        expect(getOperationName('/api/v{api-version}/users', 'GET', false, 'GetAllUsers')).toEqual('getAllUsers');
+        expect(getOperationName('/api/v{api-version}/users', 'GET', false, undefined)).toEqual('getApiUsers');
+        expect(getOperationName('/api/v{api-version}/users', 'POST', false, undefined)).toEqual('postApiUsers');
+        expect(getOperationName('/api/v1/users', 'GET', false, 'GetAllUsers')).toEqual('getAllUsers');
+        expect(getOperationName('/api/v1/users', 'GET', false, undefined)).toEqual('getApiV1Users');
+        expect(getOperationName('/api/v1/users', 'POST', false, undefined)).toEqual('postApiV1Users');
+        expect(getOperationName('/api/v1/users/{id}', 'GET', false, undefined)).toEqual('getApiV1UsersById');
+        expect(getOperationName('/api/v1/users/{id}', 'POST', false, undefined)).toEqual('postApiV1UsersById');
 
-        expect(getOperationName('/api/v{api-version}/users', 'GET', 'fooBar')).toEqual('fooBar');
-        expect(getOperationName('/api/v{api-version}/users', 'GET', 'FooBar')).toEqual('fooBar');
-        expect(getOperationName('/api/v{api-version}/users', 'GET', 'Foo Bar')).toEqual('fooBar');
-        expect(getOperationName('/api/v{api-version}/users', 'GET', 'foo bar')).toEqual('fooBar');
-        expect(getOperationName('/api/v{api-version}/users', 'GET', 'foo-bar')).toEqual('fooBar');
-        expect(getOperationName('/api/v{api-version}/users', 'GET', 'foo_bar')).toEqual('fooBar');
-        expect(getOperationName('/api/v{api-version}/users', 'GET', 'foo.bar')).toEqual('fooBar');
-        expect(getOperationName('/api/v{api-version}/users', 'GET', '@foo.bar')).toEqual('fooBar');
-        expect(getOperationName('/api/v{api-version}/users', 'GET', '$foo.bar')).toEqual('fooBar');
-        expect(getOperationName('/api/v{api-version}/users', 'GET', '_foo.bar')).toEqual('fooBar');
-        expect(getOperationName('/api/v{api-version}/users', 'GET', '-foo.bar')).toEqual('fooBar');
-        expect(getOperationName('/api/v{api-version}/users', 'GET', '123.foo.bar')).toEqual('fooBar');
+        expect(getOperationName('/api/v{api-version}/users', 'GET', false, 'fooBar')).toEqual('fooBar');
+        expect(getOperationName('/api/v{api-version}/users', 'GET', false, 'FooBar')).toEqual('fooBar');
+        expect(getOperationName('/api/v{api-version}/users', 'GET', false, 'Foo Bar')).toEqual('fooBar');
+        expect(getOperationName('/api/v{api-version}/users', 'GET', false, 'foo bar')).toEqual('fooBar');
+        expect(getOperationName('/api/v{api-version}/users', 'GET', false, 'foo-bar')).toEqual('fooBar');
+        expect(getOperationName('/api/v{api-version}/users', 'GET', false, 'foo_bar')).toEqual('fooBar');
+        expect(getOperationName('/api/v{api-version}/users', 'GET', false, 'foo.bar')).toEqual('fooBar');
+        expect(getOperationName('/api/v{api-version}/users', 'GET', false, '@foo.bar')).toEqual('fooBar');
+        expect(getOperationName('/api/v{api-version}/users', 'GET', false, '$foo.bar')).toEqual('fooBar');
+        expect(getOperationName('/api/v{api-version}/users', 'GET', false, '_foo.bar')).toEqual('fooBar');
+        expect(getOperationName('/api/v{api-version}/users', 'GET', false, '-foo.bar')).toEqual('fooBar');
+        expect(getOperationName('/api/v{api-version}/users', 'GET', false, '123.foo.bar')).toEqual('fooBar');
+
+        expect(getOperationName('/api/v1/users', 'GET', true, 'GetAllUsers')).toEqual('getApiV1Users');
+        expect(getOperationName('/api/v{api-version}/users', 'GET', true, 'fooBar')).toEqual('getApiUsers');
+        expect(
+            getOperationName('/api/v{api-version}/users/{userId}/location/{locationId}', 'GET', true, 'fooBar')
+        ).toEqual('getApiUsersByUserIdLocationByLocationId');
     });
 });

--- a/src/openApi/v3/parser/getOperationName.ts
+++ b/src/openApi/v3/parser/getOperationName.ts
@@ -5,8 +5,13 @@ import camelCase from 'camelcase';
  * This will use the operation ID - if available - and otherwise fallback
  * on a generated name from the URL
  */
-export const getOperationName = (url: string, method: string, operationId?: string): string => {
-    if (operationId) {
+export const getOperationName = (
+    url: string,
+    method: string,
+    ignoreOperationId: boolean,
+    operationId?: string
+): string => {
+    if (operationId && !ignoreOperationId) {
         return camelCase(
             operationId
                 .replace(/^[^a-zA-Z]+/g, '')
@@ -17,7 +22,7 @@ export const getOperationName = (url: string, method: string, operationId?: stri
 
     const urlWithoutPlaceholders = url
         .replace(/[^/]*?{api-version}.*?\//g, '')
-        .replace(/{(.*?)}/g, '')
+        .replace(/{(.*?)}/g, 'by-$1')
         .replace(/\//g, '-');
 
     return camelCase(`${method}-${urlWithoutPlaceholders}`);

--- a/src/openApi/v3/parser/getServices.spec.ts
+++ b/src/openApi/v3/parser/getServices.spec.ts
@@ -1,29 +1,33 @@
+/* eslint-disable */
 import { getServices } from './getServices';
 
 describe('getServices', () => {
     it('should create a unnamed service if tags are empty', () => {
-        const services = getServices({
-            openapi: '3.0.0',
-            info: {
-                title: 'x',
-                version: '1',
-            },
-            paths: {
-                '/api/trips': {
-                    get: {
-                        tags: [],
-                        responses: {
-                            200: {
-                                description: 'x',
-                            },
-                            default: {
-                                description: 'default',
+        const services = getServices(
+            {
+                openapi: '3.0.0',
+                info: {
+                    title: 'x',
+                    version: '1',
+                },
+                paths: {
+                    '/api/trips': {
+                        get: {
+                            tags: [],
+                            responses: {
+                                200: {
+                                    description: 'x',
+                                },
+                                default: {
+                                    description: 'default',
+                                },
                             },
                         },
                     },
                 },
             },
-        });
+            false,
+        );
 
         expect(services).toHaveLength(1);
         expect(services[0].name).toEqual('Default');

--- a/src/openApi/v3/parser/getServices.ts
+++ b/src/openApi/v3/parser/getServices.ts
@@ -7,7 +7,7 @@ import { getOperationParameters } from './getOperationParameters';
 /**
  * Get the OpenAPI services
  */
-export const getServices = (openApi: OpenApi): Service[] => {
+export const getServices = (openApi: OpenApi, ignoreOperationId: boolean): Service[] => {
     const services = new Map<string, Service>();
     for (const url in openApi.paths) {
         if (openApi.paths.hasOwnProperty(url)) {
@@ -30,7 +30,15 @@ export const getServices = (openApi: OpenApi): Service[] => {
                             const op = path[method]!;
                             const tags = op.tags?.length ? op.tags.filter(unique) : ['Default'];
                             tags.forEach(tag => {
-                                const operation = getOperation(openApi, url, method, tag, op, pathParams);
+                                const operation = getOperation(
+                                    openApi,
+                                    url,
+                                    method,
+                                    tag,
+                                    op,
+                                    pathParams,
+                                    ignoreOperationId
+                                );
 
                                 // If we have already declared a service, then we should fetch that and
                                 // append the new method to it. Otherwise we should create a new service object.


### PR DESCRIPTION
Adds a CLI parameter `--ignoreOperationId`,  which allows ignoring OperationId in the swagger and relies on the path to generate operation names.

Use path placeholders to decorate operation names.

Ignoring operation ID is handy when working with a swagger generated by `springdoc-openapi`, since it generates messy operation IDs when confronted with multiple possibilities of `Accept` header.