### PR TITLE
fix: typo in template header

### DIFF
--- a/src/templates/partials/header.hbs
+++ b/src/templates/partials/header.hbs
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */


### PR DESCRIPTION
I think this was intended to say `do not edit`