### PR TITLE
Fix code injection via unescaped spec-derived strings in generated clients

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -38,6 +38,7 @@ const handlebarsPlugin = () => ({
                     enumerator: true,
                     escapeComment: true,
                     escapeDescription: true,
+                    escapeSingleQuotedString: true,
                     camelCase: true,
                 },
             });

--- a/src/templates/client.hbs
+++ b/src/templates/client.hbs
@@ -27,8 +27,8 @@ import { {{{name}}}{{{@root.postfix}}} } from './services/{{{name}}}{{{@root.pos
 		{
 			provide: OpenAPI,
 			useValue: {
-				BASE: OpenAPI?.BASE ?? '{{{server}}}',
-				VERSION: OpenAPI?.VERSION ?? '{{{version}}}',
+				BASE: OpenAPI?.BASE ?? '{{{escapeSingleQuotedString server}}}',
+				VERSION: OpenAPI?.VERSION ?? '{{{escapeSingleQuotedString version}}}',
 				WITH_CREDENTIALS: OpenAPI?.WITH_CREDENTIALS ?? false,
 				CREDENTIALS: OpenAPI?.CREDENTIALS ?? 'include',
 				TOKEN: OpenAPI?.TOKEN,
@@ -61,8 +61,8 @@ export class {{{clientName}}} {
 
 	constructor(config?: Partial<OpenAPIConfig>, HttpRequest: HttpRequestConstructor = {{{httpRequest}}}) {
 		this.request = new HttpRequest({
-			BASE: config?.BASE ?? '{{{server}}}',
-			VERSION: config?.VERSION ?? '{{{version}}}',
+			BASE: config?.BASE ?? '{{{escapeSingleQuotedString server}}}',
+			VERSION: config?.VERSION ?? '{{{escapeSingleQuotedString version}}}',
 			WITH_CREDENTIALS: config?.WITH_CREDENTIALS ?? false,
 			CREDENTIALS: config?.CREDENTIALS ?? 'include',
 			TOKEN: config?.TOKEN,

--- a/src/templates/core/OpenAPI.hbs
+++ b/src/templates/core/OpenAPI.hbs
@@ -18,8 +18,8 @@ export type OpenAPIConfig = {
 };
 
 export const OpenAPI: OpenAPIConfig = {
-	BASE: '{{{server}}}',
-	VERSION: '{{{version}}}',
+	BASE: '{{{escapeSingleQuotedString server}}}',
+	VERSION: '{{{escapeSingleQuotedString version}}}',
 	WITH_CREDENTIALS: false,
 	CREDENTIALS: 'include',
 	TOKEN: undefined,

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -88,39 +88,39 @@ export class {{{name}}}{{{@root.postfix}}} {
 	{{/equals}}
 	{{/if}}
 			method: '{{{method}}}',
-			url: '{{{path}}}',
+			url: '{{{escapeSingleQuotedString path}}}',
 			{{#if parametersPath}}
 			path: {
 				{{#each parametersPath}}
-				'{{{prop}}}': {{{name}}},
+				'{{{escapeSingleQuotedString prop}}}': {{{name}}},
 				{{/each}}
 			},
 			{{/if}}
 			{{#if parametersCookie}}
 			cookies: {
 				{{#each parametersCookie}}
-				'{{{prop}}}': {{{name}}},
+				'{{{escapeSingleQuotedString prop}}}': {{{name}}},
 				{{/each}}
 			},
 			{{/if}}
 			{{#if parametersHeader}}
 			headers: {
 				{{#each parametersHeader}}
-				'{{{prop}}}': {{{name}}},
+				'{{{escapeSingleQuotedString prop}}}': {{{name}}},
 				{{/each}}
 			},
 			{{/if}}
 			{{#if parametersQuery}}
 			query: {
 				{{#each parametersQuery}}
-				'{{{prop}}}': {{{name}}},
+				'{{{escapeSingleQuotedString prop}}}': {{{name}}},
 				{{/each}}
 			},
 			{{/if}}
 			{{#if parametersForm}}
 			formData: {
 				{{#each parametersForm}}
-				'{{{prop}}}': {{{name}}},
+				'{{{escapeSingleQuotedString prop}}}': {{{name}}},
 				{{/each}}
 			},
 			{{/if}}
@@ -132,11 +132,11 @@ export class {{{name}}}{{{@root.postfix}}} {
 			body: {{{parametersBody.name}}},
 			{{/equals}}
 			{{#if parametersBody.mediaType}}
-			mediaType: '{{{parametersBody.mediaType}}}',
+			mediaType: '{{{escapeSingleQuotedString parametersBody.mediaType}}}',
 			{{/if}}
 			{{/if}}
 			{{#if responseHeader}}
-			responseHeader: '{{{responseHeader}}}',
+			responseHeader: '{{{escapeSingleQuotedString responseHeader}}}',
 			{{/if}}
 			{{#if errors}}
 			errors: {

--- a/src/utils/registerHandlebarHelpers.ts
+++ b/src/utils/registerHandlebarHelpers.ts
@@ -101,6 +101,24 @@ export const registerHandlebarHelpers = (root: {
         return value.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\${/g, '\\${');
     });
 
+    // Several templates interpolate spec-derived strings (the request path,
+    // a server URL, a parameter/header/media-type name, a schema
+    // type/format/pattern) directly into a single-quoted JS string literal,
+    // e.g. `url: '{{{path}}}'`. Without escaping, a single quote in that
+    // value closes the string literal early and the remainder is evaluated
+    // as live JS: a spec path of `/x'+require('fs').writeFileSync(...)+'`
+    // becomes `url: '/x'+require('fs').writeFileSync(...)+'',`, which
+    // executes whenever the generated code runs (as soon as the containing
+    // module is imported, for module-level fields like a server URL, or on
+    // every call, for per-request fields like the path). Escape backslashes
+    // and single quotes so the value can only ever be interpreted as string
+    // data.
+    Handlebars.registerHelper('escapeSingleQuotedString', function (value: unknown): string {
+        return String(value ?? '')
+            .replace(/\\/g, '\\\\')
+            .replace(/'/g, "\\'");
+    });
+
     Handlebars.registerHelper('camelCase', function (value: string): string {
         return camelCase(value);
     });


### PR DESCRIPTION
See the linked issue for the vulnerability report and impact.

## Root cause

Several templates interpolate OpenAPI-spec-derived strings directly into a single-quoted JS string literal in the generated output, with no escaping: the request path (`url: '{{{path}}}'` in `exportService.hbs`), each path/query/header/cookie parameter's wire name, the request-body media type, the response header name, and the first server URL / API version (`client.hbs`, `core/OpenAPI.hbs`). None of the corresponding parser values (`getServices.ts`'s `url`, `getServer.ts`'s return value, `openApi.info.version`, `getOperationParameter.ts`'s `parameter.name`) are sanitized before reaching these templates. A single quote in any of them closes the string literal early and the remainder is evaluated as live JS.

## Fix

- New `escapeSingleQuotedString` Handlebars helper (`registerHandlebarHelpers.ts`), registered as a known helper in `rollup.config.mjs`.
- Applied to the six sinks I traced end-to-end to a raw, unsanitized spec field: `path`, `server`, `version`, `prop` (parameter name), request-body `mediaType`, `responseHeader`.
- Deliberately did *not* touch `pattern` (already escaped in `getPattern.ts`) or the enum `name`/`value` fields (already sanitized/pre-escaped in `getEnum.ts`), to avoid double-escaping a value that's already safe.

## Testing

- Re-ran both PoCs from the issue against the fixed build: the injected payload now round-trips as inert string data in the generated output (confirmed by compiling and executing the generated code - no code runs, no marker file gets written).
- `npm test`: 50/50 suites, 80/80 tests, 285/285 snapshots pass, identical to before this change (the new escaping is a no-op for every existing benign fixture).
- `npm run test:e2e`: the browser-driven specs (angular/xhr/fetch/babel) fail identically before and after this change in the sandbox I used ("No usable sandbox", no Chrome sandbox available in this container) - not a regression from this change, every failure is a browser-launch error, not a test assertion failure.