### PR TITLE
fix: infer media-type for falsy bodies except 'undefined'

### DIFF
--- a/src/templates/core/angular/getHeaders.hbs
+++ b/src/templates/core/angular/getHeaders.hbs
@@ -26,7 +26,7 @@ export const getHeaders = (config: OpenAPIConfig, options: ApiRequestOptions): O
 				headers['Authorization'] = `Basic ${credentials}`;
 			}
 
-			if (options.body) {
+			if (options.body !== undefined) {
 				if (options.mediaType) {
 					headers['Content-Type'] = options.mediaType;
 				} else if (isBlob(options.body)) {

--- a/src/templates/core/axios/getHeaders.hbs
+++ b/src/templates/core/axios/getHeaders.hbs
@@ -29,7 +29,7 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 		headers['Authorization'] = `Basic ${credentials}`;
 	}
 
-	if (options.body) {
+	if (options.body !== undefined) {
 		if (options.mediaType) {
 			headers['Content-Type'] = options.mediaType;
 		} else if (isBlob(options.body)) {

--- a/src/templates/core/fetch/getHeaders.hbs
+++ b/src/templates/core/fetch/getHeaders.hbs
@@ -26,7 +26,7 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 		headers['Authorization'] = `Basic ${credentials}`;
 	}
 
-	if (options.body) {
+	if (options.body !== undefined) {
 		if (options.mediaType) {
 			headers['Content-Type'] = options.mediaType;
 		} else if (isBlob(options.body)) {

--- a/src/templates/core/node/getHeaders.hbs
+++ b/src/templates/core/node/getHeaders.hbs
@@ -26,7 +26,7 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 		headers['Authorization'] = `Basic ${credentials}`;
 	}
 
-	if (options.body) {
+	if (options.body !== undefined) {
 		if (options.mediaType) {
 			headers['Content-Type'] = options.mediaType;
 		} else if (isBlob(options.body)) {

--- a/src/templates/core/xhr/getHeaders.hbs
+++ b/src/templates/core/xhr/getHeaders.hbs
@@ -26,7 +26,7 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 		headers['Authorization'] = `Basic ${credentials}`;
 	}
 
-	if (options.body) {
+	if (options.body !== undefined) {
 		if (options.mediaType) {
 			headers['Content-Type'] = options.mediaType;
 		} else if (isBlob(options.body)) {


### PR DESCRIPTION
This fixes a bug, where the `Content-Type` header would be reset to the default, when the `request.body` contains a falsy value. 

For example, given using the fetch api, when sending a request with body `0` (i.e. the number zero), the `Content-Type` header would default to `text/plain; utf-8` (which is the browser default), even when `application/json` would be expected (and would be set if the request body was e.g. `1`, i.e. the number one).

