### PR TITLE
Query string issue

### DIFF
--- a/src/templates/core/functions/getQueryString.hbs
+++ b/src/templates/core/functions/getQueryString.hbs
@@ -9,7 +9,7 @@ export const getQueryString = (params: Record<string, any>): string => {
 		if (isDefined(value)) {
 			if (Array.isArray(value)) {
 				value.forEach(v => {
-					process(key, v);
+					process(`${key}[]`, v);
 				});
 			} else if (typeof value === 'object') {
 				Object.entries(value).forEach(([k, v]) => {


### PR DESCRIPTION
The issue here stems from how the getQueryString function processes arrays. When you pass an array with a single item, it doesn't append the [] to the parameter name, which is needed by many back-end frameworks to recognize the parameter as an array.

To fix this issue, you need to modify the process function so that it always appends [] to the parameter name when the value is an array, regardless of its length. Here's the modified version of your getQueryString function:

export const getQueryString = (params: Record<string, any>): string => {
	const qs: string[] = [];

	const append = (key: string, value: any) => {
		qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
	};

	const process = (key: string, value: any) => {
		if (isDefined(value)) {
			if (Array.isArray(value)) {
				value.forEach(v => {
					process(`${key}[]`, v);
				});
			} else if (typeof value === 'object') {
				Object.entries(value).forEach(([k, v]) => {
					process(`${key}[${k}]`, v);
				});
			} else {
				append(key, value);
			}
		}
	};

	Object.entries(params).forEach(([key, value]) => {
		process(key, value);
	});

	if (qs.length > 0) {
		return `?${qs.join('&')}`;
	}

	return '';
};