### PR TITLE
fix: type security requirement scopes as arrays

### DIFF
--- a/src/openApi/v2/interfaces/OpenApiSecurityRequirement.d.ts
+++ b/src/openApi/v2/interfaces/OpenApiSecurityRequirement.d.ts
@@ -2,5 +2,5 @@
  * https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#securityRequirementObject
  */
 export interface OpenApiSecurityRequirement {
-    [key: string]: string;
+    [key: string]: string[];
 }

--- a/src/openApi/v3/interfaces/OpenApiSecurityRequirement.d.ts
+++ b/src/openApi/v3/interfaces/OpenApiSecurityRequirement.d.ts
@@ -2,5 +2,5 @@
  * https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#securityRequirementObject
  */
 export interface OpenApiSecurityRequirement {
-    [name: string]: string;
+    [name: string]: string[];
 }


### PR DESCRIPTION
## Summary

Fixes #2775.

Security Requirement Object values are arrays of scope strings in OpenAPI 2.0 and 3.x. This updates the v2 and v3 parser interfaces from string values to string array values.

Valid examples include empty arrays for API key or bearer alternatives, such as { apiKey: [] }.

## Validation

- git diff --check
- Unit tests were not run locally because this clone has no installed dependencies and the machine is currently out of disk space after a prior dependency install attempt in another repository.