### PR TITLE
fix: updated axios sendRequest (#2063)

### DIFF
--- a/src/templates/core/axios/sendRequest.hbs
+++ b/src/templates/core/axios/sendRequest.hbs
@@ -16,6 +16,7 @@ export const sendRequest = async <T>(
 		data: body ?? formData,
 		method: options.method,
 		withCredentials: config.WITH_CREDENTIALS,
+		withXSRFToken: config.CREDENTIALS === 'include' ? config.WITH_CREDENTIALS : false,
 		cancelToken: source.token,
 	};
 


### PR DESCRIPTION
Fix for #2063 
added backwards compatibility for axios vulnerable parameter

I checked all the changes for axios, and it looks like setting it to true when credentials are forced for any domain is the right choice. 

I'm not able to run the tests properly as #2052 causes wrong paths to be resolved.
I will take a look at that PR and see if it helps.